### PR TITLE
Implement automatic similar card grouping

### DIFF
--- a/admin_ui/server.py
+++ b/admin_ui/server.py
@@ -2017,6 +2017,182 @@ def create_app() -> Flask:
         top_rows = [row for _, row in top]
         return _hydrate_card_rows(conn, top_rows, extras=extras)
 
+    def _find_similar_groups(
+        conn: sqlite3.Connection,
+        *,
+        limit: int = 20,
+        threshold: float = 0.7,
+    ) -> List[Dict[str, Any]]:
+        try:
+            limit_val = int(limit)
+        except (TypeError, ValueError):
+            limit_val = 20
+        limit = max(1, min(limit_val, 200))
+        try:
+            threshold_val = float(threshold)
+        except (TypeError, ValueError):
+            threshold_val = 0.7
+        threshold = max(0.0, min(threshold_val, 1.0))
+
+        phrase_rows = conn.execute(
+            "SELECT phrase FROM display_name_exception ORDER BY lower(phrase)"
+        ).fetchall()
+        phrases = [row["phrase"] for row in phrase_rows if row["phrase"]]
+
+        product_rows = conn.execute(
+            """
+            SELECT id, article, name, local_name, photo_path
+            FROM product
+            WHERE archived=0
+            """
+        ).fetchall()
+        if not product_rows:
+            return []
+
+        alias_rows = conn.execute(
+            "SELECT product_id, normalized_name FROM product_name_alias"
+        ).fetchall()
+        alias_map: Dict[int, List[str]] = {}
+        for alias_row in alias_rows:
+            pid = int(alias_row["product_id"])
+            raw_alias = alias_row["normalized_name"]
+            normalized_alias = _normalize_match_name(raw_alias, phrases)
+            if not normalized_alias:
+                continue
+            alias_map.setdefault(pid, []).append(normalized_alias)
+
+        candidates: List[Dict[str, Any]] = []
+        token_map: Dict[str, List[int]] = {}
+        for row in product_rows:
+            variants_raw = [row["local_name"], row["name"]]
+            variants_raw.extend(alias_map.get(int(row["id"]), []))
+            variants: List[str] = []
+            seen_variants: Set[str] = set()
+            for variant in variants_raw:
+                normalized = _normalize_match_name(variant, phrases)
+                if not normalized or normalized in seen_variants:
+                    continue
+                seen_variants.add(normalized)
+                variants.append(normalized)
+            if not variants:
+                continue
+            tokens: Set[str] = set()
+            for variant in variants:
+                for token in _tokenize_match_name(variant):
+                    tokens.add(token)
+            if not tokens:
+                continue
+            idx = len(candidates)
+            candidates.append({
+                "row": row,
+                "variants": variants,
+                "tokens": tokens,
+            })
+            for token in tokens:
+                token_map.setdefault(token, []).append(idx)
+
+        if not candidates:
+            return []
+
+        MAX_TOKEN_NEIGHBORS = 400
+        adjacency: Dict[int, Set[int]] = {i: set() for i in range(len(candidates))}
+        edge_scores: Dict[Tuple[int, int], float] = {}
+
+        for idx, cand in enumerate(candidates):
+            possible: Set[int] = set()
+            for token in cand["tokens"]:
+                neighbors = token_map.get(token, [])
+                if len(neighbors) > MAX_TOKEN_NEIGHBORS:
+                    continue
+                for other_idx in neighbors:
+                    if other_idx <= idx:
+                        continue
+                    possible.add(other_idx)
+            if not possible:
+                continue
+            for other_idx in possible:
+                other = candidates[other_idx]
+                best_score = 0.0
+                for left in cand["variants"]:
+                    for right in other["variants"]:
+                        score = _similarity_ratio(left, right)
+                        if score > best_score:
+                            best_score = score
+                            if best_score >= 0.9999:
+                                break
+                    if best_score >= 0.9999:
+                        break
+                if best_score < threshold:
+                    continue
+                adjacency[idx].add(other_idx)
+                adjacency[other_idx].add(idx)
+                edge_scores[(idx, other_idx)] = best_score
+
+        visited: Set[int] = set()
+        groups_idx: List[List[int]] = []
+        for idx in range(len(candidates)):
+            if idx in visited:
+                continue
+            if not adjacency.get(idx):
+                continue
+            stack = [idx]
+            component: List[int] = []
+            while stack:
+                current = stack.pop()
+                if current in visited:
+                    continue
+                visited.add(current)
+                component.append(current)
+                for neighbor in adjacency.get(current, set()):
+                    if neighbor not in visited:
+                        stack.append(neighbor)
+            if len(component) >= 2:
+                groups_idx.append(component)
+
+        if not groups_idx:
+            return []
+
+        groups: List[Dict[str, Any]] = []
+        for component in groups_idx:
+            per_idx_best: Dict[int, float] = {}
+            group_best = 0.0
+            for idx in component:
+                best = 0.0
+                for neighbor in component:
+                    if neighbor == idx:
+                        continue
+                    key = (min(idx, neighbor), max(idx, neighbor))
+                    score = edge_scores.get(key, 0.0)
+                    if score > best:
+                        best = score
+                    if score > group_best:
+                        group_best = score
+                per_idx_best[idx] = best
+            sorted_component = sorted(
+                component,
+                key=lambda i: (-per_idx_best.get(i, 0.0), int(candidates[i]["row"]["id"])),
+            )
+            rows = [candidates[i]["row"] for i in sorted_component]
+            extras: Dict[int, Dict[str, Any]] = {}
+            for i in sorted_component:
+                pid = int(candidates[i]["row"]["id"])
+                best_score = per_idx_best.get(i, 0.0)
+                if best_score > 0:
+                    extras[pid] = {"match_score": round(best_score, 4)}
+            items = _hydrate_card_rows(conn, rows, extras=extras)
+            group_id = min(int(candidates[i]["row"]["id"]) for i in sorted_component)
+            groups.append(
+                {
+                    "group_id": group_id,
+                    "size": len(sorted_component),
+                    "score": round(group_best, 4),
+                    "items": items,
+                }
+            )
+
+        groups.sort(key=lambda g: (g["score"], g["size"], -g["group_id"]), reverse=True)
+        return groups[:limit]
+
     @app.get("/api/cards/search")
     def api_cards_search():
         q = request.args.get("q", "").strip()
