### PR TITLE
Add HTML schedule export for admin bot

### DIFF
--- a/app/handlers/schedule.py
+++ b/app/handlers/schedule.py
@@ -45,6 +45,7 @@ async def cmd_sched_admin(m: Message):
     b.button(text="Календарь", callback_data="sched|admin|calendar")
     b.button(text="Создать график", callback_data="sched|admin|create")
     b.button(text="Поменять двух (все даты)", callback_data="sched|admin|swap_global")
+    b.button(text="Скачать таблицей", callback_data="sched|admin|table_html")
     b.adjust(1)
     b.row(InlineKeyboardButton(text="← Назад", callback_data="home"))
     await m.answer("Управление расписанием (админ):", reply_markup=b.as_markup())
@@ -341,6 +342,32 @@ async def cb_admin_calendar(cb: CallbackQuery):
     kb = month_calendar_kb(d.year, d.month, cb.from_user.id, back_cb="home")
     await cb.message.edit_text(f"Календарь — {d.strftime('%B %Y')}", reply_markup=kb)
     await cb.answer()
+
+
+@router.callback_query(F.data == "sched|admin|table_html")
+async def cb_admin_table_html(cb: CallbackQuery):
+    if not botmod.is_admin(cb.from_user.id, cb.from_user.username):
+        await cb.answer("Нет доступа", show_alert=True); return
+    today = dt.date.today()
+    m1 = _month_start(today)
+    m2 = dt.date(m1.year + (1 if m1.month == 12 else 0), 1 if m1.month == 12 else m1.month + 1, 1)
+    from app import config as app_config
+    from app.services.schedule_report import render_two_month_html
+    from aiogram.types import FSInputFile
+
+    ts = dt.datetime.now().strftime('%Y%m%d-%H%M%S')
+    html_path = app_config.REPORTS_DIR / f"schedule_{ts}.html"
+    try:
+        render_two_month_html(m1, m2, html_path)
+    except Exception as exc:
+        await cb.answer("Не удалось сформировать файл", show_alert=True)
+        await cb.message.answer(f"Ошибка при создании таблицы: {exc}")
+        return
+    caption = (
+        f"График на {m1.strftime('%B %Y')} и {m2.strftime('%B %Y')}"
+    )
+    await cb.message.answer_document(FSInputFile(str(html_path)), caption=caption)
+    await cb.answer("Готово")
 
 
 @router.callback_query(F.data.startswith("sched|admin|toggle|"))

--- a/app/services/schedule_report.py
+++ b/app/services/schedule_report.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import datetime as dt
-from typing import List, Tuple
+import html as _html
 from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
 
 from PIL import Image, ImageDraw, ImageFont
 
@@ -109,3 +110,124 @@ def png_to_pdf(png_path: Path, pdf_path: Path) -> Path:
     img = Image.open(png_path).convert('RGB')
     img.save(pdf_path, "PDF", resolution=150.0)
     return pdf_path
