### PR TITLE
Increase supply preview column limit

### DIFF
--- a/app/services/imports.py
+++ b/app/services/imports.py
@@ -130,7 +130,7 @@ def _accumulate_row(
 
 
 _PREVIEW_MAX_ROWS = 200
-_PREVIEW_MAX_COLS = 12
+_PREVIEW_MAX_COLS = 40
 
 
 def _preview_cell(val) -> str:


### PR DESCRIPTION
## Summary
- increase the supply import preview column limit to 40 so the UI can display more columns

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68cfaa73b024832ca3665284a7925fc2