### PR TITLE
Add CI workflow with Docker build and deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install flake8 pytest
+      - name: Lint
+        run: flake8 .
+      - name: Test
+        run: pytest
+
+  build_push:
+    needs: lint_test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/dvorik:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/dvorik:${{ github.sha }}
+
+  deploy:
+    needs: build_push
+    runs-on: ubuntu-latest
+    if: ${{ secrets.SSH_HOST && secrets.SSH_USER && secrets.SSH_KEY }}
+    steps:
+      - name: Deploy to server
+        uses: appleboy/ssh-action@v0.1.10
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          script: |
+            docker-compose pull
+            docker-compose up -d

--- a/README.md
+++ b/README.md
@@ -87,6 +87,20 @@ python stress_test.py
 
 В томах `data`, `media`, `reports` сохраняются база и файлы; логи доступны через `docker compose logs -f bot` и `docker compose logs -f admin`.
 
+## CI/CD
+
+GitHub Actions workflow `.github/workflows/ci.yml` запускает линтер, тесты и сборку Docker-образа.
+
+1. **lint_test** — установка зависимостей, запуск `flake8` и `pytest`.
+2. **build_push** — после успешных проверок собирает и пушит образ с тегами `latest` и `${{ github.sha }}` в Docker Hub.
+3. **deploy** (опционально) — по SSH выполняет `docker-compose pull && docker-compose up -d`.
+
+Перед запуском настроите секреты репозитория:
+- `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN` — учётные данные Docker Hub;
+- `SSH_HOST`, `SSH_USER`, `SSH_KEY` — данные для деплоя (если нужен).
+
+Workflow выполняется при `push` и `pull request` в ветку `main`.
+
 ## Файловая карта
 - Вход: `app/main.py`
 - Конфиг: `app/config.py`


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running lint, tests, Docker build/push, and optional deploy
- document workflow usage and required secrets

## Testing
- `flake8 app admin_ui` (fails: E501 and other style errors)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68c77bb27e8c832c8e44d4eedc04f990