### PR TITLE
Add advanced filters for product cards

### DIFF
--- a/admin_ui/server.py
+++ b/admin_ui/server.py
@@ -1555,76 +1555,161 @@ def create_app() -> Flask:
         return jsonify(items)
 
     # ====== API для карточек товаров ======
-    def _cards_search(conn, q: str, limit: int = 60) -> List[Dict[str, Any]]:
+    def _cards_search(
+        conn,
+        q: str,
+        limit: int = 60,
+        *,
+        without_local: bool = False,
+        hide_empty: bool = False,
+        only_empty: bool = False,
+        location_codes: Optional[Sequence[str]] = None,
+    ) -> List[Dict[str, Any]]:
         q = (q or "").strip()
+        try:
+            limit_val = int(limit)
+        except (TypeError, ValueError):
+            limit_val = 60
+        limit = max(limit_val, 1)
+
+        only_empty = bool(only_empty)
+        hide_empty = bool(hide_empty) and not only_empty
+        without_local = bool(without_local)
+
+        normalized_codes: List[str] = []
+        seen_codes: Set[str] = set()
+        if location_codes:
+            for raw_code in location_codes:
+                code = (raw_code or "").strip()
+                if not code or code in seen_codes:
+                    continue
+                seen_codes.add(code)
+                normalized_codes.append(code)
+
+        agg_params: List[Any] = list(normalized_codes)
+        if normalized_codes:
+            placeholders = ",".join(["?"] * len(normalized_codes))
+            filtered_case = (
+                f"SUM(CASE WHEN s.location_code IN ({placeholders}) THEN s.qty_pack ELSE 0 END)"
+            )
+        else:
+            filtered_case = "SUM(s.qty_pack)"
+
+        totals_subquery = f"""
+            SELECT s.product_id,
+                   SUM(s.qty_pack) AS total_all,
+                   {filtered_case} AS total_filtered
+            FROM stock s
+            GROUP BY s.product_id
+        """
+        EPS = 0.000001
+
+        def apply_common_filters(conditions: List[str], params: List[Any]) -> None:
+            if without_local:
+                conditions.append("(NULLIF(TRIM(p.local_name), '') IS NULL)")
+            if only_empty:
+                conditions.append("ABS(COALESCE(t.total_filtered,0)) <= ?")
+                params.append(EPS)
+            elif hide_empty:
+                conditions.append("COALESCE(t.total_filtered,0) > ?")
+                params.append(EPS)
+
+        def execute_query(query: str, params: Sequence[Any]) -> List[Any]:
+            query_params: List[Any] = list(agg_params)
+            query_params.extend(params)
+            query_params.append(limit)
+            return conn.execute(query, query_params).fetchall()
+
         rows: List[Any] = []
         try:
             if q:
-                has_fts = conn.execute(
-                    "SELECT 1 FROM sqlite_master WHERE type='table' AND name='product_fts'"
-                ).fetchone() is not None
+                has_fts = (
+                    conn.execute(
+                        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='product_fts'"
+                    ).fetchone()
+                    is not None
+                )
                 if has_fts:
                     match = (q.replace(" ", "* ") + "*").strip()