@@ -2076,6 +2252,23 @@ def create_app() -> Flask:
         with adb.db() as conn:
             items = _find_similar_cards(conn, pid, limit=limit, threshold=threshold)
         return jsonify(items)
+
+    @app.get("/api/cards/similar-groups")
+    def api_cards_similar_groups():
+        try:
+            limit = int(request.args.get("limit", "20"))
+        except (TypeError, ValueError):
+            limit = 20
+        limit = max(1, min(limit, 200))
+        threshold_param = request.args.get("threshold")
+        try:
+            threshold = float(threshold_param) if threshold_param else 0.7
+        except (TypeError, ValueError):
+            threshold = 0.7
+        threshold = max(0.0, min(threshold, 1.0))
+        with adb.db() as conn:
+            groups = _find_similar_groups(conn, limit=limit, threshold=threshold)
+        return jsonify(groups)
 
     @app.get("/api/merge/product/<int:pid>")
     def api_merge_product(pid: int):

--- a/admin_ui/templates/edit.html
+++ b/admin_ui/templates/edit.html
@@ -198,6 +198,15 @@
     .card-option .card-meta{font-size:13px;color:var(--muted)}
     .card-option .card-stocks{display:flex;flex-direction:column;gap:4px;font-size:12px;color:var(--muted)}
     .selector-empty{color:var(--muted);padding:24px;text-align:center;border:1px dashed rgba(255,255,255,0.08);border-radius:14px}
+    .similar-group{display:flex;flex-direction:column;gap:12px;background:rgba(13,18,36,0.68);border:1px solid rgba(255,255,255,0.08);border-radius:16px;padding:16px}
+    .similar-group-head{display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:10px}
+    .similar-group-title{margin:0;font-size:15px;font-weight:600}
+    .similar-group-meta{display:flex;align-items:center;gap:8px;flex-wrap:wrap;color:var(--muted);font-size:13px}
+    .similar-group-score{background:rgba(55,148,255,0.14);color:var(--accent);padding:4px 10px;border-radius:999px;font-size:12px;font-weight:500}
+    .similar-group-fill{border:none;background:rgba(55,148,255,0.18);color:var(--accent);padding:6px 12px;border-radius:10px;font-size:13px;font-weight:600;cursor:pointer;transition:background .2s ease,color .2s ease}
+    .similar-group-fill:hover{background:rgba(55,148,255,0.28)}
+    .similar-group-fill:disabled{opacity:.6;cursor:not-allowed}
+    .similar-group-list{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:10px}
     .history-wrapper{display:flex;flex-direction:column;gap:18px}
     .history-head h4{margin:0;font-size:20px}
     .history-head p{margin:4px 0 0;color:var(--muted)}