+
+
+_MONTH_NAMES_RU = {
+    1: "Январь",
+    2: "Февраль",
+    3: "Март",
+    4: "Апрель",
+    5: "Май",
+    6: "Июнь",
+    7: "Июль",
+    8: "Август",
+    9: "Сентябрь",
+    10: "Октябрь",
+    11: "Ноябрь",
+    12: "Декабрь",
+}
+
+
+def _month_title_ru(d: dt.date) -> str:
+    return f"{_MONTH_NAMES_RU.get(d.month, d.strftime('%B')).capitalize()} {d.year}"
+
+
+def _day_meta(week: List[dt.date], month_start: dt.date, conn) -> List[Optional[Dict[str, Set[int]]]]:
+    info: List[Optional[Dict[str, Set[int]]]] = []
+    for day in week:
+        if day.month != month_start.month:
+            info.append(None)
+            continue
+        assigned = set(sched.get_assignments(day, conn))
+        closed = not sched.is_open(day, conn)
+        info.append({"assigned": assigned, "closed": closed})
+    return info
+
+
+def render_two_month_html(m1: dt.date, m2: dt.date, out_html: Path, conn=None) -> Path:
+    own = False
+    if conn is None:
+        conn = sched._conn(); own = True
+    try:
+        sellers = sched.list_sellers(conn)
+        weekdays = ["Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Вс"]
+        now = dt.datetime.now().strftime('%d.%m.%Y %H:%M')
+
+        def render_month(month_start: dt.date) -> str:
+            weeks = _week_blocks(month_start)
+            rows: List[str] = []
+            rows.append(f"<section class=\"month\"><h2>{_html.escape(_month_title_ru(month_start))}</h2>")
+            rows.append("<table class=\"schedule-table\">")
+            header_cells = ''.join(f"<th>{_html.escape(w)}</th>" for w in weekdays)
+            rows.append(f"<thead><tr><th>Сотрудник</th>{header_cells}</tr></thead>")
+            rows.append("<tbody>")
+            for week in weeks:
+                meta = _day_meta(week, month_start, conn)
+                day_cells = ''.join(
+                    "<td class=\"day-num\">{}</td>".format(d.day if d.month == month_start.month else "")
+                    for d in week
+                )
+                rows.append(f"<tr class=\"week-days\"><td></td>{day_cells}</tr>")
+                for seller in sellers:
+                    name = _html.escape(_name_for(seller) or "")
+                    cell_html: List[str] = []
+                    for info, day in zip(meta, week):
+                        if info is None:
+                            cell_html.append("<td class=\"na\"></td>")
+                            continue
+                        if info["closed"]:
+                            cell_html.append("<td class=\"closed\">✖</td>")
+                        elif seller.tg_id in info["assigned"]:
+                            cell_html.append("<td class=\"on\">О</td>")
+                        else:
+                            cell_html.append("<td class=\"off\">–</td>")
+                    rows.append(f"<tr><td class=\"name\">{name}</td>{''.join(cell_html)}</tr>")
+            rows.append("</tbody></table></section>")
+            return ''.join(rows)
+
+        html_parts = [
+            "<!DOCTYPE html>",
+            "<html lang=\"ru\">",
+            "<head>",
+            "  <meta charset=\"utf-8\">",
+            "  <title>График работы</title>",
+            "  <style>",
+            "    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; margin: 24px; color: #222; background: #fff; }",
+            "    h1 { font-size: 24px; margin-bottom: 16px; }",
+            "    .month { margin-bottom: 40px; }",
+            "    .month h2 { margin: 0 0 12px; font-size: 20px; }",
+            "    .schedule-table { border-collapse: collapse; width: 100%; max-width: 960px; }",
+            "    .schedule-table th, .schedule-table td { border: 1px solid #d0d0d0; padding: 6px 8px; text-align: center; font-size: 14px; }",
+            "    .schedule-table th:first-child, .schedule-table td:first-child { text-align: left; font-weight: 600; min-width: 180px; }",
+            "    .schedule-table td.day-num { background: #f3f3f3; font-weight: 600; }",
+            "    .schedule-table tr.week-days td { border-top: 2px solid #bdbdbd; }",
+            "    .schedule-table td.off { color: #666; }",
+            "    .schedule-table td.on { color: #0a7a00; font-weight: 600; }",
+            "    .schedule-table td.closed { color: #c21807; font-weight: 600; }",
+            "    .legend { margin: 16px 0 32px; font-size: 14px; }",
+            "    .legend span { display: inline-block; min-width: 24px; text-align: center; padding: 2px 6px; margin-right: 8px; border: 1px solid #d0d0d0; border-radius: 4px; }",
+            "    .legend .on { border-color: #0a7a00; color: #0a7a00; }",
+            "    .legend .off { color: #666; }",
+            "    .legend .closed { border-color: #c21807; color: #c21807; }",
+            "    .generated { font-size: 12px; color: #666; margin-top: 24px; }",
+            "  </style>",
+            "</head>",
+            "<body>",
+            "  <h1>График работы продавцов</h1>",
+            "  <div class=\"legend\">",
+            "    <span class=\"on\">О</span> — в смене,",
+            "    <span class=\"off\">–</span> — выходной,",
+            "    <span class=\"closed\">✖</span> — нерабочий день",
+            "  </div>",
+            render_month(m1),
+            render_month(m2),
+            f"  <div class=\"generated\">Файл создан: {now}</div>",
+            "</body>",
+            "</html>",
+        ]
+        out_html.parent.mkdir(parents=True, exist_ok=True)
+        out_html.write_text('\n'.join(html_parts), encoding='utf-8')
+        return out_html
+    finally:
+        if own:
+            conn.close()


### PR DESCRIPTION
## Summary
- add a "Скачать таблицей" action to the admin schedule panel and deliver the generated file
- render a two-month HTML schedule report that mirrors the calendar data for download

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d0cc9a7454832cbcaf39c293004c08