### PR TITLE
Improve feedback for supply file uploads

### DIFF
--- a/admin_ui/server.py
+++ b/admin_ui/server.py
@@ -23,6 +23,7 @@ from flask import (
     jsonify,
     send_from_directory,
 )
+from werkzeug.exceptions import RequestEntityTooLarge
 
 from app import config as app_config
 from app import db as adb
@@ -411,6 +412,25 @@ def create_app() -> Flask:
         if extra:
             payload.update(extra)
         return jsonify(payload), status
+
+    @app.errorhandler(RequestEntityTooLarge)
+    def handle_request_too_large(exc: RequestEntityTooLarge):
+        max_len = app.config.get("MAX_CONTENT_LENGTH")
+        message = "Файл слишком большой."
+        extra: Dict[str, Any] = {}
+        if max_len:
+            size_mb = max_len / (1024 * 1024)
+            if size_mb >= 10:
+                size_str = f"{size_mb:.0f}"
+            elif size_mb >= 1:
+                size_str = f"{size_mb:.1f}".rstrip("0").rstrip(".")
+            else:
+                size_str = f"{size_mb:.2f}".rstrip("0").rstrip(".")
+            message = f"Файл слишком большой. Максимальный размер: {size_str} МБ."
+            extra["max_size"] = int(max_len)
+        if _wants_json_response() or (request.path or "").startswith("/supply"):
+            return _supply_error(message, status=413, **extra)
+        return message, 413
 
     @app.context_processor
     def inject_tables():

--- a/admin_ui/templates/supply.html
+++ b/admin_ui/templates/supply.html
@@ -961,6 +961,7 @@
 
       function resetState(opts){
         const keepFile = !!(opts && opts.keepFile);
+        const preserveAlert = !!(opts && opts.preserveAlert);
         clearRowHeights();
         clearPairedHover();
         currentSession = null;
@@ -981,7 +982,9 @@
         foundInfo.textContent = '';
         supplierInput.value = '';
         invoiceInput.value = '';
-        showAlert('');
+        if(!preserveAlert){
+          showAlert('');
+        }
         if(!keepFile){
           form.reset();
           fileInput.value = '';
@@ -1010,15 +1013,55 @@
         fetch('{{ url_for('supply_preview') }}', {
           method: 'POST',
           body: fd,
+          headers: {
+            'X-Requested-With': 'fetch',
+            'Accept': 'application/json',
+          },
         }).then(async (resp) => {
-          const data = await resp.json().catch(() => null);
-          if(!data){
-            throw new Error('Не удалось обработать ответ сервера');
+          const contentType = (resp.headers.get('Content-Type') || '').toLowerCase();
+          let data = null;
+          if(contentType.includes('application/json')){
+            data = await resp.json().catch(() => null);
           }
-          if(!resp.ok || !data.success){
-            throw new Error(data.message || 'Ошибка обработки файла');
+          if(data){
+            if(!resp.ok || data.success === false){
+              const parts = [];
+              const mainMessage = data.message || data.error;
+              if(mainMessage){
+                parts.push(String(mainMessage));
+              }
+              if(Array.isArray(data.details) && data.details.length){
+                parts.push(data.details.map((item) => String(item)).join(' '));
+              }
+              if(Array.isArray(data.errors) && data.errors.length){
+                parts.push(data.errors.map((item) => String(item)).join('; '));
+              }
+              const message = parts.filter((text) => text && text.length).join(' ');
+              throw new Error(message || 'Ошибка обработки файла');
+            }
+            return data;
           }
-          return data;
+          if(!resp.ok){
+            const rawText = await resp.text().catch(() => '');
+            if(rawText){
+              let parsed = rawText;
+              if(window.DOMParser){
+                try {
+                  const parser = new DOMParser();
+                  const doc = parser.parseFromString(rawText, 'text/html');
+                  parsed = doc && doc.body ? (doc.body.textContent || '') : rawText;
+                } catch(parseErr){
+                  parsed = rawText;
+                }
+              }
+              const normalized = parsed.replace(/\s+/g, ' ').trim();
+              if(normalized){
+                throw new Error(normalized);
+              }
+            }
+            throw new Error(`Ошибка загрузки файла (код ${resp.status})`);
+          }
+          throw new Error('Не удалось обработать ответ сервера');
         }).then((data) => {
           currentSession = {
             token: data.token,
@@ -1042,8 +1085,9 @@
           updateNormalizedTable();
           showAlert(`Файл ${data.original_name} успешно распознан.`, 'success');
         }).catch((err) => {
-          showAlert(err.message, 'warning');
-          resetState();
+          const message = err && err.message ? err.message : 'Неизвестная ошибка загрузки файла';
+          showAlert(message, 'warning');
+          resetState({ preserveAlert: true });
         }).finally(() => {
           fileInput.disabled = false;
           progressEl.classList.add('d-none');


### PR DESCRIPTION
## Summary
- keep supply upload alerts visible on failure and enhance client-side parsing so detailed error reasons are surfaced
- send preview requests with JSON-friendly headers and parse non-JSON responses to show fallback messages instead of generic failures
- add a Flask handler that returns a JSON error when the uploaded file exceeds the maximum size, including the configured limit

## Testing
- `pytest` *(fails: _extract_excel_rows requires an .xls engine even with xlrd/xlrd2 installed in the current environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cf65e4fc28832c882288fca58ca491