@@ -562,55 +571,135 @@
         updateBoard();
       }
 
-      function renderCards(items){
+      function createCardOption(item){
+        const card = document.createElement('article');
+        card.className = 'card-option';
+        card.dataset.id = item.id;
+        const title = document.createElement('h5');
+        title.textContent = item.local_name || item.name || `#${item.id}`;
+        const meta = document.createElement('div');
+        meta.className = 'card-meta';
+        const parts = [];
+        if(item.article) parts.push(item.article);
+        if(item.name && item.local_name) parts.push(item.name);
+        meta.textContent = parts.join(' • ');
+        card.append(title, meta);
+        if(typeof item.match_score === 'number'){
+          const match = document.createElement('div');
+          match.className = 'card-match';
+          const percent = Math.round(item.match_score * 100);
+          match.textContent = `Совпадение ${percent}%`;
+          card.append(match);
+        }
+        if(item.stocks && item.stocks.length){
+          const stocks = document.createElement('div');
+          stocks.className = 'card-stocks';
+          item.stocks.forEach(s => {
+            const span = document.createElement('span');
+            span.textContent = `${s.title}: ${s.qty}`;
+            stocks.append(span);
+          });
+          card.append(stocks);
+        }
+        const selected = Object.values(state.slots).some(s => s && s.id === item.id);
+        if(selected) card.classList.add('is-selected');
+        card.addEventListener('click', async () => {
+          const targetSlot = state.activeSlot || 'a';
+          await selectCard(targetSlot, item);
+          refreshGridSelection();
+        });
+        return card;
+      }
+
+      function renderSearchResults(items){
         gridEl.innerHTML = '';
         if(!items.length){
           const empty = document.createElement('div');
           empty.className = 'selector-empty';
-          empty.textContent = lastGridMode === 'similar'
-            ? 'Совпадения не найдены. Попробуйте выбрать другую карточку.'
-            : 'Не найдено карточек. Попробуйте другой запрос.';
+          empty.textContent = 'Не найдено карточек. Попробуйте другой запрос.';
           gridEl.append(empty);
           return;
         }
         items.forEach(item => {
-          const card = document.createElement('article');
-          card.className = 'card-option';
-          card.dataset.id = item.id;
-          const title = document.createElement('h5');
-          title.textContent = item.local_name || item.name || `#${item.id}`;
-          const meta = document.createElement('div');
-          meta.className = 'card-meta';
-          const parts = [];
-          if(item.article) parts.push(item.article);
-          if(item.name && item.local_name) parts.push(item.name);
-          meta.textContent = parts.join(' • ');
-          card.append(title, meta);
-          if(typeof item.match_score === 'number'){
-            const match = document.createElement('div');
-            match.className = 'card-match';
-            const percent = Math.round(item.match_score * 100);
-            match.textContent = `Совпадение ${percent}%`;
-            card.append(match);
-          }
-          if(item.stocks && item.stocks.length){
-            const stocks = document.createElement('div');
-            stocks.className = 'card-stocks';
-            item.stocks.forEach(s => {
-              const span = document.createElement('span');
-              span.textContent = `${s.title}: ${s.qty}`;
-              stocks.append(span);
-            });
-            card.append(stocks);
-          }
-          const selected = Object.values(state.slots).some(s => s && s.id === item.id);
-          if(selected) card.classList.add('is-selected');
-          card.addEventListener('click', async () => {
-            const targetSlot = state.activeSlot || 'a';
-            await selectCard(targetSlot, item);
-            refreshGridSelection();
-          });
+          const card = createCardOption(item);
           gridEl.append(card);
+        });
+      }
+
+      function renderSimilarGroups(groups){
+        gridEl.innerHTML = '';
+        if(!groups.length){
+          const empty = document.createElement('div');
+          empty.className = 'selector-empty';
+          empty.textContent = 'Похожие группы не найдены. Система не обнаружила кандидатов для объединения.';
+          gridEl.append(empty);
+          return;
+        }
+        groups.forEach((group, index) => {
+          const section = document.createElement('section');
+          section.className = 'similar-group';
+          const header = document.createElement('div');
+          header.className = 'similar-group-head';
+          const title = document.createElement('h5');
+          title.className = 'similar-group-title';
+          const ordinal = index + 1;
+          title.textContent = `Группа ${ordinal} · ${group.size} карточек`;
+          header.append(title);
+          const meta = document.createElement('div');
+          meta.className = 'similar-group-meta';
+          if(typeof group.score === 'number'){
+            const scoreSpan = document.createElement('span');
+            scoreSpan.className = 'similar-group-score';
+            const percent = Math.round(group.score * 100);
+            scoreSpan.textContent = `макс. совпадение ${percent}%`;
+            meta.append(scoreSpan);
+          }
+          if(typeof group.group_id === 'number'){
+            const idSpan = document.createElement('span');
+            idSpan.textContent = `ID: ${group.group_id}`;
+            meta.append(idSpan);
+          }
+          if(meta.children.length){
+            header.append(meta);
+          }
+          if(group.items && group.items.length >= 2){
+            const fillBtn = document.createElement('button');
+            fillBtn.type = 'button';
+            fillBtn.className = 'similar-group-fill';
+            fillBtn.textContent = 'Загрузить пару';
+            fillBtn.addEventListener('click', async () => {
+              if(fillBtn.disabled) return;
+              const [first, second] = group.items;
+              if(!first) return;
+              fillBtn.disabled = true;
+              try{
+                setActiveSlot('a');
+                await selectCard('a', first);
+                if(second){
+                  await selectCard('b', second);
+                  setActiveSlot('b');
+                } else {
+                  setActiveSlot('b');
+                }
+                refreshGridSelection();
+              } catch(err){
+                console.error(err);
+                window.alert('Не удалось загрузить группу.');
+              } finally {
+                fillBtn.disabled = false;
+              }
+            });
+            header.append(fillBtn);
+          }
+          section.append(header);
+          const list = document.createElement('div');
+          list.className = 'similar-group-list';
+          (group.items || []).forEach(item => {
+            const card = createCardOption(item);
+            list.append(card);
+          });
+          section.append(list);
+          gridEl.append(section);
         });
       }
 
@@ -623,14 +712,12 @@
       }
 
       let searchTimer = null;
