### PR TITLE
Reassign aliases when merging products

### DIFF
--- a/app/services/product_merge.py
+++ b/app/services/product_merge.py
@@ -306,6 +306,32 @@ def apply_merge(
             """,
             (placeholder, source_b_id),
         )
+
+        article_alias_reassigned_ids: List[int] = []
+        name_alias_reassigned_ids: List[int] = []
+
+        existing_article_aliases = conn.execute(
+            "SELECT id FROM product_article_alias WHERE product_id=?",
+            (source_b_id,),
+        ).fetchall()
+        if existing_article_aliases:
+            article_alias_reassigned_ids = [int(row["id"]) for row in existing_article_aliases]
+            conn.execute(
+                "UPDATE product_article_alias SET product_id=? WHERE product_id=?",
+                (source_a_id, source_b_id),
+            )
+
+        existing_name_aliases = conn.execute(
+            "SELECT id FROM product_name_alias WHERE product_id=?",
+            (source_b_id,),
+        ).fetchall()
+        if existing_name_aliases:
+            name_alias_reassigned_ids = [int(row["id"]) for row in existing_name_aliases]
+            conn.execute(
+                "UPDATE product_name_alias SET product_id=? WHERE product_id=?",
+                (source_a_id, source_b_id),
+            )
+
         other_after = _load_product(conn, source_b_id)
 
         conn.execute(
@@ -346,6 +372,8 @@ def apply_merge(
             "stock_mode": stock_mode,
             "requested_field_modes": field_modes,
             "applied_field_modes": applied_modes,
+            "article_alias_reassigned_ids": article_alias_reassigned_ids,
+            "name_alias_reassigned_ids": name_alias_reassigned_ids,
         }
 
         cur = conn.execute(
@@ -476,6 +504,22 @@ def undo_merge(conn: sqlite3.Connection, merge_id: int) -> Dict[str, Any]:
     base_id = row["result_id"]
     other_id = row["source_b_id"]
     with conn:
+        article_alias_ids = [int(value) for value in changes.get("article_alias_reassigned_ids") or []]
+        if article_alias_ids:
+            placeholders = ", ".join("?" for _ in article_alias_ids)
+            conn.execute(
+                f"UPDATE product_article_alias SET product_id=? WHERE product_id=? AND id IN ({placeholders})",
+                [other_id, base_id, *article_alias_ids],
+            )
+
+        name_alias_ids = [int(value) for value in changes.get("name_alias_reassigned_ids") or []]
+        if name_alias_ids:
+            placeholders = ", ".join("?" for _ in name_alias_ids)
+            conn.execute(
+                f"UPDATE product_name_alias SET product_id=? WHERE product_id=? AND id IN ({placeholders})",
+                [other_id, base_id, *name_alias_ids],
+            )
+
         conn.execute("DELETE FROM product_article_alias WHERE merge_log_id=?", (merge_id,))
         conn.execute("DELETE FROM product_name_alias WHERE merge_log_id=?", (merge_id,))
         conn.execute(

--- a/tests/test_product_merge.py
+++ b/tests/test_product_merge.py
@@ -160,3 +160,130 @@ def test_import_uses_aliases(app_modules):
         assert pytest.approx(total_qty, rel=1e-5) == 8.0
     finally:
         conn.close()
+
+
+def test_merge_reassigns_existing_aliases(app_modules):
+    db = app_modules["db"]
+    merge = app_modules["merge"]
+    imports = app_modules["imports"]
+    article_a = "CANON-A1"
+    article_b = "CANON-B1"
+    article_c = "CANON-C1"
+    conn = db.db()
+    try:
+        with conn:
+            cur = conn.execute(
+                "INSERT INTO product(article, name, brand_country, local_name) VALUES (?,?,?,?)",
+                (article_a, "Карточка A", "RU", "A"),
+            )
+            pid_a = int(cur.lastrowid)
+            cur = conn.execute(
+                "INSERT INTO product(article, name, brand_country, local_name) VALUES (?,?,?,?)",
+                (article_b, "Карточка B", "RU", "B"),
+            )
+            pid_b = int(cur.lastrowid)
+            cur = conn.execute(
+                "INSERT INTO product(article, name, brand_country, local_name) VALUES (?,?,?,?)",
+                (article_c, "Карточка C", "RU", "C"),
+            )
+            pid_c = int(cur.lastrowid)
+            conn.execute(
+                "INSERT INTO stock(product_id, location_code, qty_pack, name, local_name) VALUES (?,?,?,?,?)",
+                (pid_a, "SKL-0", 1.0, "Карточка A", "A"),
+            )
+            conn.execute(
+                "INSERT INTO stock(product_id, location_code, qty_pack, name, local_name) VALUES (?,?,?,?,?)",
+                (pid_b, "SKL-0", 2.0, "Карточка B", "B"),
+            )
+            conn.execute(
+                "INSERT INTO stock(product_id, location_code, qty_pack, name, local_name) VALUES (?,?,?,?,?)",
+                (pid_c, "SKL-0", 3.0, "Карточка C", "C"),
+            )
+
+        first_merge = merge.apply_merge(
+            conn,
+            pid_b,
+            pid_c,
+            field_modes={
+                "article": "a",
+                "name": "merge",
+                "brand_country": "a",
+                "local_name": "merge",
+                "photo": "a",
+            },
+            stock_mode="merge",
+        )
+        assert first_merge["ok"] is True
+
+        alias_before = conn.execute(
+            "SELECT product_id FROM product_article_alias WHERE alias_article=?",
+            (article_c,),
+        ).fetchone()
+        assert alias_before and alias_before["product_id"] == pid_b
+
+        second_merge = merge.apply_merge(
+            conn,
+            pid_a,
+            pid_b,
+            field_modes={
+                "article": "a",
+                "name": "merge",
+                "brand_country": "a",
+                "local_name": "merge",
+                "photo": "a",
+            },
+            stock_mode="merge",
+        )
+        assert second_merge["ok"] is True
+        log_id = second_merge["log_id"]
+
+        alias_after = conn.execute(
+            "SELECT product_id FROM product_article_alias WHERE alias_article=?",
+            (article_c,),
+        ).fetchone()
+        assert alias_after and alias_after["product_id"] == pid_a
+        norm_c = merge.normalize_name("Карточка C")
+        name_alias_after = conn.execute(
+            "SELECT product_id FROM product_name_alias WHERE normalized_name=?",
+            (norm_c,),
+        ).fetchone()
+        assert name_alias_after and name_alias_after["product_id"] == pid_a
+
+        stats = imports._import_article_rows(
+            [(article_c, "Карточка C", 4.0)],
+            err_prefix="Row",
+            start_index=1,
+        )
+        assert stats["imported"] == 1
+        total_a = conn.execute(
+            "SELECT SUM(qty_pack) AS total FROM stock WHERE product_id=?",
+            (pid_a,),
+        ).fetchone()["total"]
+        assert pytest.approx(total_a or 0.0, rel=1e-5) == 10.0
+
+        undo = merge.undo_merge(conn, log_id)
+        assert undo["ok"] is True
+
+        alias_restored = conn.execute(
+            "SELECT product_id FROM product_article_alias WHERE alias_article=?",
+            (article_c,),
+        ).fetchone()
+        assert alias_restored and alias_restored["product_id"] == pid_b
+        name_alias_restored = conn.execute(
+            "SELECT product_id FROM product_name_alias WHERE normalized_name=?",
+            (norm_c,),
+        ).fetchone()
+        assert name_alias_restored and name_alias_restored["product_id"] == pid_b
+
+        total_a_after_undo = conn.execute(
+            "SELECT SUM(qty_pack) AS total FROM stock WHERE product_id=?",
+            (pid_a,),
+        ).fetchone()["total"]
+        assert pytest.approx(total_a_after_undo or 0.0, rel=1e-5) == 1.0
+        total_b_after_undo = conn.execute(
+            "SELECT SUM(qty_pack) AS total FROM stock WHERE product_id=?",
+            (pid_b,),
+        ).fetchone()["total"]
+        assert pytest.approx(total_b_after_undo or 0.0, rel=1e-5) == 5.0
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary
- reassign article and name aliases to the canonical product during merge and store their ids for rollback
- restore reassigned aliases in undo_merge so previous mappings return to the archived product
- add a regression test covering repeated merges with existing aliases and import behavior

## Testing
- pytest tests/test_product_merge.py

------
https://chatgpt.com/codex/tasks/task_b_68d0daf29bd0832c85f0f94fc0a8c29c