### PR TITLE
Adjust low stock widget layout and filtering

### DIFF
--- a/admin_ui/server.py
+++ b/admin_ui/server.py
@@ -51,6 +51,41 @@ def _sanitize_filename(name: str) -> str:
     return cleaned or "upload"
 
 
+def _strip_display_exceptions(name: Optional[str], phrases: Sequence[str]) -> str:
+    if not name:
+        return ""
+    cleaned = str(name)
+    for raw_phrase in phrases:
+        if raw_phrase is None:
+            continue
+        phrase = str(raw_phrase)
+        if not phrase.strip():
+            continue
+        cleaned = re.sub(
+            rf"\s*{re.escape(phrase)}\s*",
+            " ",
+            cleaned,
+            flags=re.IGNORECASE,
+        )
+    cleaned = re.sub(r"\s{2,}", " ", cleaned)
+    return cleaned.strip(" ,.;:-")
+
+
+def _prepare_low_stock_rows(
+    rows: Sequence[sqlite3.Row], phrases: Sequence[str]
+) -> List[Dict[str, Any]]:
+    prepared: List[Dict[str, Any]] = []
+    for row in rows:
+        data = dict(row)
+        cleaned_name = _strip_display_exceptions(data.get("disp_name"), phrases)
+        if not cleaned_name:
+            article = data.get("article")
+            cleaned_name = str(article).strip() if article else ""
+        data["disp_name"] = cleaned_name
+        prepared.append(data)
+    return prepared
+
+
 def _wants_json_response() -> bool:
     """Detect if the current request expects a JSON payload back."""
     accept = (request.headers.get("Accept") or "").lower()
@@ -1051,7 +1086,7 @@ def create_app() -> Flask:
 
         with adb.db() as conn:
             # Low stock report (like reports 'low'): total in (0,2]