-      let lastGridMode = 'search';
       async function searchCards(){
-        lastGridMode = 'search';
         const q = searchInput.value.trim();
         try{
           const res = await fetch(`/api/cards/search?q=${encodeURIComponent(q)}&limit=60`);
           const items = await res.json();
-          renderCards(items);
+          renderSearchResults(items);
         } catch(err){
           console.error(err);
         }
@@ -642,23 +729,16 @@
       });
 
       async function findSimilarCards(){
-        const active = state.activeSlot || 'a';
-        const selected = state.slots[active];
-        if(!selected){
-          window.alert('Сначала выберите карточку, чтобы найти совпадения.');
-          return;
-        }
         clearTimeout(searchTimer);
-        lastGridMode = 'similar';
         try{
           if(similarBtn) similarBtn.disabled = true;
-          const res = await fetch(`/api/cards/similar?product_id=${selected.id}&limit=60`);
+          const res = await fetch('/api/cards/similar-groups?limit=30');
           if(!res.ok){
             throw new Error('failed');
           }
-          const items = await res.json();
+          const groups = await res.json();
           searchInput.value = '';
-          renderCards(items);
+          renderSimilarGroups(groups);
         } catch(err){
           console.error(err);
           window.alert('Не удалось получить совпадения.');


### PR DESCRIPTION
## Summary
- add a server-side routine that scans the catalog for similar product names and expose it through `/api/cards/similar-groups`
- refresh the merge UI to show the discovered groups, allow quick loading of a pair, and stop requiring a preselected card

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d36d680430832cbadc7d754c09b9a4