-                    rows = conn.execute(
-                        """
+                    conditions = ["product_fts MATCH ?", "p.archived=0"]
+                    params_list: List[Any] = [match]
+                    apply_common_filters(conditions, params_list)
+                    where_sql = " AND ".join(conditions) if conditions else "1=1"
+                    query = f"""
                         SELECT p.id, p.article, p.name, p.local_name, p.photo_path
                         FROM product_fts f
                         JOIN product p ON p.id=f.rowid
-                        LEFT JOIN (SELECT product_id, SUM(qty_pack) AS total FROM stock GROUP BY product_id) t ON t.product_id=p.id
-                        WHERE product_fts MATCH ? AND p.archived=0
-                        ORDER BY (COALESCE(t.total,0) > 0) DESC, p.id DESC
+                        LEFT JOIN ({totals_subquery}) t ON t.product_id=p.id
+                        WHERE {where_sql}
+                        ORDER BY (COALESCE(t.total_filtered,0) > 0) DESC,
+                                 (COALESCE(t.total_all,0) > 0) DESC,
+                                 p.id DESC
                         LIMIT ?
-                        """,
-                        (match, limit),
-                    ).fetchall()
+                    """
+                    rows = execute_query(query, params_list)
                 else:
                     like = f"%{q}%"
-                    rows = conn.execute(
-                        """
+                    conditions = [
+                        "p.archived=0",
+                        "(p.article LIKE ? OR p.name LIKE ? OR COALESCE(p.local_name,'') LIKE ?)",
+                    ]
+                    params_list = [like, like, like]
+                    apply_common_filters(conditions, params_list)
+                    where_sql = " AND ".join(conditions) if conditions else "1=1"
+                    query = f"""
                         SELECT p.id, p.article, p.name, p.local_name, p.photo_path,
-                               COALESCE(t.total,0) AS total
+                               COALESCE(t.total_all,0) AS total
                         FROM product p
-                        LEFT JOIN (SELECT product_id, SUM(qty_pack) AS total FROM stock GROUP BY product_id) t ON t.product_id=p.id
-                        WHERE p.archived=0 AND (p.article LIKE ? OR p.name LIKE ? OR COALESCE(p.local_name,'') LIKE ?)
-                        ORDER BY (COALESCE(t.total,0) > 0) DESC, p.id DESC
+                        LEFT JOIN ({totals_subquery}) t ON t.product_id=p.id
+                        WHERE {where_sql}
+                        ORDER BY (COALESCE(t.total_filtered,0) > 0) DESC,
+                                 (COALESCE(t.total_all,0) > 0) DESC,
+                                 p.id DESC
                         LIMIT ?
-                        """,
-                        (like, like, like, limit),
-                    ).fetchall()
-            else:
-                rows = conn.execute(
                     """
+                    rows = execute_query(query, params_list)
+            else:
+                conditions = ["p.archived=0"]
+                params_list: List[Any] = []
+                apply_common_filters(conditions, params_list)
+                where_sql = " AND ".join(conditions) if conditions else "1=1"
+                query = f"""
                     SELECT p.id, p.article, p.name, p.local_name, p.photo_path,
-                           COALESCE(t.total,0) AS total
+                           COALESCE(t.total_all,0) AS total
                     FROM product p
-                    LEFT JOIN (SELECT product_id, SUM(qty_pack) AS total FROM stock GROUP BY product_id) t ON t.product_id=p.id
-                    WHERE p.archived=0
-                    ORDER BY (COALESCE(t.total,0) > 0) DESC, p.id DESC
+                    LEFT JOIN ({totals_subquery}) t ON t.product_id=p.id
+                    WHERE {where_sql}
+                    ORDER BY (COALESCE(t.total_filtered,0) > 0) DESC,
+                             (COALESCE(t.total_all,0) > 0) DESC,
+                             p.id DESC
                     LIMIT ?
-                    """,
-                    (limit,),
-                ).fetchall()
+                """
+                rows = execute_query(query, params_list)
         except Exception:
-            # Fallback with simplified LIKE: ё->е
             like_raw = f"%{q}%"
             sq = (q or "").replace("Ё", "Е").replace("ё", "е").strip().lower()
             like_simpl = f"%{sq}%"
-            rows = conn.execute(
-                """
+            conditions = [
+                "p.archived=0",
+                "(p.article LIKE ? OR p.name LIKE ? OR COALESCE(p.local_name,'') LIKE ? "
+                "OR REPLACE(LOWER(p.name),'ё','е') LIKE ? "
+                "OR REPLACE(LOWER(COALESCE(p.local_name,'')),'ё','е') LIKE ?)",
+            ]
+            params_list = [like_raw, like_raw, like_raw, like_simpl, like_simpl]
+            apply_common_filters(conditions, params_list)
+            where_sql = " AND ".join(conditions) if conditions else "1=1"
+            query = f"""
                 SELECT p.id, p.article, p.name, p.local_name, p.photo_path,
-                       COALESCE(t.total,0) AS total
+                       COALESCE(t.total_all,0) AS total
                 FROM product p
-                LEFT JOIN (SELECT product_id, SUM(qty_pack) AS total FROM stock GROUP BY product_id) t ON t.product_id=p.id
-                WHERE p.archived=0 AND (
-                    p.article LIKE ? OR p.name LIKE ? OR COALESCE(p.local_name,'') LIKE ?
-                    OR REPLACE(LOWER(p.name),'ё','е') LIKE ?
-                    OR REPLACE(LOWER(COALESCE(p.local_name,'')),'ё','е') LIKE ?
-                )
-                ORDER BY (COALESCE(t.total,0) > 0) DESC, p.id DESC
+                LEFT JOIN ({totals_subquery}) t ON t.product_id=p.id
+                WHERE {where_sql}
+                ORDER BY (COALESCE(t.total_filtered,0) > 0) DESC,
+                         (COALESCE(t.total_all,0) > 0) DESC,
+                         p.id DESC
                 LIMIT ?
-                """,
-                (like_raw, like_raw, like_raw, like_simpl, like_simpl, limit),
-            ).fetchall()
+            """
+            rows = execute_query(query, params_list)
 
         ids = [r["id"] for r in rows]
         stocks_map: Dict[int, List[Dict[str, Any]]] = {}
@@ -1674,9 +1759,37 @@ def create_app() -> Flask:
     @app.get("/api/cards/search")
     def api_cards_search():
         q = request.args.get("q", "").strip()
-        limit = int(request.args.get("limit", "60"))
+        try:
+            limit = int(request.args.get("limit", "60"))
+        except (TypeError, ValueError):
+            limit = 60
+        limit = max(min(limit, 500), 1)
+
+        def _as_bool(value: Optional[str]) -> bool:
+            if value is None:
+                return False
+            value = value.strip().lower()
+            return value in {"1", "true", "yes", "on"}
+
+        raw_locations = request.args.getlist("locations")
+        seen_locations: Set[str] = set()
+        selected_locations: List[str] = []
+        for raw_code in raw_locations:
+            code = (raw_code or "").strip()
+            if code and code not in seen_locations:
+                seen_locations.add(code)
+                selected_locations.append(code)
+
         with adb.db() as conn:
-            items = _cards_search(conn, q, limit)
+            items = _cards_search(
+                conn,
+                q,
+                limit,
+                without_local=_as_bool(request.args.get("no_local")),
+                hide_empty=_as_bool(request.args.get("hide_empty")),
+                only_empty=_as_bool(request.args.get("only_empty")),
+                location_codes=selected_locations,
+            )
         return jsonify(items)
 
     @app.post("/api/stock/adjust")

--- a/admin_ui/templates/cards.html
+++ b/admin_ui/templates/cards.html
@@ -27,6 +27,18 @@
     #editModeToggle:checked + .edit-toggle__pill .edit-toggle__labels span:last-child{color:var(--text)}
     .cards-search input{width:100%;padding:14px 18px;border-radius:14px;border:1px solid rgba(255,255,255,0.06);background:rgba(18,24,50,0.85);color:var(--text);font-size:16px;transition:border-color .2s ease,box-shadow .2s ease}
     .cards-search input:focus{outline:none;border-color:color-mix(in srgb,var(--brand-2) 70%,transparent);box-shadow:0 0 0 2px color-mix(in srgb,var(--brand-2) 20%,transparent)}
+    .cards-filters{flex:1 1 360px;display:flex;flex-wrap:wrap;gap:12px;align-items:flex-start;background:rgba(13,18,36,0.72);border:1px solid rgba(255,255,255,0.08);border-radius:14px;padding:12px;min-width:0}
+    .cards-filter-group{display:flex;flex-wrap:wrap;gap:10px;align-items:center}
+    .cards-filter{display:inline-flex;align-items:center;gap:8px;padding:6px 12px;border-radius:10px;background:rgba(12,18,36,0.6);border:1px solid rgba(255,255,255,0.06);color:var(--muted);font-size:13px;white-space:nowrap}
+    .cards-filter input[type=checkbox]{width:16px;height:16px;margin:0}
+    .cards-filter input[type=checkbox]:focus-visible{outline:2px solid color-mix(in srgb,var(--brand-2) 45%,transparent);outline-offset:2px}
+    .cards-filter-select{display:flex;flex-direction:column;gap:6px;flex:1 1 220px;min-width:200px}
+    .cards-filter-select label{font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--muted)}
+    .cards-filter-select select{width:100%;min-height:96px;padding:8px 10px;border-radius:12px;border:1px solid rgba(255,255,255,0.08);background:rgba(12,18,36,0.82);color:var(--text);font-size:14px;resize:vertical}
+    .cards-filter-select select option{padding:4px 6px}
+    .cards-filter-select select:focus{outline:none;border-color:color-mix(in srgb,var(--brand-2) 40%,transparent);box-shadow:0 0 0 2px color-mix(in srgb,var(--brand-2) 18%,transparent)}
+    .cards-reset{align-self:flex-start;border-radius:10px;border:1px solid rgba(255,255,255,0.1);background:rgba(13,18,36,0.88);color:var(--muted);font-size:13px;padding:8px 16px;cursor:pointer;transition:border-color .2s ease,color .2s ease,background .2s ease}
+    .cards-reset:hover{color:var(--text);border-color:color-mix(in srgb,var(--brand-2) 32%,transparent);background:rgba(13,18,36,0.95)}
     .cards-suggest{position:absolute;top:calc(100% + 6px);left:0;right:0;background:color-mix(in srgb,var(--surface-1) 94%,transparent);border:1px solid rgba(255,255,255,0.06);border-radius:14px;box-shadow:0 20px 44px rgba(0,0,0,0.55);overflow:hidden;display:none;max-height:280px;overflow-y:auto;z-index:20}
     .cards-suggest.is-open{display:block}
     .cards-suggest button{width:100%;padding:12px 16px;background:transparent;border:none;text-align:left;color:var(--text);font-size:14px;cursor:pointer;display:flex;flex-direction:column;gap:2px}
@@ -87,6 +99,11 @@
       .cards-controls{flex-direction:column;align-items:stretch;gap:8px;margin-bottom:16px}
       .cards-search{flex-basis:auto}
       .cards-search input{padding:12px 14px;font-size:14px;border-radius:12px}
+      .cards-filters{width:100%;flex:1 1 auto;padding:10px;border-radius:12px}
+      .cards-filter{font-size:12px;padding:6px 10px}
+      .cards-filter-select{min-width:0;width:100%}
+      .cards-filter-select select{min-height:80px;font-size:13px}
+      .cards-reset{width:100%;text-align:center}
       .cards-suggest button{padding:10px 12px;font-size:13px}
       .cards-suggest button span{font-size:11px}
       .edit-toggle{font-size:13px}
@@ -137,6 +154,10 @@
       .product-card .card-media{height:120px}
       .product-heading h4{font-size:14px}
       .product-sub{font-size:11px}
+      .cards-filters{flex-direction:column;gap:10px}
+      .cards-filter-group{width:100%}
+      .cards-filter-select select{min-height:72px}
+      .cards-reset{width:100%}
       .local-field{padding:6px 10px;border-radius:10px}
       .local-field input{font-size:13px;min-height:30px}
       .field-status{min-width:0;text-align:left;font-size:11px}
@@ -159,6 +180,31 @@
     <div class="cards-search">
       <input id="cardsSearch" type="search" placeholder="Поиск (название или локальное имя)">
       <div class="cards-suggest" id="cardsResults" role="listbox"></div>
+    </div>
+    <div class="cards-filters">
+      <div class="cards-filter-group">
+        <label class="cards-filter">
+          <input type="checkbox" id="filterNoLocal">
+          <span>Без локального имени</span>
+        </label>
+        <label class="cards-filter">
+          <input type="checkbox" id="filterHideEmpty">
+          <span>Скрыть отсутствующие</span>
+        </label>
+        <label class="cards-filter">
+          <input type="checkbox" id="filterOnlyEmpty">
+          <span>Показать только отсутствующие</span>
+        </label>
+      </div>
+      <div class="cards-filter-select">
+        <label for="filterLocations">Фильтр по локациям</label>
+        <select id="filterLocations" multiple size="6">
+          {% for l in locations %}
+            <option value="{{ l['code'] }}">{{ l['title'] }} ({{ l['code'] }})</option>
+          {% endfor %}
+        </select>
+      </div>
+      <button type="button" class="cards-reset" id="filtersReset">Сбросить</button>
     </div>
     <label class="edit-toggle">
       <input id="editModeToggle" type="checkbox">
@@ -271,6 +317,11 @@
     const writeOffQtyInput = document.getElementById('writeOffQty');
     const writeOffQtyGroup = document.getElementById('writeOffQtyGroup');
     const writeOffSubmitBtn = document.getElementById('writeOffSubmit');
+    const filterNoLocal = document.getElementById('filterNoLocal');
+    const filterHideEmpty = document.getElementById('filterHideEmpty');
+    const filterOnlyEmpty = document.getElementById('filterOnlyEmpty');
+    const filterLocations = document.getElementById('filterLocations');
+    const filtersResetBtn = document.getElementById('filtersReset');
     const allLocations = {{ locations | tojson | safe }};
     const locationMap = new Map(allLocations.map(loc => [loc.code, loc]));
     const debounceTimers = new WeakMap();
@@ -281,6 +332,7 @@
     let currentWriteOffStocks = [];
     const HUB_CODE = 'SKL-0';
     const WRITE_OFF_DST = 'HALL';
+    const SEARCH_LIMIT = 60;
 
     function escapeHtml(s){
       return (s||'').replace(/[&<>"']/g, c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[c]));
@@ -580,8 +632,29 @@
         </article>`;
     }
 
-    async function fetchItems(q){
-      const r = await fetch(`/api/cards/search?q=${encodeURIComponent(q||'')}&limit=60`);
+    function buildSearchParams(q){
+      const params = new URLSearchParams();
+      params.set('q', q || '');
+      params.set('limit', String(SEARCH_LIMIT));
+      if(filterNoLocal && filterNoLocal.checked){
+        params.set('no_local', '1');
+      }
+      if(filterOnlyEmpty && filterOnlyEmpty.checked){
+        params.set('only_empty', '1');
+      } else if(filterHideEmpty && filterHideEmpty.checked){
+        params.set('hide_empty', '1');
+      }
+      if(filterLocations){
+        Array.from(filterLocations.selectedOptions || []).map(opt => opt.value).filter(Boolean).forEach(code => {
+          params.append('locations', code);
+        });
+      }
+      return params;
+    }
+
+    async function fetchItems(params){
+      const url = `/api/cards/search?${params.toString()}`;
+      const r = await fetch(url);
       return await r.json();
     }
 
@@ -625,9 +698,12 @@
     }
 
     async function searchNow(){
+      clearTimeout(searchTimer);
+      searchTimer = null;
       const q = search.value.trim();
+      const params = buildSearchParams(q);
       const [items, sugg] = await Promise.all([
-        fetchItems(q),
+        fetchItems(params),
         q ? fetch(`/api/products/search?q=${encodeURIComponent(q)}&limit=15`).then(r=>r.json()) : []
       ]);
       render(items);
@@ -649,6 +725,12 @@
       if(results.childElementCount){ results.classList.add('is-open'); }
     }
 
+    function triggerSearch(){
+      clearTimeout(searchTimer);
+      searchTimer = null;
+      searchNow();
+    }
+
     search.addEventListener('input', function(){
       clearTimeout(searchTimer);
       searchTimer = setTimeout(searchNow, 300);
@@ -663,6 +745,50 @@
         clearSuggestions();
       }
     });
+
+    if(filterNoLocal){
+      filterNoLocal.addEventListener('change', function(){
+        triggerSearch();
+      });
+    }
+
+    if(filterHideEmpty){
+      filterHideEmpty.addEventListener('change', function(){
+        if(filterHideEmpty.checked && filterOnlyEmpty){
+          filterOnlyEmpty.checked = false;
+        }
+        triggerSearch();
+      });
+    }
+
+    if(filterOnlyEmpty){
+      filterOnlyEmpty.addEventListener('change', function(){
+        if(filterOnlyEmpty.checked && filterHideEmpty){
+          filterHideEmpty.checked = false;
+        }
+        triggerSearch();
+      });
+    }
+
+    if(filterLocations){
+      filterLocations.addEventListener('change', function(){
+        triggerSearch();
+      });
+    }
+
+    if(filtersResetBtn){
+      filtersResetBtn.addEventListener('click', function(){
+        search.value = '';
+        if(filterNoLocal){ filterNoLocal.checked = false; }
+        if(filterHideEmpty){ filterHideEmpty.checked = false; }
+        if(filterOnlyEmpty){ filterOnlyEmpty.checked = false; }
+        if(filterLocations){
+          Array.from(filterLocations.options || []).forEach(opt => { opt.selected = false; });
+        }
+        clearSuggestions();
+        triggerSearch();
+      });
+    }
 
     function setStatus(input, state, label){
       const block = input.closest('.field-block');


### PR DESCRIPTION
## Summary
- add rich filter controls to the product cards page including local-name, availability, location selection and reset actions
- extend the cards search API to honour the new filters and improve ordering around location-specific stock totals

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d0cd6ba6a4832c939d59f0ee17db97