### PR TITLE
Add controls for tuning similar card matches

### DIFF
--- a/admin_ui/server.py
+++ b/admin_ui/server.py
@@ -2022,6 +2022,7 @@ def create_app() -> Flask:
         *,
         limit: int = 20,
         threshold: float = 0.7,
+        use_exceptions: bool = True,
     ) -> List[Dict[str, Any]]:
         try:
             limit_val = int(limit)
@@ -2034,10 +2035,14 @@ def create_app() -> Flask:
             threshold_val = 0.7
         threshold = max(0.0, min(threshold_val, 1.0))
 
-        phrase_rows = conn.execute(
-            "SELECT phrase FROM display_name_exception ORDER BY lower(phrase)"
-        ).fetchall()
-        phrases = [row["phrase"] for row in phrase_rows if row["phrase"]]
+        phrases: Sequence[str]
+        if use_exceptions:
+            phrase_rows = conn.execute(
+                "SELECT phrase FROM display_name_exception ORDER BY lower(phrase)"
+            ).fetchall()
+            phrases = [row["phrase"] for row in phrase_rows if row["phrase"]]
+        else:
+            phrases = []
 
         product_rows = conn.execute(
             """
@@ -2266,8 +2271,23 @@ def create_app() -> Flask:
         except (TypeError, ValueError):
             threshold = 0.7
         threshold = max(0.0, min(threshold, 1.0))
+        disable_exceptions = False
+        for raw in (
+            request.args.get("no_exceptions"),
+            request.args.get("ignore_exceptions"),
+        ):
+            if not raw:
+                continue
+            if raw.strip().lower() in {"1", "true", "yes", "on"}:
+                disable_exceptions = True
+                break
         with adb.db() as conn:
-            groups = _find_similar_groups(conn, limit=limit, threshold=threshold)
+            groups = _find_similar_groups(
+                conn,
+                limit=limit,
+                threshold=threshold,
+                use_exceptions=not disable_exceptions,
+            )
         return jsonify(groups)
 
     @app.get("/api/merge/product/<int:pid>")

--- a/admin_ui/templates/edit.html
+++ b/admin_ui/templates/edit.html
@@ -121,6 +121,14 @@
           <div class="selector-controls">
             <input id="mergeSearch" type="search" placeholder="Название или артикул" autocomplete="off" spellcheck="false">
             <button type="button" id="mergeSimilar" class="selector-similar">Возможные совпадения</button>
+            <div class="selector-threshold">
+              <label for="similarThreshold">Порог совпадения</label>
+              <div class="threshold-control">
+                <input id="similarThreshold" type="range" min="50" max="100" value="70" step="1" aria-describedby="similarThresholdValue">
+                <span class="selector-threshold-value" id="similarThresholdValue">70%</span>
+              </div>
+            </div>
+            <button type="button" id="mergeExclusionsToggle" class="selector-toggle" aria-pressed="false">Исключения включены</button>
           </div>
         </div>
         <div class="selector-grid" id="mergeGrid" aria-live="polite"></div>
@@ -189,6 +197,14 @@
     .selector-similar{border:none;background:rgba(55,148,255,0.18);color:var(--accent);padding:10px 16px;border-radius:12px;font-size:14px;font-weight:600;cursor:pointer;transition:background .2s ease,color .2s ease}
     .selector-similar:hover{background:rgba(55,148,255,0.28)}
     .selector-similar:disabled{opacity:.6;cursor:not-allowed}
+    .selector-threshold{display:flex;flex-direction:column;gap:6px;padding:10px 14px;border-radius:12px;background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.05);color:var(--muted);min-width:220px;flex:0 1 260px}
+    .selector-threshold label{font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted)}
+    .threshold-control{display:flex;align-items:center;gap:10px}
+    .selector-threshold input[type=range]{width:160px;accent-color:var(--accent)}
+    .selector-threshold-value{font-size:14px;font-weight:600;color:var(--text)}
+    .selector-toggle{border:none;background:rgba(255,255,255,0.08);color:var(--text);padding:10px 16px;border-radius:12px;font-size:13px;font-weight:600;cursor:pointer;transition:background .2s ease,color .2s ease;flex:0 0 auto}
+    .selector-toggle:hover{background:rgba(255,255,255,0.15)}
+    .selector-toggle.is-disabled{background:rgba(244,63,94,0.28);color:#fff}
     .selector-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:12px}
     .card-option{position:relative;background:rgba(13,18,36,0.68);border:1px solid rgba(255,255,255,0.08);border-radius:16px;padding:14px;display:flex;flex-direction:column;gap:8px;cursor:pointer;transition:border-color .2s ease,transform .2s ease}
     .card-option:hover{transform:translateY(-2px);border-color:color-mix(in srgb,var(--brand-2) 40%,transparent)}
@@ -206,7 +222,10 @@
     .similar-group-fill{border:none;background:rgba(55,148,255,0.18);color:var(--accent);padding:6px 12px;border-radius:10px;font-size:13px;font-weight:600;cursor:pointer;transition:background .2s ease,color .2s ease}
     .similar-group-fill:hover{background:rgba(55,148,255,0.28)}
     .similar-group-fill:disabled{opacity:.6;cursor:not-allowed}
-    .similar-group-list{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:10px}
+    .similar-group-list{display:flex;flex-wrap:nowrap;gap:12px;overflow-x:auto;padding:4px 4px 8px;margin:0 -4px}
+    .similar-group-list::-webkit-scrollbar{height:8px}
+    .similar-group-list::-webkit-scrollbar-thumb{background:rgba(255,255,255,0.18);border-radius:999px}
+    .similar-group-list .card-option{min-width:220px;flex:0 0 auto}
     .history-wrapper{display:flex;flex-direction:column;gap:18px}
     .history-head h4{margin:0;font-size:20px}
     .history-head p{margin:4px 0 0;color:var(--muted)}
@@ -274,10 +293,14 @@
       const searchInput = document.getElementById('mergeSearch');
       const similarBtn = document.getElementById('mergeSimilar');
       const gridEl = document.getElementById('mergeGrid');
+      const thresholdInput = document.getElementById('similarThreshold');
+      const thresholdValueEl = document.getElementById('similarThresholdValue');
+      const exceptionsToggle = document.getElementById('mergeExclusionsToggle');
       const historyEl = document.getElementById('mergeHistory');
       const tabButtons = document.querySelectorAll('.edit-tab');
       const mergeView = document.getElementById('mergeView');
       const historyView = document.getElementById('historyView');
+      let disableExceptions = false;
 
       function hasValue(value){
         if(value === null || value === undefined) return false;
@@ -287,6 +310,22 @@
 
       function normalize(text){
         return (text || '').toString().trim().toLowerCase().replace(/\s+/g,' ');
+      }
+
+      function clampThresholdValue(value){
+        const numeric = Number(value);
+        if(Number.isFinite(numeric)){
+          return Math.min(100, Math.max(50, Math.round(numeric)));
+        }
+        return 70;
+      }
+
+      function getThresholdRatio(){
+        if(!thresholdInput){
+          return 0.7;
+        }
+        const sliderValue = clampThresholdValue(thresholdInput.value);
+        return sliderValue / 100;
       }
 
       function mergeValues(mode, aVal, bVal){
@@ -711,6 +750,37 @@
         });
       }
 
+      if(thresholdInput){
+        const updateThresholdDisplay = () => {
+          const sliderValue = clampThresholdValue(thresholdInput.value);
+          thresholdInput.value = sliderValue;
+          if(thresholdValueEl){
+            thresholdValueEl.textContent = `${sliderValue}%`;
+          }
+        };
+        thresholdInput.addEventListener('input', updateThresholdDisplay);
+        updateThresholdDisplay();
+      } else if(thresholdValueEl){
+        thresholdValueEl.textContent = '';
+      }
+
+      function applyExceptionsToggleState(){
+        if(!exceptionsToggle){
+          return;
+        }
+        exceptionsToggle.classList.toggle('is-disabled', disableExceptions);
+        exceptionsToggle.setAttribute('aria-pressed', disableExceptions ? 'true' : 'false');
+        exceptionsToggle.textContent = disableExceptions ? 'Исключения отключены' : 'Исключения включены';
+      }
+
+      if(exceptionsToggle){
+        applyExceptionsToggleState();
+        exceptionsToggle.addEventListener('click', () => {
+          disableExceptions = !disableExceptions;
+          applyExceptionsToggleState();
+        });
+      }
+
       let searchTimer = null;
       async function searchCards(){
         const q = searchInput.value.trim();
@@ -732,7 +802,15 @@
         clearTimeout(searchTimer);
         try{
           if(similarBtn) similarBtn.disabled = true;
-          const res = await fetch('/api/cards/similar-groups?limit=30');
+          const params = new URLSearchParams({ limit: '30' });
+          const thresholdRatio = getThresholdRatio();
+          if(Number.isFinite(thresholdRatio)){
+            params.set('threshold', thresholdRatio.toFixed(2));
+          }
+          if(disableExceptions){
+            params.set('no_exceptions', '1');
+          }
+          const res = await fetch(`/api/cards/similar-groups?${params.toString()}`);
           if(!res.ok){
             throw new Error('failed');
           }


### PR DESCRIPTION
## Summary
- add a similarity threshold slider and exception toggle to the edit page search controls
- allow the similar groups API to skip display name exceptions and accept the new threshold value
- render similar group match lists horizontally for easier scanning

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d3928996b4832cae5906ab8690e95f