### PR TITLE
Adjust schedule seller column width dynamically

### DIFF
--- a/admin_ui/templates/home.html
+++ b/admin_ui/templates/home.html
@@ -101,9 +101,34 @@
 
               const measure = () => {
                 const cells = tbl.querySelectorAll('td.seller-col, th.seller-col');
-                let max = 0;
-                cells.forEach(cell => { max = Math.max(max, cell.scrollWidth); });
-                if(max > 0){ tbl.style.setProperty('--mini-seller-w', `${Math.ceil(max) + 16}px`); }
+                if(!cells.length) return;
+                const probe = document.createElement('span');
+                probe.style.position = 'absolute';
+                probe.style.visibility = 'hidden';
+                probe.style.whiteSpace = 'nowrap';
+                document.body.appendChild(probe);
+                const baseWidth = 160;
+                const parse = v => (v ? parseFloat(v) : 0) || 0;
+                let max = baseWidth;
+                cells.forEach(cell => {
+                  const text = cell.textContent.trim();
+                  if(!text) return;
+                  const cs = window.getComputedStyle(cell);
+                  probe.style.fontFamily = cs.fontFamily;
+                  probe.style.fontSize = cs.fontSize;
+                  probe.style.fontWeight = cs.fontWeight;
+                  probe.style.fontStyle = cs.fontStyle;
+                  probe.style.fontVariant = cs.fontVariant;
+                  probe.style.letterSpacing = cs.letterSpacing;
+                  probe.style.fontKerning = cs.fontKerning;
+                  probe.style.fontFeatureSettings = cs.fontFeatureSettings;
+                  probe.style.fontVariationSettings = cs.fontVariationSettings;
+                  probe.textContent = text;
+                  const padded = probe.getBoundingClientRect().width + parse(cs.paddingLeft) + parse(cs.paddingRight);
+                  max = Math.max(max, Math.ceil(padded) + 12);
+                });
+                probe.remove();
+                tbl.style.setProperty('--mini-seller-w', `${max}px`);
               };
 
               measure();

--- a/admin_ui/templates/schedule.html
+++ b/admin_ui/templates/schedule.html
@@ -106,7 +106,8 @@
     // Persist horizontal scroll and fit seller column to longest name
     (function(){
       const wrap = document.getElementById('schedWrap');
-      if(!wrap) return;
+      const table = document.getElementById('schedTable');
+      if(!wrap || !table) return;
       const KEY = 'scrollX:'+location.pathname+location.search;
       const restore = ()=>{
         try {
@@ -120,10 +121,40 @@
         try { sessionStorage.setItem(KEY, String(wrap.scrollLeft||0)); } catch(e){}
       });
       // Compute seller column width based on longest name
-      const cells = document.querySelectorAll('#schedTable td.seller-col, #schedTable th.seller-col');
-      let w = 0;
-      cells.forEach(c=>{ w=Math.max(w, c.scrollWidth); });
-      if(w>0){ document.getElementById('schedTable').style.setProperty('--seller-w', (w+24)+'px'); }
+      const measureSellerColumn = () => {
+        const cells = table.querySelectorAll('td.seller-col, th.seller-col');
+        if(!cells.length) return;
+        const probe = document.createElement('span');
+        probe.style.position = 'absolute';
+        probe.style.visibility = 'hidden';
+        probe.style.whiteSpace = 'nowrap';
+        document.body.appendChild(probe);
+        const baseWidth = 180;
+        const parse = v => (v ? parseFloat(v) : 0) || 0;
+        let width = baseWidth;
+        cells.forEach(cell => {
+          const text = cell.textContent.trim();
+          if(!text) return;
+          const cs = window.getComputedStyle(cell);
+          probe.style.fontFamily = cs.fontFamily;
+          probe.style.fontSize = cs.fontSize;
+          probe.style.fontWeight = cs.fontWeight;
+          probe.style.fontStyle = cs.fontStyle;
+          probe.style.fontVariant = cs.fontVariant;
+          probe.style.letterSpacing = cs.letterSpacing;
+          probe.style.fontKerning = cs.fontKerning;
+          probe.style.fontFeatureSettings = cs.fontFeatureSettings;
+          probe.style.fontVariationSettings = cs.fontVariationSettings;
+          probe.textContent = text;
+          const padded = probe.getBoundingClientRect().width + parse(cs.paddingLeft) + parse(cs.paddingRight);
+          width = Math.max(width, Math.ceil(padded) + 12);
+        });
+        probe.remove();
+        table.style.setProperty('--seller-w', width + 'px');
+      };
+      measureSellerColumn();
+      if(document.fonts && document.fonts.ready){ document.fonts.ready.then(measureSellerColumn); }
+      window.addEventListener('resize', measureSellerColumn, { passive: true });
     })();
   </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- compute the seller column width on the schedule page with a hidden probe so it grows to the longest name
- apply the same measurement approach to the dashboard mini schedule to keep widths aligned with real name lengths

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cc44b36d4c832cb8a80e9646fe8942