### PR TITLE
Allow unlimited product cards

### DIFF
--- a/admin_ui/server.py
+++ b/admin_ui/server.py
@@ -1708,7 +1708,7 @@ def create_app() -> Flask:
     def _cards_search(
         conn,
         q: str,
-        limit: int = 60,
+        limit: Optional[int] = 60,
         *,
         without_local: bool = False,
         hide_empty: bool = False,
@@ -1716,11 +1716,20 @@ def create_app() -> Flask:
         location_codes: Optional[Sequence[str]] = None,
     ) -> List[Dict[str, Any]]:
         q = (q or "").strip()
-        try:
-            limit_val = int(limit)
-        except (TypeError, ValueError):
-            limit_val = 60
-        limit = max(limit_val, 1)
+        DEFAULT_LIMIT = 60
+        if limit is None:
+            limit_val: Optional[int] = None
+        else:
+            try:
+                parsed_limit = int(limit)
+            except (TypeError, ValueError):
+                parsed_limit = DEFAULT_LIMIT
+            if parsed_limit <= 0:
+                limit_val = None
+            else:
+                limit_val = max(parsed_limit, 1)
+
+        limit_clause = "LIMIT ?" if limit_val is not None else ""
 
         only_empty = bool(only_empty)
         hide_empty = bool(hide_empty) and not only_empty
@@ -1767,7 +1776,8 @@ def create_app() -> Flask:
         def execute_query(query: str, params: Sequence[Any]) -> List[Any]:
             query_params: List[Any] = list(agg_params)
             query_params.extend(params)
-            query_params.append(limit)
+            if limit_val is not None:
+                query_params.append(limit_val)
             return conn.execute(query, query_params).fetchall()
 
         rows: List[Any] = []
@@ -1794,7 +1804,7 @@ def create_app() -> Flask:
                         ORDER BY (COALESCE(t.total_filtered,0) > 0) DESC,
                                  (COALESCE(t.total_all,0) > 0) DESC,
                                  p.id DESC
-                        LIMIT ?
+                        {limit_clause}
                     """
                     rows = execute_query(query, params_list)
                 else:
@@ -1815,7 +1825,7 @@ def create_app() -> Flask:
                         ORDER BY (COALESCE(t.total_filtered,0) > 0) DESC,
                                  (COALESCE(t.total_all,0) > 0) DESC,
                                  p.id DESC
-                        LIMIT ?
+                        {limit_clause}
                     """
                     rows = execute_query(query, params_list)
             else:
@@ -1832,7 +1842,7 @@ def create_app() -> Flask:
                     ORDER BY (COALESCE(t.total_filtered,0) > 0) DESC,
                              (COALESCE(t.total_all,0) > 0) DESC,
                              p.id DESC
-                    LIMIT ?
+                    {limit_clause}
                 """
                 rows = execute_query(query, params_list)
         except Exception:
@@ -1857,7 +1867,7 @@ def create_app() -> Flask:
                 ORDER BY (COALESCE(t.total_filtered,0) > 0) DESC,
                          (COALESCE(t.total_all,0) > 0) DESC,
                          p.id DESC
-                LIMIT ?
+                {limit_clause}
             """
             rows = execute_query(query, params_list)
 
@@ -2201,11 +2211,19 @@ def create_app() -> Flask:
     @app.get("/api/cards/search")
     def api_cards_search():
         q = request.args.get("q", "").strip()
-        try:
-            limit = int(request.args.get("limit", "60"))
-        except (TypeError, ValueError):
+        raw_limit = request.args.get("limit")
+        limit: Optional[int]
+        if raw_limit is None:
             limit = 60
-        limit = max(min(limit, 500), 1)
+        else:
+            try:
+                parsed_limit = int(raw_limit)
+            except (TypeError, ValueError):
+                parsed_limit = 60
+            if parsed_limit <= 0:
+                limit = None
+            else:
+                limit = parsed_limit
 
         def _as_bool(value: Optional[str]) -> bool:
             if value is None:

--- a/admin_ui/templates/cards.html
+++ b/admin_ui/templates/cards.html
@@ -332,7 +332,7 @@
     let currentWriteOffStocks = [];
     const HUB_CODE = 'SKL-0';
     const WRITE_OFF_DST = 'HALL';
-    const SEARCH_LIMIT = 60;
+    const SEARCH_LIMIT = 0; // 0 — без ограничений на количество результатов
 
     function escapeHtml(s){
       return (s||'').replace(/[&<>"']/g, c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[c]));


### PR DESCRIPTION
## Summary
- allow `/api/cards/search` to treat non-positive limits as no limit and adjust SQL accordingly
- keep card search SQL flexible so queries omit `LIMIT` when unlimited results are requested
- set the admin UI search limit to 0 so all product cards are displayed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d4a6b61f70832c95a71c4639dbe7cd