### PR TITLE
Improve quantity parsing and filter import mapping columns

### DIFF
--- a/admin_ui/templates/supply.html
+++ b/admin_ui/templates/supply.html
@@ -704,17 +704,31 @@
 
       function prepareMappingOptions(){
         const headers = getHeaderTexts();
-        mappingOptions = headers.map((_, idx) => String(idx));
+        const rawHeaders = Array.isArray(originalHeaders) ? originalHeaders : [];
+        const headerEntries = headers.map((headerText, idx) => {
+          const trimmedRaw = idx < rawHeaders.length ? String(rawHeaders[idx] ?? '').trim() : '';
+          const trimmedHeader = String(headerText || '').trim();
+          const fallback = `Колонка ${idx + 1}`;
+          const display = trimmedRaw || trimmedHeader || fallback;
+          const isPlaceholder = /^колонка\s*\d+$/i.test(display);
+          return {
+            idx,
+            display,
+            isPlaceholder,
+          };
+        }).filter((entry) => !entry.isPlaceholder);
         const sampleRow = Array.isArray(originalRowsRaw) && originalRowsRaw.length ? originalRowsRaw[0] : [];
-        const labels = headers.map((headerText, idx) => {
-          const base = String(headerText || '').trim() || `Колонка ${idx + 1}`;
+        const labeledEntries = headerEntries.map((entry) => {
+          const value = String(entry.idx);
           let sample = '';
-          if(Array.isArray(sampleRow) && sampleRow[idx] !== undefined && sampleRow[idx] !== null){
-            sample = String(sampleRow[idx]).trim();
+          if(Array.isArray(sampleRow) && sampleRow[entry.idx] !== undefined && sampleRow[entry.idx] !== null){
+            sample = String(sampleRow[entry.idx]).trim();
             if(sample.length > 30){ sample = `${sample.slice(0, 27)}…`; }
           }
-          return sample ? `${idx + 1}. ${base} — ${sample}` : `${idx + 1}. ${base}`;
+          const label = sample ? `${entry.idx + 1}. ${entry.display} — ${sample}` : `${entry.idx + 1}. ${entry.display}`;
+          return { value, label };
         });
+        mappingOptions = labeledEntries.map((entry) => entry.value);
         MAPPING_FIELD_ORDER.forEach((field) => {
           const select = mappingSelects[field];
           if(!select){ return; }
@@ -724,10 +738,10 @@
           emptyOption.value = '';
           emptyOption.textContent = '— Не выбрано —';
           select.appendChild(emptyOption);
-          labels.forEach((label, idx) => {
+          labeledEntries.forEach((entry) => {
             const option = document.createElement('option');
-            option.value = String(idx);
-            option.textContent = label;
+            option.value = entry.value;
+            option.textContent = entry.label;
             select.appendChild(option);
           });
           if(current && mappingOptions.includes(current)){
@@ -752,7 +766,7 @@
           return;
         }
         if(!mappingOptions.length){
-          mappingNotice.textContent = 'В исходном файле не найдены колонки для сопоставления.';
+          mappingNotice.textContent = 'В исходном файле не найдены колонки с названиями для сопоставления.';
           mappingNotice.classList.add('text-warning');
           if(mappingApplyBtn){ mappingApplyBtn.disabled = true; }
           return;

--- a/app/services/imports.py
+++ b/app/services/imports.py
@@ -978,26 +978,20 @@ def _extract_excel_rows(
                 continue
             qty_raw = row.get(qty_col)
             qty = _to_float_qty(qty_raw)
-            if qty is None:
+            if (qty is None or qty <= 0) and qty_raw is not None:
                 raw_text = ""
-                if qty_raw is not None:
-                    try:
-                        if isinstance(qty_raw, float) and not math.isfinite(qty_raw):
-                            raw_text = ""
-                        else:
-                            raw_text = str(qty_raw)
-                    except Exception:
+                try:
+                    if isinstance(qty_raw, float) and not math.isfinite(qty_raw):
                         raw_text = ""
+                    else:
+                        raw_text = str(qty_raw)
+                except Exception:
+                    raw_text = ""
                 raw_text = raw_text.strip()
                 if raw_text and re.search(r"\d", raw_text):
-                    digit_match = re.search(r"\d", raw_text)
-                    if digit_match:
-                        trimmed = raw_text[digit_match.start() :]
-                    else:
-                        trimmed = raw_text
-                    cleaned = re.split(r"[^0-9,\.\s×x*]+", trimmed, 1)[0]
-                    if cleaned.strip():
-                        qty = _to_float_qty(cleaned)
+                    qty_retry = _to_float_qty(raw_text)
+                    if qty_retry is not None:
+                        qty = qty_retry
             if qty is None or qty <= 0:
                 continue
             art = None
@@ -1356,7 +1350,9 @@ def import_supply_rows(rows: Sequence[Tuple[str, str, float]]) -> dict:
     return _import_article_rows(list(rows), err_prefix="Row", start_index=1)
 
 
-_LEADING_QTY_FRAGMENT_RX = re.compile(r"^\s*([+-]?\d[\d\s,\.\u00A0×x*]*)")
+_NUMERIC_FRAGMENT_RX = re.compile(
+    r"(?<![A-Za-zА-Яа-я0-9])(?<![A-Za-zА-Яа-я0-9]-)([+-]?(?:\d{1,3}(?:[ \u00A0]\d{3})+|\d+)(?:[\.,]\d+)?)"
+)
 
 
 def _to_float_qty(val) -> Optional[float]:
@@ -1369,19 +1365,21 @@ def _to_float_qty(val) -> Optional[float]:
     s = str(val).strip()
     if s == "":
         return None
-    match = _LEADING_QTY_FRAGMENT_RX.match(s)
-    if not match:
+    fragment_match: Optional[str] = None
+    for candidate in _NUMERIC_FRAGMENT_RX.finditer(s):
+        fragment = candidate.group(1)
+        if not fragment:
+            continue
+        prefix = s[: candidate.start(1)]
+        if prefix.rstrip().endswith("№"):
+            continue
+        fragment_match = fragment
+        break
+    if fragment_match is None:
         return None
-    fragment = match.group(1)
+    fragment = fragment_match
     fragment = fragment.replace("\u00A0", " ")
-    fragment = re.sub(r"[×xX*]", " ", fragment)
-    fragment = re.sub(r"\s+", " ", fragment).strip()
-    if not fragment:
-        return None
-    if re.fullmatch(r"[+-]?\d{1,3}(?:\s\d{3})*(?:[\.,]\d+)?", fragment):
-        fragment = fragment.replace(" ", "")
-    else:
-        fragment = fragment.split(" ")[0]
+    fragment = fragment.replace(" ", "")
     fragment = fragment.replace(",", ".")
     try:
         f = float(fragment)

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -124,6 +124,28 @@ def test_extract_excel_rows_quantity_with_text(imports_module, tmp_path):
     ]
 
 
+def test_extract_excel_rows_quantity_with_units(imports_module, tmp_path):
+    sample_path = tmp_path / "quantity_units.xlsx"
+    data = [
+        ["№", "Артикул", "Наименование товара", "Кол-во"],
+        [1, "SKU-010", "Маршмеллоу Персик", "пакет 1 кг"],
+        [2, "SKU-011", "Маршмеллоу Апельсин", "масса ~ 0,75 кг"],
+        [3, "SKU-012", "Маршмеллоу Лимон", "вес нетто: 1 250,5 г"],
+    ]
+    df = pd.DataFrame(data)
+    df.to_excel(sample_path, header=False, index=False)
+
+    rows, stats = imports_module._extract_excel_rows(str(sample_path))
+
+    assert stats["errors"] == []
+    assert stats["found"] == 3
+    assert rows == [
+        ("SKU-010", "Маршмеллоу Персик", 1.0),
+        ("SKU-011", "Маршмеллоу Апельсин", 0.75),
+        ("SKU-012", "Маршмеллоу Лимон", 1250.5),
+    ]
+
+
 def test_accumulate_rows_uses_name_key(imports_module):
     rows_map = {}
     order = []


### PR DESCRIPTION
## Summary
- update `_to_float_qty` to locate numeric fragments with support for decimal commas and skip article-like tokens
- retry quantity parsing in `_extract_excel_rows` when original cell text still contains digits
- add dataframe-based tests that cover quantities with unit text such as "пакет 1 кг" and "масса ~ 0,75 кг"
- hide placeholder "Колонка N" entries in the supply import mapping dropdown and clarify the empty-state notice

## Testing
- `pytest tests/test_imports.py`


------
https://chatgpt.com/codex/tasks/task_b_68cfa4c3d374832c99e9a108bc0f44e9