### PR TITLE
Fix theme toggle thumb translation

### DIFF
--- a/admin_ui/static/css/admin.css
+++ b/admin_ui/static/css/admin.css
@@ -472,7 +472,7 @@
 }
 
 #theme-carbon:checked ~ .theme-switch-thumb {
-  transform: translateX(calc(var(--segment-width) + var(--switch-gap)));
+  transform: translateX(calc(100% + var(--switch-gap)));
 }
 
 /* Alternate carbon palette */


### PR DESCRIPTION
## Summary
- adjust the theme switch thumb translation so the highlight snaps fully to the selected option

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68cff539e108832ca6bf553f134a89c3