### PR TITLE
Add product merge editor with history and alias support

### DIFF
--- a/admin_ui/server.py
+++ b/admin_ui/server.py
@@ -30,6 +30,7 @@ from app import db as adb
 from app.services import schedule as sched
 from app.services import stock as stock_svc
 from app.services import imports as import_svc
+from app.services import product_merge as merge_svc
 
 
 @dataclass
@@ -146,6 +147,52 @@ def _list_tables(conn) -> List[Tuple[str, str]]:
             continue
         out.append((name, "table"))
     return out
+
+
+def _product_detail(conn, pid: int) -> Optional[Dict[str, Any]]:
+    row = conn.execute(
+        """
+        SELECT id, article, name, brand_country, local_name, photo_file_id, photo_path, archived
+        FROM product WHERE id=?
+        """,
+        (pid,),
+    ).fetchone()
+    if not row:
+        return None
+    data = dict(row)
+    ppath = (row["photo_path"] or "").strip()
+    photo_url = None
+    if ppath and os.path.isfile(ppath):
+        try:
+            rel = os.path.relpath(ppath, "media")
+        except Exception:
+            rel = None
+        if rel and not rel.startswith(".."):
+            photo_url = url_for("serve_media", subpath=rel)
+    data["photo_url"] = photo_url
+    stocks = conn.execute(
+        """
+        SELECT s.location_code AS code,
+               COALESCE(l.title, s.location_code) AS title,
+               SUM(s.qty_pack) AS qty
+        FROM stock s
+        LEFT JOIN location l ON l.code=s.location_code
+        WHERE s.product_id=?
+        GROUP BY s.location_code
+        HAVING ABS(SUM(s.qty_pack))>0.000001
+        ORDER BY s.location_code
+        """,
+        (pid,),
+    ).fetchall()
+    data["stocks"] = [
+        {
+            "code": r["code"],
+            "title": r["title"],
+            "qty": float(r["qty"] or 0.0),
+        }
+        for r in stocks
+    ]
+    return data
 
 # Подписи/переводы на русский
 TABLE_LABELS: Dict[str, str] = {
@@ -1146,6 +1193,10 @@ def create_app() -> Flask:
             abort(404)
         return send_from_directory(str(base), subpath)
 
+    @app.route("/edit")
+    def edit_page():
+        return render_template("edit.html")
+
     # ====== Страница карточек товаров (маркетплейс) ======
     @app.route("/cards")
     def cards_page():
@@ -1678,6 +1729,66 @@ def create_app() -> Flask:
         with adb.db() as conn:
             items = _cards_search(conn, q, limit)
         return jsonify(items)
+
+    @app.get("/api/merge/product/<int:pid>")
+    def api_merge_product(pid: int):
+        with adb.db() as conn:
+            detail = _product_detail(conn, pid)
+            if not detail:
+                abort(404)
+        return jsonify(detail)
+
+    @app.post("/api/merge/apply")
+    def api_merge_apply():
+        payload = request.get_json(silent=True) or {}
+        try:
+            source_a = int(payload.get("source_a_id"))
+            source_b = int(payload.get("source_b_id"))
+        except Exception:
+            abort(400)
+        raw_modes = payload.get("field_modes") or {}
+        if not isinstance(raw_modes, dict):
+            raw_modes = {}
+        field_modes = {str(k): str(v) for k, v in raw_modes.items()}
+        stock_mode = str(payload.get("stock_mode") or "merge")
+        with adb.db() as conn:
+            try:
+                result = merge_svc.apply_merge(
+                    conn,
+                    source_a,
+                    source_b,
+                    field_modes=field_modes,
+                    stock_mode=stock_mode,
+                )
+            except ValueError as exc:
+                return jsonify({"ok": False, "error": str(exc)}), 400
+        return jsonify(result)
+
+    @app.get("/api/merge/history")
+    def api_merge_history():
+        raw_limit = request.args.get("limit", "")
+        try:
+            limit = int(raw_limit) if raw_limit else 20
+        except Exception:
+            limit = 20
+        limit = max(1, min(limit, 200))
+        with adb.db() as conn:
+            items = merge_svc.list_history(conn, limit=limit)
+        return jsonify(items)
+
+    @app.post("/api/merge/undo")
+    def api_merge_undo():
+        payload = request.get_json(silent=True) or {}
+        if not payload:
+            payload = request.form.to_dict()
+        try:
+            merge_id = int(payload.get("merge_id"))
+        except Exception:
+            abort(400)
+        with adb.db() as conn:
+            result = merge_svc.undo_merge(conn, merge_id)
+        status = 200 if result.get("ok") else 400
+        return jsonify(result), status
 
     @app.post("/api/stock/adjust")
     def api_stock_adjust():

--- a/admin_ui/templates/base.html
+++ b/admin_ui/templates/base.html
@@ -44,6 +44,7 @@
           <a class="list-group-item list-group-item-action {% if request.path == url_for('reports_page') %}active{% endif %}" href="{{ url_for('reports_page') }}" {% if request.path == url_for('reports_page') %}aria-current="page"{% endif %}>Отчёты</a>
           <a class="list-group-item list-group-item-action {% if request.path == url_for('supply_page') %}active{% endif %}" href="{{ url_for('supply_page') }}" {% if request.path == url_for('supply_page') %}aria-current="page"{% endif %}>Поставка</a>
           <a class="list-group-item list-group-item-action {% if request.path == url_for('cards_page') %}active{% endif %}" href="{{ url_for('cards_page') }}" {% if request.path == url_for('cards_page') %}aria-current="page"{% endif %}>Карточки товаров</a>
+          <a class="list-group-item list-group-item-action {% if request.path == url_for('edit_page') %}active{% endif %}" href="{{ url_for('edit_page') }}" {% if request.path == url_for('edit_page') %}aria-current="page"{% endif %}>Редактировать</a>
         </div>
         <div class="mb-2 text-muted">Основные таблицы</div>
         <div class="list-group list-group-flush mb-3">
@@ -70,6 +71,7 @@
               <a class="list-group-item list-group-item-action {% if request.path.startswith('/table/' ~ name) %}active{% endif %}" href="{{ url_for('table_browse', table=name) }}" {% if request.path.startswith('/table/' ~ name) %}aria-current="page"{% endif %}>{{ table_title(name) }}</a>
             {% endfor %}
             <a class="list-group-item list-group-item-action {% if request.path == url_for('cards_page') %}active{% endif %}" href="{{ url_for('cards_page') }}" {% if request.path == url_for('cards_page') %}aria-current="page"{% endif %}>Карточки товаров</a>
+            <a class="list-group-item list-group-item-action {% if request.path == url_for('edit_page') %}active{% endif %}" href="{{ url_for('edit_page') }}" {% if request.path == url_for('edit_page') %}aria-current="page"{% endif %}>Редактировать</a>
             <div class="list-group-item {% if tech_section_active %}active{% endif %}">
               <a class="d-flex justify-content-between align-items-center text-decoration-none" data-bs-toggle="collapse" href="#techTables" role="button" aria-expanded="{{ 'true' if tech_section_active else 'false' }}" aria-controls="techTables">
                 <span>Технические таблицы</span>

--- a/admin_ui/templates/edit.html
+++ b/admin_ui/templates/edit.html
@@ -1,0 +1,830 @@
+{% extends 'base.html' %}
+{% block content %}
+  <div class="edit-shell">
+    <div class="edit-headline">
+      <div>
+        <h3>Редактировать карточки товаров</h3>
+        <p>Объединяйте дубликаты карточек, формируйте единые остатки и сохраняйте правила для будущих поставок.</p>
+      </div>
+      <div class="edit-tabs" role="tablist">
+        <button class="edit-tab is-active" type="button" data-view="merge" role="tab" aria-selected="true">Объединить</button>
+        <button class="edit-tab" type="button" data-view="history" role="tab" aria-selected="false">История</button>
+      </div>
+    </div>
+
+    <div class="edit-view" id="mergeView" role="tabpanel" aria-label="Объединить">
+      <div class="merge-board" id="mergeBoard">
+        <div class="merge-slot" data-slot="a" role="button" tabindex="0" aria-label="Выберите первую карточку">
+          <div class="slot-label">Первая карточка</div>
+          <div class="slot-body">
+            <div class="slot-placeholder">Нажмите, чтобы выбрать карточку</div>
+            <div class="slot-summary"></div>
+          </div>
+          <button type="button" class="slot-clear" hidden data-clear="a">Сбросить</button>
+        </div>
+        <div class="merge-operator">+</div>
+        <div class="merge-slot" data-slot="b" role="button" tabindex="0" aria-label="Выберите вторую карточку">
+          <div class="slot-label">Вторая карточка</div>
+          <div class="slot-body">
+            <div class="slot-placeholder">Нажмите, чтобы выбрать карточку</div>
+            <div class="slot-summary"></div>
+          </div>
+          <button type="button" class="slot-clear" hidden data-clear="b">Сбросить</button>
+        </div>
+        <div class="merge-operator">=</div>
+        <div class="merge-result" id="mergeResult">
+          <div class="result-empty">Выберите две карточки, чтобы настроить объединение.</div>
+          <div class="result-card" hidden>
+            <h4>Новая карточка</h4>
+            <div class="result-fields">
+              <div class="result-field" data-field="article">
+                <div class="field-header">
+                  <span>Артикул</span>
+                  <div class="field-controls" role="group">
+                    <button type="button" class="field-btn" data-dir="-1" aria-label="Предыдущее значение">&#x2039;</button>
+                    <div class="field-value">—</div>
+                    <button type="button" class="field-btn" data-dir="1" aria-label="Следующее значение">&#x203A;</button>
+                  </div>
+                </div>
+                <div class="field-hint"></div>
+              </div>
+              <div class="result-field" data-field="name">
+                <div class="field-header">
+                  <span>Название</span>
+                  <div class="field-controls" role="group">
+                    <button type="button" class="field-btn" data-dir="-1" aria-label="Предыдущее значение">&#x2039;</button>
+                    <div class="field-value">—</div>
+                    <button type="button" class="field-btn" data-dir="1" aria-label="Следующее значение">&#x203A;</button>
+                  </div>
+                </div>
+                <div class="field-hint"></div>
+              </div>
+              <div class="result-field" data-field="brand_country">
+                <div class="field-header">
+                  <span>Бренд / страна</span>
+                  <div class="field-controls" role="group">
+                    <button type="button" class="field-btn" data-dir="-1" aria-label="Предыдущее значение">&#x2039;</button>
+                    <div class="field-value">—</div>
+                    <button type="button" class="field-btn" data-dir="1" aria-label="Следующее значение">&#x203A;</button>
+                  </div>
+                </div>
+                <div class="field-hint"></div>
+              </div>
+              <div class="result-field" data-field="local_name">
+                <div class="field-header">
+                  <span>Локальное имя</span>
+                  <div class="field-controls" role="group">
+                    <button type="button" class="field-btn" data-dir="-1" aria-label="Предыдущее значение">&#x2039;</button>
+                    <div class="field-value">—</div>
+                    <button type="button" class="field-btn" data-dir="1" aria-label="Следующее значение">&#x203A;</button>
+                  </div>
+                </div>
+                <div class="field-hint"></div>
+              </div>
+              <div class="result-field" data-field="photo">
+                <div class="field-header">
+                  <span>Фото</span>
+                  <div class="field-controls" role="group">
+                    <button type="button" class="field-btn" data-dir="-1" aria-label="Предыдущее значение">&#x2039;</button>
+                    <div class="field-value photo-value">Нет фото</div>
+                    <button type="button" class="field-btn" data-dir="1" aria-label="Следующее значение">&#x203A;</button>
+                  </div>
+                </div>
+                <div class="photo-preview" hidden>
+                  <img src="" alt="Предпросмотр фото" loading="lazy">
+                </div>
+                <div class="field-hint"></div>
+              </div>
+            </div>
+            <div class="result-stocks">
+              <div class="stocks-header">
+                <span>Наличие</span>
+                <div class="field-controls" data-field="stocks" role="group">
+                  <button type="button" class="field-btn" data-dir="-1" aria-label="Предыдущее значение">&#x2039;</button>
+                  <div class="field-value">—</div>
+                  <button type="button" class="field-btn" data-dir="1" aria-label="Следующее значение">&#x203A;</button>
+                </div>
+              </div>
+              <div class="stocks-list" id="resultStocks"></div>
+            </div>
+            <div class="result-actions">
+              <button type="button" id="mergeApply" class="merge-apply">Объединить карточки</button>
+              <div class="merge-notice" id="mergeNotice" role="status"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="selector-panel">
+        <div class="selector-head">
+          <label for="mergeSearch" class="selector-label">Поиск по карточкам</label>
+          <input id="mergeSearch" type="search" placeholder="Название или артикул" autocomplete="off" spellcheck="false">
+        </div>
+        <div class="selector-grid" id="mergeGrid" aria-live="polite"></div>
+      </div>
+    </div>
+
+    <div class="edit-view" id="historyView" role="tabpanel" aria-label="История" hidden>
+      <div class="history-wrapper">
+        <div class="history-head">
+          <h4>Журнал объединений</h4>
+          <p>Здесь сохраняются все операции объединения. Любую запись можно отменить, чтобы вернуть исходные карточки.</p>
+        </div>
+        <div class="history-list" id="mergeHistory" aria-live="polite"></div>
+      </div>
+    </div>
+  </div>
+
+  <style>
+    .edit-shell{display:flex;flex-direction:column;gap:24px}
+    .edit-headline{display:flex;flex-wrap:wrap;align-items:center;gap:16px;justify-content:space-between}
+    .edit-headline h3{margin:0;font-size:clamp(1.8rem,3vw,2.4rem)}
+    .edit-headline p{margin:4px 0 0;color:var(--muted);max-width:640px}
+    .edit-tabs{display:inline-flex;gap:8px;background:rgba(13,18,36,0.7);padding:6px;border-radius:999px;border:1px solid rgba(255,255,255,0.08)}
+    .edit-tab{border:none;background:transparent;color:var(--muted);padding:8px 16px;border-radius:999px;font-weight:500;cursor:pointer;transition:background .2s ease,color .2s ease}
+    .edit-tab.is-active{background:rgba(34,211,238,0.15);color:var(--text)}
+    .edit-view{display:flex;flex-direction:column;gap:24px}
+    .merge-board{display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:12px;align-items:stretch}
+    .merge-slot,.merge-result{position:relative;background:rgba(13,18,36,0.7);border:1px solid rgba(255,255,255,0.08);border-radius:18px;padding:16px;display:flex;flex-direction:column;gap:12px;min-height:200px;cursor:pointer;transition:border-color .2s ease,box-shadow .2s ease}
+    .merge-slot.is-active{border-color:color-mix(in srgb,var(--brand-2) 45%,transparent);box-shadow:0 12px 32px rgba(0,0,0,0.45)}
+    .merge-slot .slot-label{font-size:12px;letter-spacing:.08em;text-transform:uppercase;color:var(--muted)}
+    .merge-slot .slot-placeholder{color:var(--muted);font-size:14px}
+    .merge-slot .slot-summary{display:none;flex-direction:column;gap:6px}
+    .merge-slot.has-selection .slot-placeholder{display:none}
+    .merge-slot.has-selection .slot-summary{display:flex}
+    .slot-summary .slot-title{font-weight:600;font-size:16px}
+    .slot-summary .slot-meta{font-size:13px;color:var(--muted)}
+    .slot-clear{position:absolute;top:12px;right:12px;border:none;background:rgba(255,255,255,0.08);color:var(--text);border-radius:999px;padding:4px 10px;font-size:12px;cursor:pointer}
+    .merge-operator{display:flex;align-items:center;justify-content:center;font-size:28px;color:var(--muted)}
+    .merge-result{grid-column:span 2;cursor:default}
+    .merge-result .result-empty{margin:auto;color:var(--muted);text-align:center;max-width:240px;line-height:1.5}
+    .result-card{display:flex;flex-direction:column;gap:18px}
+    .result-card h4{margin:0;font-size:18px}
+    .result-fields{display:flex;flex-direction:column;gap:12px}
+    .result-field{background:rgba(12,18,38,0.9);border-radius:14px;padding:12px 14px;display:flex;flex-direction:column;gap:8px;border:1px solid rgba(255,255,255,0.05)}
+    .field-header{display:flex;align-items:center;justify-content:space-between;gap:10px;font-size:14px}
+    .field-controls{display:inline-flex;align-items:center;gap:8px;background:rgba(255,255,255,0.04);padding:4px 10px;border-radius:999px}
+    .field-btn{border:none;background:transparent;color:var(--text);font-size:18px;line-height:1;cursor:pointer;padding:2px 6px}
+    .field-value{font-weight:500;font-size:15px}
+    .field-hint{font-size:12px;color:var(--muted)}
+    .photo-preview{max-width:160px;border-radius:12px;overflow:hidden;border:1px solid rgba(255,255,255,0.06)}
+    .photo-preview img{display:block;width:100%;height:100%;object-fit:cover}
+    .result-stocks{display:flex;flex-direction:column;gap:12px}
+    .stocks-header{display:flex;align-items:center;justify-content:space-between;gap:12px}
+    .stocks-list{display:flex;flex-direction:column;gap:8px;background:rgba(12,18,38,0.9);padding:12px;border-radius:14px;border:1px solid rgba(255,255,255,0.05)}
+    .stocks-row{display:flex;justify-content:space-between;align-items:center;font-size:14px}
+    .stocks-row span:last-child{font-variant-numeric:tabular-nums}
+    .result-actions{display:flex;flex-direction:column;gap:10px}
+    .merge-apply{align-self:flex-start;background:var(--brand-2);color:#000;border:none;border-radius:12px;padding:10px 18px;font-weight:600;cursor:pointer}
+    .merge-apply:disabled{opacity:.5;cursor:not-allowed}
+    .merge-notice{min-height:20px;font-size:13px;color:var(--muted)}
+    .selector-panel{display:flex;flex-direction:column;gap:12px}
+    .selector-head{display:flex;flex-direction:column;gap:6px}
+    .selector-label{font-size:13px;color:var(--muted)}
+    #mergeSearch{border-radius:14px;border:1px solid rgba(255,255,255,0.08);background:rgba(13,18,36,0.75);color:var(--text);padding:12px 16px;font-size:15px}
+    .selector-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:12px}
+    .card-option{position:relative;background:rgba(13,18,36,0.68);border:1px solid rgba(255,255,255,0.08);border-radius:16px;padding:14px;display:flex;flex-direction:column;gap:8px;cursor:pointer;transition:border-color .2s ease,transform .2s ease}
+    .card-option:hover{transform:translateY(-2px);border-color:color-mix(in srgb,var(--brand-2) 40%,transparent)}
+    .card-option.is-selected{border-color:color-mix(in srgb,var(--brand-2) 70%,transparent)}
+    .card-option h5{margin:0;font-size:16px}
+    .card-option .card-meta{font-size:13px;color:var(--muted)}
+    .card-option .card-stocks{display:flex;flex-direction:column;gap:4px;font-size:12px;color:var(--muted)}
+    .selector-empty{color:var(--muted);padding:24px;text-align:center;border:1px dashed rgba(255,255,255,0.08);border-radius:14px}
+    .history-wrapper{display:flex;flex-direction:column;gap:18px}
+    .history-head h4{margin:0;font-size:20px}
+    .history-head p{margin:4px 0 0;color:var(--muted)}
+    .history-list{display:flex;flex-direction:column;gap:12px}
+    .history-item{background:rgba(13,18,36,0.7);border:1px solid rgba(255,255,255,0.08);border-radius:16px;padding:16px;display:flex;flex-direction:column;gap:12px}
+    .history-item header{display:flex;flex-wrap:wrap;gap:8px;align-items:center;justify-content:space-between}
+    .history-summary{font-weight:600}
+    .history-meta{font-size:13px;color:var(--muted)}
+    .history-fields{display:flex;flex-wrap:wrap;gap:10px;font-size:13px;color:var(--muted)}
+    .history-fields span{background:rgba(255,255,255,0.05);padding:4px 8px;border-radius:999px}
+    .history-actions{display:flex;gap:10px;align-items:center}
+    .history-actions button{border:none;border-radius:10px;background:rgba(34,211,238,0.18);color:var(--text);padding:6px 12px;font-size:13px;cursor:pointer}
+    .history-actions button:disabled{opacity:.5;cursor:not-allowed}
+    .history-flag{font-size:12px;color:var(--muted);background:rgba(255,255,255,0.05);padding:3px 8px;border-radius:999px}
+    @media(max-width:1100px){
+      .merge-board{grid-template-columns:repeat(1,minmax(0,1fr))}
+      .merge-result{grid-column:auto}
+      .merge-operator{order:-1}
+    }
+  </style>
+
+  <script>
+    (function(){
+      const SLOT_KEYS = ['a','b'];
+      const FIELD_ORDER = {
+        article: ['a','b','merge'],
+        name: ['a','b','merge'],
+        brand_country: ['a','b','merge'],
+        local_name: ['a','b','merge'],
+        photo: ['a','b','merge'],
+      };
+      const STOCK_ORDER = ['a','merge','b'];
+      const MODE_LABELS = {
+        a: 'из первой карточки',
+        b: 'из второй карточки',
+        merge: 'объединение значений'
+      };
+      const STOCK_LABELS = {
+        a: 'использовать остатки первой карточки',
+        b: 'использовать остатки второй карточки',
+        merge: 'объединить остатки'
+      };
+
+      const state = {
+        activeSlot: 'a',
+        slots: { a: null, b: null },
+        details: { a: null, b: null },
+        fieldModes: { article: 'a', name: 'merge', brand_country: 'a', local_name: 'merge', photo: 'a' },
+        stockMode: 'merge',
+        results: null,
+        loading: false,
+      };
+
+      const board = document.getElementById('mergeBoard');
+      const slotEls = {
+        a: board.querySelector('[data-slot="a"]'),
+        b: board.querySelector('[data-slot="b"]')
+      };
+      const resultEl = document.getElementById('mergeResult');
+      const resultCard = resultEl.querySelector('.result-card');
+      const resultEmpty = resultEl.querySelector('.result-empty');
+      const noticeEl = document.getElementById('mergeNotice');
+      const applyBtn = document.getElementById('mergeApply');
+      const stocksList = document.getElementById('resultStocks');
+      const searchInput = document.getElementById('mergeSearch');
+      const gridEl = document.getElementById('mergeGrid');
+      const historyEl = document.getElementById('mergeHistory');
+      const tabButtons = document.querySelectorAll('.edit-tab');
+      const mergeView = document.getElementById('mergeView');
+      const historyView = document.getElementById('historyView');
+
+      function hasValue(value){
+        if(value === null || value === undefined) return false;
+        if(typeof value === 'string'){ return value.trim().length > 0; }
+        return true;
+      }
+
+      function normalize(text){
+        return (text || '').toString().trim().toLowerCase().replace(/\s+/g,' ');
+      }
+
+      function mergeValues(mode, aVal, bVal){
+        const values = [];
+        const seen = new Set();
+        [['a', aVal], ['b', bVal]].forEach(([src,val]) => {
+          if(!hasValue(val)) return;
+          const text = String(val).trim();
+          const key = normalize(text);
+          if(seen.has(key)) return;
+          seen.add(key);
+          values.push({src, text});
+        });
+        if(!values.length){
+          return { value: '', mode: 'merge' };
+        }
+        if(values.length === 1){
+          return { value: values[0].text, mode: values[0].src };
+        }
+        return { value: values.map(v => v.text).join(' / '), mode: 'merge' };
+      }
+
+      function resolveField(field, mode){
+        const aDetail = state.details.a || {};
+        const bDetail = state.details.b || {};
+        const aValue = aDetail[field];
+        const bValue = bDetail[field];
+        if(mode === 'merge'){
+          return mergeValues(mode, aValue, bValue);
+        }
+        if(mode === 'a'){
+          if(hasValue(aValue)) return { value: aValue, mode: 'a' };
+          if(hasValue(bValue)) return { value: bValue, mode: 'b' };
+          return { value: '', mode: 'a' };
+        }
+        if(hasValue(bValue)) return { value: bValue, mode: 'b' };
+        if(hasValue(aValue)) return { value: aValue, mode: 'a' };
+        return { value: '', mode: 'b' };
+      }
+
+      function resolvePhoto(mode){
+        const aDetail = state.details.a || {};
+        const bDetail = state.details.b || {};
+        const aFile = aDetail.photo_file_id;
+        const aPath = aDetail.photo_path;
+        const bFile = bDetail.photo_file_id;
+        const bPath = bDetail.photo_path;
+        const aUrl = aDetail.photo_url;
+        const bUrl = bDetail.photo_url;
+
+        function pick(src){
+          if(src === 'b') return { file: bFile, path: bPath, url: bUrl };
+          return { file: aFile, path: aPath, url: aUrl };
+        }
+
+        if(mode === 'merge'){
+          const first = pick('a');
+          if(hasValue(first.file) || hasValue(first.path) || hasValue(first.url)){
+            return { value: first, mode: 'a' };
+          }
+          const second = pick('b');
+          if(hasValue(second.file) || hasValue(second.path) || hasValue(second.url)){
+            return { value: second, mode: 'b' };
+          }
+          return { value: { file: null, path: null, url: null }, mode: 'merge' };
+        }
+        const chosen = pick(mode);
+        if(hasValue(chosen.file) || hasValue(chosen.path) || hasValue(chosen.url)){
+          return { value: chosen, mode };
+        }
+        const alt = pick(mode === 'a' ? 'b' : 'a');
+        if(hasValue(alt.file) || hasValue(alt.path) || hasValue(alt.url)){
+          return { value: alt, mode: mode === 'a' ? 'b' : 'a' };
+        }
+        return { value: chosen, mode };
+      }
+
+      function stocksToMap(list){
+        const map = new Map();
+        (list || []).forEach(item => {
+          const code = item.code;
+          const qty = Number(item.qty) || 0;
+          const title = item.title || code;
+          if(!map.has(code)){
+            map.set(code, { code, title, qty });
+          } else {
+            map.get(code).qty += qty;
+          }
+        });
+        return map;
+      }
+
+      function resolveStocks(mode){
+        const aStocks = state.details.a ? state.details.a.stocks || [] : [];
+        const bStocks = state.details.b ? state.details.b.stocks || [] : [];
+        if(mode === 'a') return { items: [...aStocks], mode: 'a' };
+        if(mode === 'b') return { items: [...bStocks], mode: 'b' };
+        const combined = stocksToMap(aStocks);
+        stocksToMap(bStocks).forEach((value, key) => {
+          if(!combined.has(key)){
+            combined.set(key, value);
+          } else {
+            combined.get(key).qty += value.qty;
+          }
+        });
+        return { items: Array.from(combined.values()).sort((a,b)=>a.code.localeCompare(b.code)), mode: 'merge' };
+      }
+
+      function computeResult(){
+        if(!state.details.a || !state.details.b){
+          state.results = null;
+          return;
+        }
+        const applied = {};
+        const resolved = {};
+        Object.keys(FIELD_ORDER).forEach(key => {
+          if(key === 'photo'){
+            const res = resolvePhoto(state.fieldModes[key]);
+            resolved.photo = res.value;
+            applied.photo = res.mode;
+          } else {
+            const res = resolveField(key, state.fieldModes[key]);
+            resolved[key] = res.value;
+            applied[key] = res.mode;
+          }
+        });
+        const stockRes = resolveStocks(state.stockMode);
+        state.results = { fields: resolved, modes: applied, stocks: stockRes.items, stockMode: stockRes.mode };
+      }
+
+      function setActiveSlot(slot){
+        state.activeSlot = slot;
+        SLOT_KEYS.forEach(key => {
+          slotEls[key].classList.toggle('is-active', key === slot);
+        });
+      }
+
+      function updateSlot(slot){
+        const el = slotEls[slot];
+        const clearBtn = el.querySelector('.slot-clear');
+        const summary = el.querySelector('.slot-summary');
+        const placeholder = el.querySelector('.slot-placeholder');
+        const data = state.slots[slot];
+        if(data){
+          el.classList.add('has-selection');
+          clearBtn.hidden = false;
+          placeholder.hidden = true;
+          summary.innerHTML = '';
+          const title = document.createElement('div');
+          title.className = 'slot-title';
+          title.textContent = data.display || data.name || `#${data.id}`;
+          const meta = document.createElement('div');
+          meta.className = 'slot-meta';
+          const parts = [];
+          if(data.article) parts.push(data.article);
+          if(state.details[slot] && state.details[slot].stocks && state.details[slot].stocks.length){
+            const total = state.details[slot].stocks.reduce((acc,item)=>acc + Number(item.qty || 0),0);
+            parts.push(`остаток: ${total}`);
+          }
+          meta.textContent = parts.join(' • ');
+          summary.append(title, meta);
+        } else {
+          el.classList.remove('has-selection');
+          clearBtn.hidden = true;
+          placeholder.hidden = false;
+          summary.innerHTML = '';
+        }
+      }
+
+      function updateBoard(){
+        SLOT_KEYS.forEach(updateSlot);
+        computeResult();
+        renderResult();
+      }
+
+      function renderResult(){
+        if(!state.results){
+          resultCard.hidden = true;
+          resultEmpty.hidden = false;
+          noticeEl.textContent = '';
+          return;
+        }
+        resultCard.hidden = false;
+        resultEmpty.hidden = true;
+        const fields = state.results.fields;
+        const modes = state.results.modes;
+        resultCard.querySelectorAll('.result-field').forEach(fieldEl => {
+          const key = fieldEl.getAttribute('data-field');
+          const valueEl = fieldEl.querySelector('.field-value');
+          const hintEl = fieldEl.querySelector('.field-hint');
+          if(key === 'photo'){
+            const preview = fieldEl.querySelector('.photo-preview');
+            const data = fields.photo || {};
+            if(data.url){
+              preview.hidden = false;
+              preview.querySelector('img').src = data.url;
+            } else {
+              preview.hidden = true;
+            }
+            if(valueEl) valueEl.textContent = data.url ? 'Фото выбрано' : 'Нет фото';
+          } else if(valueEl){
+            valueEl.textContent = fields[key] ? String(fields[key]) : '—';
+          }
+          if(hintEl){
+            hintEl.textContent = MODE_LABELS[modes[key]] || '';
+          }
+        });
+        const stockFieldValue = resultCard.querySelector('.result-stocks .field-value');
+        if(stockFieldValue){
+          stockFieldValue.textContent = STOCK_LABELS[state.results.stockMode] || '';
+        }
+        stocksList.innerHTML = '';
+        if(state.results.stocks.length){
+          state.results.stocks.forEach(item => {
+            const row = document.createElement('div');
+            row.className = 'stocks-row';
+            const name = document.createElement('span');
+            name.textContent = `${item.title} (${item.code})`;
+            const qty = document.createElement('span');
+            qty.textContent = String(item.qty);
+            row.append(name, qty);
+            stocksList.append(row);
+          });
+        } else {
+          const row = document.createElement('div');
+          row.className = 'stocks-row';
+          const label = document.createElement('span');
+          label.textContent = 'Нет наличия';
+          const qty = document.createElement('span');
+          qty.textContent = '0';
+          row.append(label, qty);
+          stocksList.append(row);
+        }
+      }
+
+      function resetBoard(){
+        state.slots = { a: null, b: null };
+        state.details = { a: null, b: null };
+        state.fieldModes = { article: 'a', name: 'merge', brand_country: 'a', local_name: 'merge', photo: 'a' };
+        state.stockMode = 'merge';
+        state.results = null;
+        setActiveSlot('a');
+        updateBoard();
+        noticeEl.textContent = '';
+        applyBtn.disabled = false;
+      }
+
+      async function loadDetails(slot, pid){
+        try{
+          const res = await fetch(`/api/merge/product/${pid}`);
+          if(!res.ok){ throw new Error('not found'); }
+          const data = await res.json();
+          state.details[slot] = data;
+        } catch(err){
+          window.alert('Не удалось загрузить карточку.');
+        }
+      }
+
+      async function selectCard(slot, item){
+        state.slots[slot] = item;
+        await loadDetails(slot, item.id);
+        updateBoard();
+        if(slot === 'a' && !state.slots.b){
+          setActiveSlot('b');
+        }
+      }
+
+      function cycleMode(field, direction){
+        const order = FIELD_ORDER[field];
+        if(!order) return;
+        const current = state.fieldModes[field] || order[0];
+        const idx = order.indexOf(current);
+        const nextIdx = (idx + direction + order.length) % order.length;
+        state.fieldModes[field] = order[nextIdx];
+        updateBoard();
+      }
+
+      function cycleStockMode(direction){
+        const idx = STOCK_ORDER.indexOf(state.stockMode);
+        const nextIdx = (idx + direction + STOCK_ORDER.length) % STOCK_ORDER.length;
+        state.stockMode = STOCK_ORDER[nextIdx];
+        updateBoard();
+      }
+
+      function renderCards(items){
+        gridEl.innerHTML = '';
+        if(!items.length){
+          const empty = document.createElement('div');
+          empty.className = 'selector-empty';
+          empty.textContent = 'Не найдено карточек. Попробуйте другой запрос.';
+          gridEl.append(empty);
+          return;
+        }
+        items.forEach(item => {
+          const card = document.createElement('article');
+          card.className = 'card-option';
+          card.dataset.id = item.id;
+          const title = document.createElement('h5');
+          title.textContent = item.local_name || item.name || `#${item.id}`;
+          const meta = document.createElement('div');
+          meta.className = 'card-meta';
+          const parts = [];
+          if(item.article) parts.push(item.article);
+          if(item.name && item.local_name) parts.push(item.name);
+          meta.textContent = parts.join(' • ');
+          card.append(title, meta);
+          if(item.stocks && item.stocks.length){
+            const stocks = document.createElement('div');
+            stocks.className = 'card-stocks';
+            item.stocks.forEach(s => {
+              const span = document.createElement('span');
+              span.textContent = `${s.title}: ${s.qty}`;
+              stocks.append(span);
+            });
+            card.append(stocks);
+          }
+          const selected = Object.values(state.slots).some(s => s && s.id === item.id);
+          if(selected) card.classList.add('is-selected');
+          card.addEventListener('click', async () => {
+            const targetSlot = state.activeSlot || 'a';
+            await selectCard(targetSlot, item);
+            refreshGridSelection();
+          });
+          gridEl.append(card);
+        });
+      }
+
+      function refreshGridSelection(){
+        gridEl.querySelectorAll('.card-option').forEach(el => {
+          const id = Number(el.dataset.id);
+          const selected = Object.values(state.slots).some(s => s && s.id === id);
+          el.classList.toggle('is-selected', selected);
+        });
+      }
+
+      let searchTimer = null;
+      async function searchCards(){
+        const q = searchInput.value.trim();
+        try{
+          const res = await fetch(`/api/cards/search?q=${encodeURIComponent(q)}&limit=60`);
+          const items = await res.json();
+          renderCards(items);
+        } catch(err){
+          console.error(err);
+        }
+      }
+
+      searchInput.addEventListener('input', () => {
+        clearTimeout(searchTimer);
+        searchTimer = setTimeout(searchCards, 250);
+      });
+
+      SLOT_KEYS.forEach(slot => {
+        const el = slotEls[slot];
+        el.addEventListener('click', () => {
+          setActiveSlot(slot);
+        });
+        el.addEventListener('keydown', evt => {
+          if(evt.key === 'Enter' || evt.key === ' '){
+            evt.preventDefault();
+            setActiveSlot(slot);
+          }
+        });
+        el.querySelector('.slot-clear').addEventListener('click', evt => {
+          evt.stopPropagation();
+          state.slots[slot] = null;
+          state.details[slot] = null;
+          updateBoard();
+          refreshGridSelection();
+        });
+      });
+
+      resultCard.addEventListener('click', evt => {
+        const btn = evt.target.closest('.field-btn');
+        if(btn){
+          const fieldEl = btn.closest('.result-field');
+          if(fieldEl){
+            const field = fieldEl.dataset.field;
+            const dir = btn.dataset.dir === '-1' ? -1 : 1;
+            if(field === 'photo'){
+              cycleMode('photo', dir);
+            } else {
+              cycleMode(field, dir);
+            }
+          }
+        }
+        const stockBtn = evt.target.closest('.result-stocks .field-btn');
+        if(stockBtn){
+          const dir = stockBtn.dataset.dir === '-1' ? -1 : 1;
+          cycleStockMode(dir);
+        }
+      });
+
+      async function applyMerge(){
+        if(state.loading || !state.details.a || !state.details.b){
+          return;
+        }
+        state.loading = true;
+        applyBtn.disabled = true;
+        noticeEl.textContent = 'Объединение...';
+        const payload = {
+          source_a_id: state.details.a.id,
+          source_b_id: state.details.b.id,
+          field_modes: state.fieldModes,
+          stock_mode: state.stockMode,
+        };
+        try{
+          const res = await fetch('/api/merge/apply', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+          });
+          const data = await res.json();
+          if(!res.ok || !data.ok){
+            throw new Error(data.error || 'Не удалось объединить карточки');
+          }
+          noticeEl.textContent = 'Карточки объединены. Правила сохранены.';
+          await searchCards();
+          await loadHistory();
+          resetBoard();
+        } catch(err){
+          console.error(err);
+          noticeEl.textContent = err.message || 'Ошибка объединения';
+        } finally {
+          state.loading = false;
+          applyBtn.disabled = false;
+        }
+      }
+
+      applyBtn.addEventListener('click', applyMerge);
+
+      async function loadHistory(){
+        try{
+          const res = await fetch('/api/merge/history?limit=50');
+          const items = await res.json();
+          renderHistory(items);
+        } catch(err){
+          console.error(err);
+        }
+      }
+
+      function renderHistory(items){
+        historyEl.innerHTML = '';
+        if(!items.length){
+          const empty = document.createElement('div');
+          empty.className = 'selector-empty';
+          empty.textContent = 'Пока нет записей. Объедините первую пару карточек.';
+          historyEl.append(empty);
+          return;
+        }
+        items.forEach(item => {
+          const art = document.createElement('article');
+          art.className = 'history-item';
+          art.dataset.id = item.id;
+          const header = document.createElement('header');
+          const summary = document.createElement('span');
+          summary.className = 'history-summary';
+          summary.textContent = item.summary || `Объединение #${item.id}`;
+          const meta = document.createElement('span');
+          meta.className = 'history-meta';
+          meta.textContent = item.created_at || '';
+          header.append(summary, meta);
+          if(item.reverted){
+            const flag = document.createElement('span');
+            flag.className = 'history-flag';
+            flag.textContent = 'Отменено';
+            header.append(flag);
+          }
+          art.append(header);
+
+          const fields = document.createElement('div');
+          fields.className = 'history-fields';
+          const modes = item.field_modes || {};
+          Object.entries(modes).forEach(([key,val]) => {
+            if(key === 'photo'){
+              const span = document.createElement('span');
+              span.textContent = `Фото: ${MODE_LABELS[val] || val}`;
+              fields.append(span);
+            } else {
+              const label = {article:'Артикул', name:'Название', brand_country:'Бренд/страна', local_name:'Локальное имя'}[key];
+              if(label){
+                const span = document.createElement('span');
+                span.textContent = `${label}: ${MODE_LABELS[val] || val}`;
+                fields.append(span);
+              }
+            }
+          });
+          const stockSpan = document.createElement('span');
+          stockSpan.textContent = `Наличие: ${STOCK_LABELS[item.stock_mode] || item.stock_mode}`;
+          fields.append(stockSpan);
+          art.append(fields);
+
+          if(item.rule){
+            const rule = document.createElement('div');
+            rule.className = 'history-meta';
+            const srcArticles = (item.rule.articles && item.rule.articles.source || []).filter(Boolean);
+            if(srcArticles.length){
+              rule.textContent = `Правило: ${srcArticles.join(' + ')} → ${item.rule.articles.result || ''}`;
+            }
+            art.append(rule);
+          }
+
+          const actions = document.createElement('div');
+          actions.className = 'history-actions';
+          const undoBtn = document.createElement('button');
+          undoBtn.type = 'button';
+          undoBtn.textContent = 'Отменить';
+          undoBtn.disabled = item.reverted;
+          undoBtn.addEventListener('click', async () => {
+            try{
+              undoBtn.disabled = true;
+              const res = await fetch('/api/merge/undo', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ merge_id: item.id })
+              });
+              const data = await res.json();
+              if(!res.ok || !data.ok){
+                throw new Error(data.error || 'Не удалось отменить объединение');
+              }
+              await loadHistory();
+              await searchCards();
+              resetBoard();
+            } catch(err){
+              window.alert(err.message || 'Ошибка отмены');
+              undoBtn.disabled = false;
+            }
+          });
+          actions.append(undoBtn);
+          art.append(actions);
+          historyEl.append(art);
+        });
+      }
+
+      tabButtons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          const view = btn.dataset.view;
+          tabButtons.forEach(other => {
+            const active = other === btn;
+            other.classList.toggle('is-active', active);
+            other.setAttribute('aria-selected', active ? 'true' : 'false');
+          });
+          if(view === 'history'){
+            mergeView.hidden = true;
+            historyView.hidden = false;
+            loadHistory();
+          } else {
+            mergeView.hidden = false;
+            historyView.hidden = true;
+          }
+        });
+      });
+
+      // initial
+      setActiveSlot('a');
+      searchCards();
+    })();
+  </script>
+{% endblock %}

