### PR TITLE
feat: polish admin UI styling

### DIFF
--- a/admin_ui/static/css/admin.css
+++ b/admin_ui/static/css/admin.css
@@ -1,0 +1,48 @@
+body {
+  background: #f7f7fb;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  line-height: 1.5;
+  color: #212529;
+}
+
+.navbar-brand {
+  font-weight: 600;
+}
+
+.sidebar {
+  min-width: 260px;
+  max-width: 300px;
+  background-color: #fff;
+}
+
+
+.sidebar .list-group-item,
+.offcanvas .list-group-item {
+  border: 0;
+  border-radius: 0;
+  padding: 0.75rem 1rem;
+}
+
+.sidebar .list-group-item.active,
+.offcanvas .list-group-item.active {
+  background-color: #0d6efd;
+  color: #fff;
+  font-weight: 500;
+}
+
+.list-group-item-action:hover {
+  background-color: #f0f0f5;
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+.form-control,
+.form-select {
+  max-width: 720px;
+}
+
+.pk-badge {
+  font-size: 0.75rem;
+}

--- a/admin_ui/templates/base.html
+++ b/admin_ui/templates/base.html
@@ -5,13 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Админка БД</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <style>
-      body { background: #f7f7fb; }
-      .sidebar { min-width: 260px; max-width: 300px; }
-      .table-wrap { overflow-x: auto; }
-      .form-control, .form-select { max-width: 720px; }
-      .pk-badge { font-size: 0.75rem; }
-    </style>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+    <link href="{{ url_for('static', filename='css/admin.css') }}" rel="stylesheet">
   </head>
   <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">


### PR DESCRIPTION
## Summary
- add Inter font and external stylesheet for admin panel
- unify sidebar and offcanvas menu styles for a cleaner look

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from admin_ui.server import create_app
app=create_app()
print('routes:', sorted(rule.rule for rule in app.url_map.iter_rules())[:5])
PY` *(fails: heavy import chain triggers KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_b_68c64dbb53e0832cb951b334182b4e7c