### PR TITLE
Alias run_main for admin UI entrypoint

### DIFF
--- a/admin_ui/__main__.py
+++ b/admin_ui/__main__.py
@@ -1,5 +1,5 @@
-from . import main
+from . import main as run_main
 
 if __name__ == "__main__":
-    main()
+    run_main()
 


### PR DESCRIPTION
## Summary
- alias `main` as `run_main` in admin UI module
- invoke `run_main()` from `__main__` block

## Testing
- `python -m admin_ui` *(fails: SyntaxError in admin_ui/server.py)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c39530f6f4832c98843fd8860a87fa