--- a/app/db.py
+++ b/app/db.py
@@ -179,6 +179,86 @@ def init_db():
         )
         conn.execute(
             """
+            CREATE TABLE IF NOT EXISTS product_merge_log(
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                created_at TEXT DEFAULT (datetime('now','localtime')),
+                source_a_id INTEGER NOT NULL,
+                source_b_id INTEGER NOT NULL,
+                result_id INTEGER NOT NULL,
+                field_modes TEXT NOT NULL,
+                stock_mode TEXT NOT NULL,
+                summary TEXT,
+                changes_json TEXT NOT NULL,
+                reverted_at TEXT,
+                FOREIGN KEY(source_a_id) REFERENCES product(id),
+                FOREIGN KEY(source_b_id) REFERENCES product(id),
+                FOREIGN KEY(result_id) REFERENCES product(id)
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS product_article_alias(
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                product_id INTEGER NOT NULL,
+                alias_article TEXT NOT NULL UNIQUE,
+                source_product_id INTEGER,
+                merge_log_id INTEGER,
+                created_at TEXT DEFAULT (datetime('now','localtime')),
+                FOREIGN KEY(product_id) REFERENCES product(id),
+                FOREIGN KEY(source_product_id) REFERENCES product(id),
+                FOREIGN KEY(merge_log_id) REFERENCES product_merge_log(id)
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS product_name_alias(
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                product_id INTEGER NOT NULL,
+                alias_name TEXT NOT NULL,
+                normalized_name TEXT NOT NULL UNIQUE,
+                source_product_id INTEGER,
+                merge_log_id INTEGER,
+                created_at TEXT DEFAULT (datetime('now','localtime')),
+                FOREIGN KEY(product_id) REFERENCES product(id),
+                FOREIGN KEY(source_product_id) REFERENCES product(id),
+                FOREIGN KEY(merge_log_id) REFERENCES product_merge_log(id)
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS product_merge_rule(
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                result_id INTEGER NOT NULL,
+                field_modes TEXT NOT NULL,
+                stock_mode TEXT NOT NULL,
+                articles_json TEXT,
+                names_json TEXT,
+                merge_log_id INTEGER,
+                active INTEGER NOT NULL DEFAULT 1,
+                created_at TEXT DEFAULT (datetime('now','localtime')),
+                reverted_at TEXT,
+                FOREIGN KEY(result_id) REFERENCES product(id),
+                FOREIGN KEY(merge_log_id) REFERENCES product_merge_log(id)
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_product_article_alias_product
+            ON product_article_alias(product_id)
+            """
+        )
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_product_name_alias_product
+            ON product_name_alias(product_id)
+            """
+        )
+        conn.execute(
+            """
             CREATE TABLE IF NOT EXISTS display_name_exception(
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 phrase TEXT NOT NULL UNIQUE,

--- a/app/services/imports.py
+++ b/app/services/imports.py
@@ -30,6 +30,7 @@ from app import config as app_config
 from app.db import db
 from app.services.notify import log_event_to_skl
 from app.services.archival import mark_restock
+from app.services import product_merge as merge_svc
 
 
 #
@@ -1260,19 +1261,76 @@ def _import_article_rows(rows: List[Tuple[str, str, float]], *, err_prefix: str,
                 if not _looks_like_article(art):
                     continue
                 with conn:
-                    cur = conn.execute(
-                        "INSERT OR IGNORE INTO product(article, name, is_new) VALUES (?,?,1)",
-                        (art, name),
-                    )
-                    pid = conn.execute("SELECT id FROM product WHERE article=?", (art,)).fetchone()["id"]
-                    if (cur.rowcount or 0) > 0:
-                        stats["created"] += 1
+                    alias_row = conn.execute(
+                        "SELECT product_id, merge_log_id FROM product_article_alias WHERE alias_article=?",
+                        (art,),
+                    ).fetchone()
+                    alias_via_name = None
+                    pid: Optional[int] = None
+                    if alias_row:
+                        pid = int(alias_row["product_id"])
                     else:
-                        conn.execute(
-                            "UPDATE product SET name = COALESCE(NULLIF(name,''), ?) WHERE id=?",
-                            (name, pid),
+                        existing = conn.execute(
+                            "SELECT id, name FROM product WHERE article=?",
+                            (art,),
+                        ).fetchone()
+                        if existing:
+                            pid = int(existing["id"])
+                    if pid is None:
+                        norm = merge_svc.normalize_name(name)
+                        if norm:
+                            alias_via_name = conn.execute(
+                                "SELECT product_id, merge_log_id FROM product_name_alias WHERE normalized_name=?",
+                                (norm,),
+                            ).fetchone()
+                            if alias_via_name:
+                                pid = int(alias_via_name["product_id"])
+
+                    if pid is None:
+                        cur = conn.execute(
+                            "INSERT OR IGNORE INTO product(article, name, is_new) VALUES (?,?,1)",
+                            (art, name),
                         )
+                        pid_row = conn.execute(
+                            "SELECT id FROM product WHERE article=?",
+                            (art,),
+                        ).fetchone()
+                        if not pid_row:
+                            continue
+                        pid = int(pid_row["id"])
+                        if (cur.rowcount or 0) > 0:
+                            stats["created"] += 1
+                        else:
+                            conn.execute(
+                                "UPDATE product SET name = COALESCE(NULLIF(name,''), ?) WHERE id=?",
+                                (name, pid),
+                            )
+                            stats["updated"] += 1
+                    else:
                         stats["updated"] += 1
+                        if alias_row is None:
+                            conn.execute(
+                                """
+                                INSERT OR IGNORE INTO product_article_alias(product_id, alias_article, source_product_id, merge_log_id)
+                                VALUES (?,?,?,?)
+                                """,
+                                (
+                                    pid,
+                                    art,
+                                    None,
+                                    alias_via_name["merge_log_id"] if alias_via_name else None,
+                                ),
+                            )
+                        prod_name_row = conn.execute(
+                            "SELECT name FROM product WHERE id=?",
+                            (pid,),
+                        ).fetchone()
+                        if prod_name_row and not (prod_name_row["name"] or "").strip() and name:
+                            conn.execute(
+                                "UPDATE product SET name=? WHERE id=?",
+                                (name, pid),
+                            )
+
                     prow = conn.execute(
                         "SELECT name, local_name FROM product WHERE id=?",
                         (pid,),

--- a/app/services/product_merge.py
+++ b/app/services/product_merge.py
@@ -1,0 +1,587 @@
+from __future__ import annotations
+
+import json
+import re
+import time
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+import sqlite3
+
+FIELD_KEYS = ("article", "name", "brand_country", "local_name")
+MERGE_MODES = {"a", "b", "merge"}
+PHOTO_MODES = {"a", "b", "merge"}
+
+
+def normalize_name(value: Optional[str]) -> str:
+    """Normalize product names for alias matching."""
+    if value is None:
+        return ""
+    normalized = re.sub(r"\s+", " ", str(value)).strip().lower()
+    return normalized
+
+
+def _row_to_dict(row: sqlite3.Row) -> Dict[str, Any]:
+    return {key: row[key] for key in row.keys()}
+
+
+def _has_value(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    return True
+
+
+def _coerce_text(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _merge_values(values: Iterable[Tuple[str, Any]]) -> Tuple[str, str]:
+    parts: List[str] = []
+    seen: set[str] = set()
+    last_mode = "merge"
+    for mode, value in values:
+        if not _has_value(value):
+            continue
+        text = _coerce_text(value).strip()
+        norm = normalize_name(text)
+        if norm in seen:
+            if not parts:
+                last_mode = mode
+            continue
+        seen.add(norm)
+        parts.append(text)
+        last_mode = mode
+    if not parts:
+        return "", "merge"
+    if len(parts) == 1:
+        return parts[0], last_mode
+    return " / ".join(parts), "merge"
+
+
+def _resolve_field(field: str, mode: str, a_value: Any, b_value: Any) -> Tuple[str, str]:
+    if mode not in MERGE_MODES:
+        mode = "a"
+    if mode == "merge":
+        merged, applied = _merge_values((("a", a_value), ("b", b_value)))
+        return merged, applied
+    if mode == "a":
+        if _has_value(a_value):
+            return _coerce_text(a_value), "a"
+        if _has_value(b_value):
+            return _coerce_text(b_value), "b"
+        return "", "a"
+    # mode == "b"
+    if _has_value(b_value):
+        return _coerce_text(b_value), "b"
+    if _has_value(a_value):
+        return _coerce_text(a_value), "a"
+    return "", "b"
+
+
+def _resolve_photo(mode: str, base: Dict[str, Any], other: Dict[str, Any]) -> Tuple[Optional[str], Optional[str], str]:
+    if mode not in PHOTO_MODES:
+        mode = "a"
+    a_file = base.get("photo_file_id")
+    a_path = base.get("photo_path")
+    b_file = other.get("photo_file_id")
+    b_path = other.get("photo_path")
+
+    def pick(source: str) -> Tuple[Optional[str], Optional[str]]:
+        if source == "b":
+            return b_file, b_path
+        return a_file, a_path
+
+    if mode == "merge":
+        file_id, path = pick("a")
+        applied = "a"
+        if not (_has_value(file_id) or _has_value(path)):
+            file_id, path = pick("b")
+            if _has_value(file_id) or _has_value(path):
+                applied = "b"
+        return file_id if _has_value(file_id) else None, path if _has_value(path) else None, applied
+
+    file_id, path = pick(mode)
+    applied = mode
+    if not (_has_value(file_id) or _has_value(path)):
+        alt = "b" if mode == "a" else "a"
+        file_id, path = pick(alt)
+        if _has_value(file_id) or _has_value(path):
+            applied = alt
+    return file_id if _has_value(file_id) else None, path if _has_value(path) else None, applied
+
+
+def _load_product(conn: sqlite3.Connection, pid: int) -> Dict[str, Any]:
+    row = conn.execute("SELECT * FROM product WHERE id=?", (pid,)).fetchone()
+    if not row:
+        raise ValueError(f"Product #{pid} not found")
+    return _row_to_dict(row)
+
+
+def _load_stocks(conn: sqlite3.Connection, pid: int) -> List[Dict[str, Any]]:
+    rows = conn.execute(
+        "SELECT location_code, qty_pack, name, local_name FROM stock WHERE product_id=?",
+        (pid,),
+    ).fetchall()
+    out: List[Dict[str, Any]] = []
+    for row in rows:
+        qty = row["qty_pack"] if row["qty_pack"] is not None else 0.0
+        out.append(
+            {
+                "location_code": row["location_code"],
+                "qty": float(qty),
+                "name": row["name"],
+                "local_name": row["local_name"],
+            }
+        )
+    return out
+
+
+def _placeholder_article(base_id: int, other_id: int) -> str:
+    stamp = int(time.time())
+    return f"MERGED-{base_id}-{other_id}-{stamp}"
+
+
+def _compute_stocks(mode: str, base: List[Dict[str, Any]], other: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    if mode not in {"a", "b", "merge"}:
+        mode = "merge"
+    if mode == "a":
+        return [dict(item) for item in base]
+    if mode == "b":
+        return [dict(item) for item in other]
+    combined: Dict[str, Dict[str, Any]] = {}
+    for source in (base, other):
+        for row in source:
+            code = row["location_code"]
+            qty = float(row.get("qty") or 0.0)
+            if code not in combined:
+                combined[code] = {
+                    "location_code": code,
+                    "qty": qty,
+                    "name": row.get("name"),
+                    "local_name": row.get("local_name"),
+                }
+            else:
+                combined[code]["qty"] += qty
+    return [combined[key] for key in sorted(combined.keys())]
+
+
+def _insert_stocks(
+    conn: sqlite3.Connection,
+    product_id: int,
+    stocks: List[Dict[str, Any]],
+    name: Optional[str],
+    local_name: Optional[str],
+) -> None:
+    for row in stocks:
+        qty = float(row.get("qty") or 0.0)
+        if abs(qty) < 1e-9:
+            continue
+        code = row.get("location_code")
+        conn.execute(
+            """
+            INSERT INTO stock(product_id, location_code, qty_pack, name, local_name)
+            VALUES (?,?,?,?,?)
+            """,
+            (
+                product_id,
+                code,
+                qty,
+                name,
+                local_name,
+            ),
+        )
+
+
+def _ensure_article_alias(
+    conn: sqlite3.Connection,
+    product_id: int,
+    alias_article: Optional[str],
+    source_product_id: Optional[int],
+    merge_log_id: Optional[int],
+) -> Optional[int]:
+    alias = (alias_article or "").strip()
+    if not alias:
+        return None
+    existing = conn.execute(
+        "SELECT id, merge_log_id FROM product_article_alias WHERE alias_article=?",
+        (alias,),
+    ).fetchone()
+    if existing:
+        return None
+    cur = conn.execute(
+        """
+        INSERT INTO product_article_alias(product_id, alias_article, source_product_id, merge_log_id)
+        VALUES (?,?,?,?)
+        """,
+        (product_id, alias, source_product_id, merge_log_id),
+    )
+    return int(cur.lastrowid)
+
+
+def _ensure_name_alias(
+    conn: sqlite3.Connection,
+    product_id: int,
+    alias_name: Optional[str],
+    source_product_id: Optional[int],
+    merge_log_id: Optional[int],
+) -> Optional[int]:
+    if not alias_name:
+        return None
+    normalized = normalize_name(alias_name)
+    if not normalized:
+        return None
+    existing = conn.execute(
+        "SELECT id FROM product_name_alias WHERE normalized_name=?",
+        (normalized,),
+    ).fetchone()
+    if existing:
+        return None
+    cur = conn.execute(
+        """
+        INSERT INTO product_name_alias(product_id, alias_name, normalized_name, source_product_id, merge_log_id)
+        VALUES (?,?,?,?,?)
+        """,
+        (product_id, alias_name.strip(), normalized, source_product_id, merge_log_id),
+    )
+    return int(cur.lastrowid)
+
+
+def _build_summary(base: Dict[str, Any], other: Dict[str, Any], result_article: str) -> str:
+    left = base.get("article") or f"#{base.get('id')}"
+    right = other.get("article") or f"#{other.get('id')}"
+    return f"{left} + {right} → {result_article}"
+
+
+def apply_merge(
+    conn: sqlite3.Connection,
+    source_a_id: int,
+    source_b_id: int,
+    *,
+    field_modes: Optional[Dict[str, str]] = None,
+    stock_mode: str = "merge",
+) -> Dict[str, Any]:
+    if source_a_id == source_b_id:
+        raise ValueError("Нельзя объединять карточку саму с собой")
+    field_modes = dict(field_modes or {})
+    if stock_mode not in {"a", "b", "merge"}:
+        stock_mode = "merge"
+
+    with conn:
+        base_before = _load_product(conn, source_a_id)
+        other_before = _load_product(conn, source_b_id)
+        if base_before.get("archived"):
+            base_before["archived"] = int(base_before.get("archived") or 0)
+        if other_before.get("archived"):
+            other_before["archived"] = int(other_before.get("archived") or 0)
+        base_stocks_before = _load_stocks(conn, source_a_id)
+        other_stocks_before = _load_stocks(conn, source_b_id)
+
+        applied_modes: Dict[str, str] = {}
+        resolved: Dict[str, Any] = {}
+        for key in FIELD_KEYS:
+            default_mode = "merge" if key in {"name", "local_name"} else "a"
+            mode = field_modes.get(key, default_mode)
+            value, applied = _resolve_field(key, mode, base_before.get(key), other_before.get(key))
+            resolved[key] = value
+            applied_modes[key] = applied
+        photo_mode = field_modes.get("photo", "a")
+        file_id, path, applied_photo = _resolve_photo(photo_mode, base_before, other_before)
+        resolved["photo_file_id"] = file_id
+        resolved["photo_path"] = path
+        applied_modes["photo"] = applied_photo
+
+        final_article = resolved.get("article", "").strip()
+        if not final_article:
+            raise ValueError("У объединённой карточки должен быть артикул")
+
+        placeholder = _placeholder_article(source_a_id, source_b_id)
+        conn.execute(
+            """
+            UPDATE product
+            SET article=?, archived=1, archived_at=datetime('now','localtime')
+            WHERE id=?
+            """,
+            (placeholder, source_b_id),
+        )
+        other_after = _load_product(conn, source_b_id)
+
+        conn.execute(
+            """
+            UPDATE product
+            SET article=?, name=?, brand_country=?, local_name=?,
+                photo_file_id=?, photo_path=?, archived=0, archived_at=NULL
+            WHERE id=?
+            """,
+            (
+                final_article,
+                resolved.get("name"),
+                resolved.get("brand_country"),
+                resolved.get("local_name"),
+                file_id,
+                path,
+                source_a_id,
+            ),
+        )
+        base_after = _load_product(conn, source_a_id)
+
+        final_stocks = _compute_stocks(stock_mode, base_stocks_before, other_stocks_before)
+        conn.execute("DELETE FROM stock WHERE product_id=?", (source_a_id,))
+        _insert_stocks(conn, source_a_id, final_stocks, base_after.get("name"), base_after.get("local_name"))
+        conn.execute("DELETE FROM stock WHERE product_id=?", (source_b_id,))
+
+        summary = _build_summary(base_before, other_before, final_article)
+        changes: Dict[str, Any] = {
+            "base_id": source_a_id,
+            "other_id": source_b_id,
+            "base_before": base_before,
+            "other_before": other_before,
+            "base_after": base_after,
+            "other_after": other_after,
+            "base_stocks_before": base_stocks_before,
+            "other_stocks_before": other_stocks_before,
+            "final_stocks": final_stocks,
+            "stock_mode": stock_mode,
+            "requested_field_modes": field_modes,
+            "applied_field_modes": applied_modes,
+        }
+
+        cur = conn.execute(
+            """
+            INSERT INTO product_merge_log(
+                source_a_id, source_b_id, result_id,
+                field_modes, stock_mode, summary, changes_json
+            ) VALUES (?,?,?,?,?,?,?)
+            """,
+            (
+                source_a_id,
+                source_b_id,
+                source_a_id,
+                json.dumps(applied_modes, ensure_ascii=False),
+                stock_mode,
+                summary,
+                json.dumps(changes, ensure_ascii=False),
+            ),
+        )
+        log_id = int(cur.lastrowid)
+
+        alias_records: List[Dict[str, Any]] = []
+        name_alias_records: List[Dict[str, Any]] = []
+
+        if base_before.get("article") and base_before.get("article") != final_article:
+            aid = _ensure_article_alias(
+                conn,
+                source_a_id,
+                base_before.get("article"),
+                source_a_id,
+                log_id,
+            )
+            if aid:
+                alias_records.append({"id": aid, "article": base_before.get("article")})
+        if other_before.get("article"):
+            aid = _ensure_article_alias(
+                conn,
+                source_a_id,
+                other_before.get("article"),
+                source_b_id,
+                log_id,
+            )
+            if aid:
+                alias_records.append({"id": aid, "article": other_before.get("article")})
+
+        for value, src in (
+            (base_before.get("name"), source_a_id),
+            (other_before.get("name"), source_b_id),
+            (base_before.get("local_name"), source_a_id),
+            (other_before.get("local_name"), source_b_id),
+        ):
+            nid = _ensure_name_alias(conn, source_a_id, value, src, log_id)
+            if nid:
+                name_alias_records.append({"id": nid, "name": value})
+
+        changes["article_aliases"] = alias_records
+        changes["name_aliases"] = name_alias_records
+        conn.execute(
+            "UPDATE product_merge_log SET changes_json=? WHERE id=?",
+            (json.dumps(changes, ensure_ascii=False), log_id),
+        )
+
+        articles_payload = {
+            "source": [base_before.get("article"), other_before.get("article")],
+            "result": final_article,
+        }
+        names_payload = {
+            "source": [
+                base_before.get("name"),
+                other_before.get("name"),
+                base_before.get("local_name"),
+                other_before.get("local_name"),
+            ],
+            "result": resolved.get("name"),
+            "local_result": resolved.get("local_name"),
+        }
+        rule_cur = conn.execute(
+            """
+            INSERT INTO product_merge_rule(
+                result_id, field_modes, stock_mode, articles_json, names_json, merge_log_id
+            ) VALUES (?,?,?,?,?,?)
+            """,
+            (
+                source_a_id,
+                json.dumps(applied_modes, ensure_ascii=False),
+                stock_mode,
+                json.dumps(articles_payload, ensure_ascii=False),
+                json.dumps(names_payload, ensure_ascii=False),
+                log_id,
+            ),
+        )
+        rule_id = int(rule_cur.lastrowid)
+        changes["rule_id"] = rule_id
+        conn.execute(
+            "UPDATE product_merge_log SET changes_json=? WHERE id=?",
+            (json.dumps(changes, ensure_ascii=False), log_id),
+        )
+
+        return {
+            "ok": True,
+            "result_id": source_a_id,
+            "log_id": log_id,
+            "summary": summary,
+            "field_modes": applied_modes,
+            "stock_mode": stock_mode,
+            "result_fields": {
+                "article": final_article,
+                "name": resolved.get("name"),
+                "brand_country": resolved.get("brand_country"),
+                "local_name": resolved.get("local_name"),
+                "photo_file_id": file_id,
+                "photo_path": path,
+            },
+            "final_stocks": final_stocks,
+        }
+
+
+def undo_merge(conn: sqlite3.Connection, merge_id: int) -> Dict[str, Any]:
+    row = conn.execute(
+        "SELECT * FROM product_merge_log WHERE id=?",
+        (merge_id,),
+    ).fetchone()
+    if not row:
+        return {"ok": False, "error": "merge_not_found"}
+    if row["reverted_at"]:
+        return {"ok": False, "error": "already_reverted"}
+    changes = json.loads(row["changes_json"] or "{}")
+    base_id = row["result_id"]
+    other_id = row["source_b_id"]
+    with conn:
+        conn.execute("DELETE FROM product_article_alias WHERE merge_log_id=?", (merge_id,))
+        conn.execute("DELETE FROM product_name_alias WHERE merge_log_id=?", (merge_id,))
+        conn.execute(
+            "UPDATE product_merge_rule SET active=0, reverted_at=datetime('now','localtime') WHERE merge_log_id=?",
+            (merge_id,),
+        )
+
+        base_before = changes.get("base_before") or {}
+        other_before = changes.get("other_before") or {}
+        conn.execute(
+            """
+            UPDATE product
+            SET article=?, name=?, brand_country=?, local_name=?,
+                photo_file_id=?, photo_path=?, archived=?, archived_at=?
+            WHERE id=?
+            """,
+            (
+                base_before.get("article"),
+                base_before.get("name"),
+                base_before.get("brand_country"),
+                base_before.get("local_name"),
+                base_before.get("photo_file_id"),
+                base_before.get("photo_path"),
+                int(base_before.get("archived") or 0),
+                base_before.get("archived_at"),
+                base_id,
+            ),
+        )
+        conn.execute(
+            """
+            UPDATE product
+            SET article=?, name=?, brand_country=?, local_name=?,
+                photo_file_id=?, photo_path=?, archived=?, archived_at=?
+            WHERE id=?
+            """,
+            (
+                other_before.get("article"),
+                other_before.get("name"),
+                other_before.get("brand_country"),
+                other_before.get("local_name"),
+                other_before.get("photo_file_id"),
+                other_before.get("photo_path"),
+                int(other_before.get("archived") or 0),
+                other_before.get("archived_at"),
+                other_id,
+            ),
+        )
+
+        conn.execute("DELETE FROM stock WHERE product_id=?", (base_id,))
+        _insert_stocks(
+            conn,
+            base_id,
+            changes.get("base_stocks_before") or [],
+            base_before.get("name"),
+            base_before.get("local_name"),
+        )
+        conn.execute("DELETE FROM stock WHERE product_id=?", (other_id,))
+        _insert_stocks(
+            conn,
+            other_id,
+            changes.get("other_stocks_before") or [],
+            other_before.get("name"),
+            other_before.get("local_name"),
+        )
+
+        changes["undone_at"] = time.time()
+        conn.execute(
+            "UPDATE product_merge_log SET reverted_at=datetime('now','localtime'), changes_json=? WHERE id=?",
+            (json.dumps(changes, ensure_ascii=False), merge_id),
+        )
+    return {"ok": True}
+
+
+def list_history(conn: sqlite3.Connection, limit: int = 20) -> List[Dict[str, Any]]:
+    rows = conn.execute(
+        """
+        SELECT l.id, l.created_at, l.source_a_id, l.source_b_id, l.result_id,
+               l.summary, l.field_modes, l.stock_mode, l.reverted_at,
+               l.changes_json,
+               r.articles_json, r.names_json, r.active
+        FROM product_merge_log l
+        LEFT JOIN product_merge_rule r ON r.merge_log_id = l.id
+        ORDER BY l.id DESC
+        LIMIT ?
+        """,
+        (limit,),
+    ).fetchall()
+    history: List[Dict[str, Any]] = []
+    for row in rows:
+        entry: Dict[str, Any] = {
+            "id": row["id"],
+            "created_at": row["created_at"],
+            "summary": row["summary"],
+            "field_modes": json.loads(row["field_modes"] or "{}"),
+            "stock_mode": row["stock_mode"],
+            "reverted": bool(row["reverted_at"]),
+            "reverted_at": row["reverted_at"],
+        }
+        changes = json.loads(row["changes_json"] or "{}")
+        if changes.get("requested_field_modes"):
+            entry["requested_field_modes"] = changes.get("requested_field_modes")
+        if row["articles_json"] or row["names_json"]:
+            entry["rule"] = {
+                "articles": json.loads(row["articles_json"] or "{}"),
+                "names": json.loads(row["names_json"] or "{}"),
+                "active": bool(row["active"]),
+            }
+        history.append(entry)
+    return history

--- a/tests/test_product_merge.py
+++ b/tests/test_product_merge.py
@@ -1,0 +1,162 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def app_modules(tmp_path, monkeypatch):
+    cfg = tmp_path / "config.json"
+    cfg.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("CONFIG_PATH", str(cfg))
+    db_path = tmp_path / "merge.sqlite3"
+    monkeypatch.setenv("DB_PATH", str(db_path))
+    repo_root = Path(__file__).resolve().parents[1]
+    monkeypatch.syspath_prepend(str(repo_root))
+    for mod in [m for m in list(sys.modules) if m == "app" or m.startswith("app.")]:
+        sys.modules.pop(mod, None)
+    db_module = importlib.import_module("app.db")
+    merge_module = importlib.import_module("app.services.product_merge")
+    imports_module = importlib.import_module("app.services.imports")
+    db_module.init_db()
+    return {"db": db_module, "merge": merge_module, "imports": imports_module}
+
+
+def test_apply_merge_creates_alias_and_can_undo(app_modules):
+    db = app_modules["db"]
+    merge = app_modules["merge"]
+    conn = db.db()
+    try:
+        with conn:
+            cur = conn.execute(
+                "INSERT INTO product(article, name, brand_country, local_name) VALUES (?,?,?,?)",
+                ("SKU-A", "Маршмеллоу A", "RU", "A"),
+            )
+            pid_a = cur.lastrowid
+            cur = conn.execute(
+                "INSERT INTO product(article, name, brand_country, local_name) VALUES (?,?,?,?)",
+                ("SKU-B", "Маршмеллоу B", "BY", "B"),
+            )
+            pid_b = cur.lastrowid
+            conn.execute(
+                "INSERT INTO stock(product_id, location_code, qty_pack, name, local_name) VALUES (?,?,?,?,?)",
+                (pid_a, "SKL-0", 2, "Маршмеллоу A", "A"),
+            )
+            conn.execute(
+                "INSERT INTO stock(product_id, location_code, qty_pack, name, local_name) VALUES (?,?,?,?,?)",
+                (pid_b, "SKL-1", 3, "Маршмеллоу B", "B"),
+            )
+        result = merge.apply_merge(
+            conn,
+            pid_a,
+            pid_b,
+            field_modes={
+                "article": "b",
+                "name": "merge",
+                "brand_country": "a",
+                "local_name": "merge",
+                "photo": "a",
+            },
+            stock_mode="merge",
+        )
+        assert result["ok"] is True
+        log_id = result["log_id"]
+
+        row = conn.execute("SELECT article, name, brand_country, local_name FROM product WHERE id=?", (pid_a,)).fetchone()
+        assert row["article"] == "SKU-B"
+        assert row["brand_country"] == "RU"
+        assert "Маршмеллоу A" in row["name"] and "Маршмеллоу B" in row["name"]
+
+        alias_rows = conn.execute(
+            "SELECT alias_article, product_id FROM product_article_alias ORDER BY alias_article",
+        ).fetchall()
+        assert {(r["alias_article"], r["product_id"]) for r in alias_rows} == {
+            ("SKU-A", pid_a),
+            ("SKU-B", pid_a),
+        }
+
+        archived_row = conn.execute("SELECT archived, article FROM product WHERE id=?", (pid_b,)).fetchone()
+        assert archived_row["archived"] == 1
+        assert archived_row["article"].startswith("MERGED-")
+
+        stock_rows = conn.execute(
+            "SELECT location_code, qty_pack FROM stock WHERE product_id=? ORDER BY location_code",
+            (pid_a,),
+        ).fetchall()
+        assert {(r["location_code"], float(r["qty_pack"])) for r in stock_rows} == {("SKL-0", 2.0), ("SKL-1", 3.0)}
+
+        rule_row = conn.execute(
+            "SELECT result_id, active FROM product_merge_rule WHERE merge_log_id=?",
+            (log_id,),
+        ).fetchone()
+        assert rule_row and rule_row["result_id"] == pid_a and rule_row["active"] == 1
+
+        undo = merge.undo_merge(conn, log_id)
+        assert undo["ok"] is True
+        restored = conn.execute(
+            "SELECT article, archived FROM product WHERE id IN (?,?) ORDER BY id",
+            (pid_a, pid_b),
+        ).fetchall()
+        assert restored[0]["article"] == "SKU-A" and restored[0]["archived"] == 0
+        assert restored[1]["article"] == "SKU-B" and restored[1]["archived"] == 0
+        remaining_aliases = conn.execute("SELECT COUNT(*) AS c FROM product_article_alias").fetchone()["c"]
+        assert remaining_aliases == 0
+        rule_after = conn.execute(
+            "SELECT active FROM product_merge_rule WHERE merge_log_id=?",
+            (log_id,),
+        ).fetchone()
+        assert rule_after and rule_after["active"] == 0
+    finally:
+        conn.close()
+
+
+def test_import_uses_aliases(app_modules):
+    db = app_modules["db"]
+    merge = app_modules["merge"]
+    imports = app_modules["imports"]
+    conn = db.db()
+    try:
+        with conn:
+            cur = conn.execute(
+                "INSERT INTO product(article, name, brand_country, local_name) VALUES (?,?,?,?)",
+                ("CANON-1", "Карамель", "RU", "Карамель"),
+            )
+            pid = cur.lastrowid
+            conn.execute(
+                "INSERT INTO stock(product_id, location_code, qty_pack, name, local_name) VALUES (?,?,?,?,?)",
+                (pid, "SKL-0", 1, "Карамель", "Карамель"),
+            )
+            conn.execute(
+                "INSERT INTO product_article_alias(product_id, alias_article) VALUES (?,?)",
+                (pid, "ALIAS-1"),
+            )
+
+        stats = imports._import_article_rows([("ALIAS-1", "Карамель", 5.0)], err_prefix="Row", start_index=1)
+        assert stats["imported"] == 1
+        total_qty = conn.execute(
+            "SELECT SUM(qty_pack) AS total FROM stock WHERE product_id=?",
+            (pid,),
+        ).fetchone()["total"]
+        assert pytest.approx(total_qty, rel=1e-5) == 6.0
+
+        norm = merge.normalize_name("Сливочная карамель")
+        with conn:
+            conn.execute(
+                "INSERT INTO product_name_alias(product_id, alias_name, normalized_name) VALUES (?,?,?)",
+                (pid, "Сливочная карамель", norm),
+            )
+        stats2 = imports._import_article_rows([("NEW-ALIAS2", "Сливочная карамель", 2.0)], err_prefix="Row", start_index=1)
+        assert stats2["imported"] == 1
+        alias_row = conn.execute(
+            "SELECT product_id FROM product_article_alias WHERE alias_article=?",
+            ("NEW-ALIAS2",),
+        ).fetchone()
+        assert alias_row and alias_row["product_id"] == pid
+        total_qty = conn.execute(
+            "SELECT SUM(qty_pack) AS total FROM stock WHERE product_id=?",
+            (pid,),
+        ).fetchone()["total"]
+        assert pytest.approx(total_qty, rel=1e-5) == 8.0
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary
- add backend service for merging product cards with undoable history, alias management and stored merge rules
- extend the database schema and import pipeline to honour article and name aliases when new supply rows arrive
- build a new "Редактировать" admin view with an interactive merge board, history log, and supporting API endpoints plus regression tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d0c8539850832ca9bf629d622729ab