-            low_rows = conn.execute(
+            low_rows_raw = conn.execute(
                 """
                 SELECT p.article,
                        COALESCE(p.local_name,p.name) AS disp_name,
@@ -1065,6 +1100,11 @@ def create_app() -> Flask:
                 LIMIT 100
                 """
             ).fetchall()
+            exception_rows = conn.execute(
+                "SELECT phrase FROM display_name_exception ORDER BY lower(phrase)"
+            ).fetchall()
+            exception_phrases = [row["phrase"] for row in exception_rows if row["phrase"] is not None]
+            low_rows = _prepare_low_stock_rows(low_rows_raw, exception_phrases)
             # Totals by location for summary table (kept for reference)
             loc_rows = conn.execute(
                 """

--- a/admin_ui/static/css/admin.css
+++ b/admin_ui/static/css/admin.css
@@ -302,26 +302,26 @@
 
 .low-stock-grid {
   display: block;
+  column-gap: 12px;
+  column-fill: balance;
 }
 
 .low-stock-grid > .list-group-item {
   break-inside: avoid;
 }
 
-@media (min-width: 1400px) {
-  .low-stock-grid {
-    column-count: 2;
-    column-gap: 12px;
-  }
+.low-stock-grid.low-stock-grid--multi {
+  column-count: 2;
+  column-width: 20ch;
+}
 
-  .low-stock-grid > .list-group-item {
-    margin-bottom: 6px;
-    border-bottom-width: 1px;
-  }
+.low-stock-grid.low-stock-grid--multi > .list-group-item {
+  margin-bottom: 6px;
+  border-bottom-width: 1px;
+}
 
-  .low-stock-grid > .list-group-item:last-child {
-    margin-bottom: 0;
-  }
+.low-stock-grid.low-stock-grid--multi > .list-group-item:last-child {
+  margin-bottom: 0;
 }
 
 .neon-list-item {

--- a/admin_ui/templates/home.html
+++ b/admin_ui/templates/home.html
@@ -44,7 +44,7 @@
   <div class="row g-4 mb-4 align-items-stretch">
     <!-- Compact schedule (график выхода сотрудников) -->
     <div class="col-12 col-lg-auto">
-      <div class="card neon-card h-100 w-100 w-lg-auto">
+      <div class="card neon-card h-100 w-100 w-lg-auto" id="homeScheduleCard">
         <div class="card-header neon-card-header d-flex align-items-center justify-content-between flex-wrap gap-2">
           <div class="d-flex align-items-center gap-2">
             <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('index', year=ms.year if ms.month>1 else ms.year-1, month=(ms.month-1) if ms.month>1 else 12) }}">←</a>
@@ -132,7 +132,7 @@
     </div>
     <!-- Low stock scroller -->
     <div class="col-12 col-lg">
-      <div class="card neon-card h-100 low-stock-card">
+      <div class="card neon-card h-100 low-stock-card" id="homeLowStockCard">
         <div class="card-header neon-card-header">Заканчиваются ( ≤ 2 )</div>
         <div class="card-body p-0">
           <div class="scroll-list">
@@ -380,6 +380,102 @@
           </form>
         </div>
       </div>
+
+      <script>
+        (function(){
+          function init(){
+            const scheduleCard = document.getElementById('homeScheduleCard');
+            const lowStockCard = document.getElementById('homeLowStockCard');
+            if(!lowStockCard){ return; }
+
+            const scrollList = lowStockCard.querySelector('.scroll-list');
+            const lowStockGrid = lowStockCard.querySelector('.low-stock-grid');
+            if(!scrollList){ return; }
+
+            const MIN_COL_CHARS = 20;
+            let chSizePx = null;
+
+            function measureCh(){
+              if(!lowStockGrid){ return 0; }
+              const style = window.getComputedStyle(lowStockGrid);
+              const probe = document.createElement('span');
+              probe.textContent = '0';
+              probe.style.position = 'absolute';
+              probe.style.visibility = 'hidden';
+              probe.style.whiteSpace = 'nowrap';
+              if(style.font){ probe.style.font = style.font; }
+              probe.style.fontSize = style.fontSize;
+              probe.style.fontFamily = style.fontFamily;
+              document.body.appendChild(probe);
+              const width = probe.getBoundingClientRect().width || 0;
+              document.body.removeChild(probe);
+              if(width > 0){
+                return width;
+              }
+              const fallbackSize = parseFloat(style.fontSize) || 16;
+              return fallbackSize * 0.6;
+            }
+
+            function ensureCh(){
+              if(chSizePx === null || chSizePx <= 0){
+                chSizePx = measureCh();
+              }
+              return chSizePx;
+            }
+
+            function updateColumns(){
+              if(!lowStockGrid){ return; }
+              const chPx = ensureCh();
+              const gap = parseFloat(window.getComputedStyle(lowStockGrid).columnGap) || 0;
+              const needed = chPx * MIN_COL_CHARS * 2 + gap;
+              const available = lowStockCard.getBoundingClientRect().width;
+              if(available >= needed){
+                lowStockGrid.classList.add('low-stock-grid--multi');
+              } else {
+                lowStockGrid.classList.remove('low-stock-grid--multi');
+              }
+            }
+
+            function updateScroll(){
+              if(!scheduleCard){ return; }
+              scrollList.style.maxHeight = '';
+              const scheduleHeight = scheduleCard.getBoundingClientRect().height;
+              if(!scheduleHeight){ return; }
+              const cardRect = lowStockCard.getBoundingClientRect();
+              const listRect = scrollList.getBoundingClientRect();
+              const staticSpace = cardRect.height - listRect.height;
+              const allowed = scheduleHeight - staticSpace;
+              if(allowed <= 0){ return; }
+              if(listRect.height > allowed + 1){
+                scrollList.style.maxHeight = Math.floor(allowed) + 'px';
+              }
+            }
+
+            function refresh(){
+              chSizePx = null;
+              updateColumns();
+              updateScroll();
+            }
+
+            refresh();
+
+            if(typeof ResizeObserver === 'function'){
+              const observer = new ResizeObserver(() => refresh());
+              observer.observe(lowStockCard);
+              if(scheduleCard){ observer.observe(scheduleCard); }
+            }
+
+            window.addEventListener('resize', () => refresh());
+            window.addEventListener('load', () => refresh());
+          }
+
+          if(document.readyState === 'loading'){
+            document.addEventListener('DOMContentLoaded', init);
+          } else {
+            init();
+          }
+        })();
+      </script>
 
       <script>
         const locationData = (() => {


### PR DESCRIPTION
## Summary
- make the low stock widget dynamically switch between one and two columns with a 20-character minimum column width and synced scroll height
- align low-stock name rendering with display name exceptions so configured phrases are removed from the list

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cfb90a1c78832ca583777e727de3d5