### PR TITLE
Add label generator and manufacturer catalog support

### DIFF
--- a/admin_ui/server.py
+++ b/admin_ui/server.py
@@ -197,8 +197,20 @@ def _list_tables(conn) -> List[Tuple[str, str]]:
 def _product_detail(conn, pid: int) -> Optional[Dict[str, Any]]:
     row = conn.execute(
         """
-        SELECT id, article, name, brand_country, local_name, photo_file_id, photo_path, archived
-        FROM product WHERE id=?
+        SELECT p.id,
+               p.article,
+               p.name,
+               p.brand_country,
+               p.local_name,
+               p.photo_file_id,
+               p.photo_path,
+               p.archived,
+               p.manufacturer_id,
+               m.name AS manufacturer_name,
+               m.country AS manufacturer_country
+        FROM product p
+        LEFT JOIN manufacturer m ON m.id = p.manufacturer_id
+        WHERE p.id=?
         """,
         (pid,),
     ).fetchone()
@@ -229,6 +241,13 @@ def _product_detail(conn, pid: int) -> Optional[Dict[str, Any]]:
         """,
         (pid,),
     ).fetchall()
+    data["manufacturer"] = None
+    if row["manufacturer_id"]:
+        data["manufacturer"] = {
+            "id": int(row["manufacturer_id"]),
+            "name": row["manufacturer_name"],
+            "country": row["manufacturer_country"],
+        }
     data["stocks"] = [
         {
             "code": r["code"],
@@ -252,6 +271,7 @@ TABLE_LABELS: Dict[str, str] = {
     "schedule_transfer_request": "График: переносы",
     "schedule_anchor": "График: якорь",
     "registration_request": "Заявки на регистрацию",
+    "manufacturer": "Производители",
 }
 
 COLUMN_LABELS: Dict[str, Dict[str, str]] = {
@@ -268,6 +288,14 @@ COLUMN_LABELS: Dict[str, Dict[str, str]] = {
         "archived_at": "Дата архивации",
         "last_restock_at": "Последнее поступление",
         "created_at": "Создано",
+        "manufacturer_id": "Производитель (ID)",
+        "manufacturer_name": "Производитель",
+        "manufacturer_country": "Страна",
+    },
+    "manufacturer": {
+        "id": "ID",
+        "name": "Производитель",
+        "country": "Страна",
     },
     "location": {
         "code": "Код",
@@ -484,7 +512,7 @@ def create_app() -> Flask:
         7: "Июль", 8: "Август", 9: "Сентябрь", 10: "Октябрь", 11: "Ноябрь", 12: "Декабрь",
     }
 
-    PRIMARY_TABLES = {"product", "user_role"}
+    PRIMARY_TABLES = {"product", "manufacturer", "user_role"}
     HIDDEN_TABLES = {"stock"}
 
     SUPPLY_ALLOWED_EXTS = {".csv", ".xls", ".xlsx", ".xlsm", ".xltx", ".xltm"}
@@ -1258,6 +1286,49 @@ def create_app() -> Flask:
             ]
         return render_template("cards.html", locations=locs)
 
+    @app.route("/labels")
+    def labels_page():
+        return render_template("labels.html")
+
+    @app.get("/labels/print")
+    def labels_print():
+        raw_ids = (request.args.get("ids") or "").strip()
+        ids: List[int] = []
+        if raw_ids:
+            for chunk in raw_ids.split(","):
+                part = chunk.strip()
+                if not part:
+                    continue
+                try:
+                    pid = int(part)
+                except Exception:
+                    continue
+                ids.append(pid)
+        items: List[Dict[str, Any]] = []
+        if ids:
+            with adb.db() as conn:
+                for pid in ids:
+                    detail = _product_detail(conn, pid)
+                    if not detail:
+                        continue
+                    detail["id"] = pid
+                    items.append(detail)
+        today = dt.date.today()
+        first_day = today.replace(day=1)
+        prev_month_last = first_day - dt.timedelta(days=1)
+        manufacture_date = prev_month_last.strftime("%d.%m.%Y")
+        open_date = today.strftime("%d.%m.%Y")
+        storage_text = "в сухом, прохладном месте"
+        expiry_months = 12
+        return render_template(
+            "labels_print.html",
+            items=items,
+            manufacture_date=manufacture_date,
+            open_date=open_date,
+            storage_text=storage_text,
+            expiry_months=expiry_months,
+        )
+
     @app.route("/table/<table>")
     def table_browse(table: str):
         table = _safe_ident(table)
@@ -1279,21 +1350,46 @@ def create_app() -> Flask:
             display_cols = _visible_columns(table, cols)
             colnames = [c.name for c in cols]
             pkcols = _pk_cols(cols)
-            order_col = sort if sort in colnames else (pkcols[0].name if pkcols else colnames[0])
+            column_expr: Dict[str, str] = {c.name: c.name for c in cols}
+            extra_expr: Dict[str, str] = {}
+            table_sql = table
+            extra_display_cols: List[Column] = []
+            if table == "product":
+                table_sql = "product p LEFT JOIN manufacturer m ON m.id=p.manufacturer_id"
+                column_expr = {c.name: f"p.{c.name}" for c in cols}
+                extra_expr = {
+                    "manufacturer_name": "m.name",
+                    "manufacturer_country": "m.country",
+                }
+                extra_display_cols = [
+                    Column("manufacturer_name", "TEXT", False, 0, None),
+                    Column("manufacturer_country", "TEXT", False, 0, None),
+                ]
+                display_cols = list(display_cols) + extra_display_cols
+            all_expr = {**column_expr, **extra_expr}
+            sortable_names = colnames + [c.name for c in extra_display_cols]
+            order_col = sort if sort in sortable_names else (pkcols[0].name if pkcols else colnames[0])
             order_dir = "DESC" if direction.lower() == "desc" else "ASC"
 
             # Filtering
             params: List[Any] = []
             where = ""
             if q:
-                text_cols = [c.name for c in cols if (c.type or "").upper() in ("TEXT", "CHAR", "CLOB", "") or "CHAR" in (c.type or "").upper()]
+                text_cols = [
+                    c.name
+                    for c in cols
+                    if (c.type or "").upper() in ("TEXT", "CHAR", "CLOB", "")
+                    or "CHAR" in (c.type or "").upper()
+                ]
+                if table == "product":
+                    text_cols.extend(["manufacturer_name", "manufacturer_country"])
                 if text_cols:
-                    like = " OR ".join([f"{name} LIKE ?" for name in text_cols])
-                    where = f"WHERE ({like})"
+                    like_parts = [f"{all_expr.get(name, name)} LIKE ?" for name in text_cols]
+                    where = f"WHERE ({' OR '.join(like_parts)})"
                     params.extend([f"%{q}%" for _ in text_cols])
 
             # Count
-            count_sql = f"SELECT COUNT(*) FROM {table} {where}"
+            count_sql = f"SELECT COUNT(*) FROM {table_sql} {where}"
             total = conn.execute(count_sql, params).fetchone()[0]
 
             # Page
@@ -1302,8 +1398,14 @@ def create_app() -> Flask:
                 page = 1
                 offset = 0
                 per_page = max(total, 1)
-            select_cols = ", ".join(colnames)
-            sql = f"SELECT {select_cols} FROM {table} {where} ORDER BY {order_col} {order_dir} LIMIT ? OFFSET ?"
+            select_parts = [f"{all_expr[name]} AS {name}" for name in colnames]
+            if table == "product":
+                select_parts.extend([
+                    "m.name AS manufacturer_name",
+                    "m.country AS manufacturer_country",
+                ])
+            select_cols = ", ".join(select_parts)
+            sql = f"SELECT {select_cols} FROM {table_sql} {where} ORDER BY {all_expr.get(order_col, order_col)} {order_dir} LIMIT ? OFFSET ?"
             rows = conn.execute(sql, (*params, per_page, offset)).fetchall()
             pages = max(1, math.ceil(total / per_page))
             if table == "product":
@@ -1696,14 +1798,64 @@ def create_app() -> Flask:
                 "article": r["article"],
                 "name": r["name"],
                 "local_name": r["local_name"],
+                "brand_country": r["brand_country"] if "brand_country" in r.keys() else None,
+                "manufacturer_id": r["manufacturer_id"] if "manufacturer_id" in r.keys() else None,
+                "manufacturer_name": r["manufacturer_name"] if "manufacturer_name" in r.keys() else None,
+                "manufacturer_country": r["manufacturer_country"] if "manufacturer_country" in r.keys() else None,
                 "photo_url": purl,
                 "stocks": stocks_map.get(pid, []),
             }
+            if data.get("manufacturer_id"):
+                data["manufacturer"] = {
+                    "id": int(data["manufacturer_id"]),
+                    "name": data.get("manufacturer_name"),
+                    "country": data.get("manufacturer_country"),
+                }
+            else:
+                data["manufacturer"] = None
             extra = extras.get(pid)
-            if extra:
-                data.update(extra)
-            items.append(data)
-        return items
+        if extra:
+            data.update(extra)
+        items.append(data)
+    return items
+
+
+    @app.get("/api/manufacturers")
+    def api_manufacturers_list():
+        q = (request.args.get("q") or "").strip()
+        try:
+            limit = int(request.args.get("limit", "200"))
+        except (TypeError, ValueError):
+            limit = 200
+        limit = max(1, min(limit, 500))
+        like = f"%{q}%" if q else None
+        with adb.db() as conn:
+            if like:
+                rows = conn.execute(
+                    """
+                    SELECT id, name, country
+                    FROM manufacturer
+                    WHERE lower(name) LIKE lower(?) OR lower(country) LIKE lower(?)
+                    ORDER BY lower(name)
+                    LIMIT ?
+                    """,
+                    (like, like, limit),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    """
+                    SELECT id, name, country
+                    FROM manufacturer
+                    ORDER BY lower(name)
+                    LIMIT ?
+                    """,
+                    (limit,),
+                ).fetchall()
+        items = [
+            {"id": int(r["id"]), "name": r["name"], "country": r["country"]}
+            for r in rows
+        ]
+        return jsonify(items)
 
     def _cards_search(
         conn,
@@ -1749,10 +1901,14 @@ def create_app() -> Flask:
             SELECT s.product_id,
                    SUM(s.qty_pack) AS total_all,
                    {filtered_case} AS total_filtered
-            FROM stock s
+        FROM stock s
             GROUP BY s.product_id
         """
         EPS = 0.000001
+        card_select = (
+            "p.id, p.article, p.name, p.local_name, p.photo_path, p.brand_country, "
+            "p.manufacturer_id, m.name AS manufacturer_name, m.country AS manufacturer_country"
+        )
 
         def apply_common_filters(conditions: List[str], params: List[Any]) -> None:
             if without_local:
@@ -1786,10 +1942,11 @@ def create_app() -> Flask:
                     apply_common_filters(conditions, params_list)
                     where_sql = " AND ".join(conditions) if conditions else "1=1"
                     query = f"""
-                        SELECT p.id, p.article, p.name, p.local_name, p.photo_path
+                        SELECT {card_select}
                         FROM product_fts f
                         JOIN product p ON p.id=f.rowid
                         LEFT JOIN ({totals_subquery}) t ON t.product_id=p.id
+                        LEFT JOIN manufacturer m ON m.id=p.manufacturer_id
                         WHERE {where_sql}
                         ORDER BY (COALESCE(t.total_filtered,0) > 0) DESC,
                                  (COALESCE(t.total_all,0) > 0) DESC,
@@ -1807,10 +1964,11 @@ def create_app() -> Flask:
                     apply_common_filters(conditions, params_list)
                     where_sql = " AND ".join(conditions) if conditions else "1=1"
                     query = f"""
-                        SELECT p.id, p.article, p.name, p.local_name, p.photo_path,
+                        SELECT {card_select},
                                COALESCE(t.total_all,0) AS total
                         FROM product p
                         LEFT JOIN ({totals_subquery}) t ON t.product_id=p.id
+                        LEFT JOIN manufacturer m ON m.id=p.manufacturer_id
                         WHERE {where_sql}
                         ORDER BY (COALESCE(t.total_filtered,0) > 0) DESC,
                                  (COALESCE(t.total_all,0) > 0) DESC,
@@ -1824,10 +1982,11 @@ def create_app() -> Flask:
                 apply_common_filters(conditions, params_list)
                 where_sql = " AND ".join(conditions) if conditions else "1=1"
                 query = f"""
-                    SELECT p.id, p.article, p.name, p.local_name, p.photo_path,
+                    SELECT {card_select},
                            COALESCE(t.total_all,0) AS total
                     FROM product p
                     LEFT JOIN ({totals_subquery}) t ON t.product_id=p.id
+                    LEFT JOIN manufacturer m ON m.id=p.manufacturer_id
                     WHERE {where_sql}
                     ORDER BY (COALESCE(t.total_filtered,0) > 0) DESC,
                              (COALESCE(t.total_all,0) > 0) DESC,
@@ -1849,10 +2008,11 @@ def create_app() -> Flask:
             apply_common_filters(conditions, params_list)
             where_sql = " AND ".join(conditions) if conditions else "1=1"
             query = f"""
-                SELECT p.id, p.article, p.name, p.local_name, p.photo_path,
+                SELECT {card_select},
                        COALESCE(t.total_all,0) AS total
                 FROM product p
                 LEFT JOIN ({totals_subquery}) t ON t.product_id=p.id
+                LEFT JOIN manufacturer m ON m.id=p.manufacturer_id
                 WHERE {where_sql}
                 ORDER BY (COALESCE(t.total_filtered,0) > 0) DESC,
                          (COALESCE(t.total_all,0) > 0) DESC,
@@ -1880,6 +2040,10 @@ def create_app() -> Flask:
         except (TypeError, ValueError):
             threshold_val = 0.7
         threshold = max(0.0, min(threshold_val, 1.0))
+        card_select = (
+            "p.id, p.article, p.name, p.local_name, p.photo_path, p.brand_country, "
+            "p.manufacturer_id, m.name AS manufacturer_name, m.country AS manufacturer_country"
+        )
 
         base_row = conn.execute(
             "SELECT id, article, name, local_name FROM product WHERE id=?", (product_id,)
@@ -1949,8 +2113,9 @@ def create_app() -> Flask:
             ])
             rows = conn.execute(
                 f"""
-                SELECT p.id, p.article, p.name, p.local_name, p.photo_path
+                SELECT {card_select}
                 FROM product p
+                LEFT JOIN manufacturer m ON m.id=p.manufacturer_id
                 WHERE {where_sql}
                 LIMIT ?
                 """,
@@ -1961,8 +2126,12 @@ def create_app() -> Flask:
         else:
             rows = conn.execute(
                 """
-                SELECT p.id, p.article, p.name, p.local_name, p.photo_path
+                SELECT p.id, p.article, p.name, p.local_name, p.photo_path,
+                       p.brand_country, p.manufacturer_id,
+                       m.name AS manufacturer_name,
+                       m.country AS manufacturer_country
                 FROM product p
+                LEFT JOIN manufacturer m ON m.id=p.manufacturer_id
                 WHERE p.archived=0 AND p.id<>?
                 ORDER BY p.id DESC
                 LIMIT ?
@@ -1977,9 +2146,13 @@ def create_app() -> Flask:
                 like = f"%{token}%"
                 alias_rows = conn.execute(
                     """
-                    SELECT p.id, p.article, p.name, p.local_name, p.photo_path
+                    SELECT p.id, p.article, p.name, p.local_name, p.photo_path,
+                           p.brand_country, p.manufacturer_id,
+                           m.name AS manufacturer_name,
+                           m.country AS manufacturer_country
                     FROM product_name_alias a
                     JOIN product p ON p.id=a.product_id
+                    LEFT JOIN manufacturer m ON m.id=p.manufacturer_id
                     WHERE p.archived=0 AND p.id<>?
                       AND REPLACE(a.normalized_name,'ё','е') LIKE ?
                     LIMIT ?
@@ -2046,9 +2219,18 @@ def create_app() -> Flask:
 
         product_rows = conn.execute(
             """
-            SELECT id, article, name, local_name, photo_path
-            FROM product
-            WHERE archived=0
+            SELECT p.id,
+                   p.article,
+                   p.name,
+                   p.local_name,
+                   p.photo_path,
+                   p.brand_country,
+                   p.manufacturer_id,
+                   m.name AS manufacturer_name,
+                   m.country AS manufacturer_country
+            FROM product p
+            LEFT JOIN manufacturer m ON m.id=p.manufacturer_id
+            WHERE p.archived=0
             """
         ).fetchall()
         if not product_rows:
@@ -2431,6 +2613,52 @@ def create_app() -> Flask:
             with conn:
                 conn.execute("UPDATE product SET local_name=? WHERE id=?", (name or None, pid))
         return jsonify({"ok": True, "local_name": name})
+
+    @app.post("/api/product/set_manufacturer")
+    def api_product_set_manufacturer():
+        payload = request.form if request.form else request.json or {}
+        try:
+            pid = int(payload.get("product_id"))
+        except Exception:
+            abort(400)
+        if not pid:
+            abort(400)
+        raw_mid = payload.get("manufacturer_id")
+        manufacturer_id: Optional[int]
+        if raw_mid is None or str(raw_mid).strip() == "" or str(raw_mid).lower() in {"null", "none"}:
+            manufacturer_id = None
+        else:
+            try:
+                manufacturer_id = int(raw_mid)
+            except Exception:
+                abort(400)
+        with adb.db() as conn:
+            with conn:
+                if manufacturer_id is None:
+                    conn.execute(
+                        "UPDATE product SET manufacturer_id=NULL, brand_country=NULL WHERE id=?",
+                        (pid,),
+                    )
+                    manufacturer = None
+                    brand = None
+                else:
+                    row = conn.execute(
+                        "SELECT id, name, country FROM manufacturer WHERE id=?",
+                        (manufacturer_id,),
+                    ).fetchone()
+                    if not row:
+                        abort(400)
+                    brand = f"{row['name']} ({row['country']})"
+                    conn.execute(
+                        "UPDATE product SET manufacturer_id=?, brand_country=? WHERE id=?",
+                        (manufacturer_id, brand, pid),
+                    )
+                    manufacturer = {
+                        "id": int(row["id"]),
+                        "name": row["name"],
+                        "country": row["country"],
+                    }
+        return jsonify({"ok": True, "manufacturer": manufacturer, "brand_country": brand})
 
     @app.post("/api/product/upload_photo")
     def api_product_upload_photo():

--- a/admin_ui/templates/base.html
+++ b/admin_ui/templates/base.html
@@ -45,6 +45,7 @@
           <a class="list-group-item list-group-item-action {% if request.path == url_for('supply_page') %}active{% endif %}" href="{{ url_for('supply_page') }}" {% if request.path == url_for('supply_page') %}aria-current="page"{% endif %}>Поставка</a>
           <a class="list-group-item list-group-item-action {% if request.path == url_for('cards_page') %}active{% endif %}" href="{{ url_for('cards_page') }}" {% if request.path == url_for('cards_page') %}aria-current="page"{% endif %}>Карточки товаров</a>
           <a class="list-group-item list-group-item-action {% if request.path == url_for('edit_page') %}active{% endif %}" href="{{ url_for('edit_page') }}" {% if request.path == url_for('edit_page') %}aria-current="page"{% endif %}>Редактировать</a>
+          <a class="list-group-item list-group-item-action {% if request.path == url_for('labels_page') %}active{% endif %}" href="{{ url_for('labels_page') }}" {% if request.path == url_for('labels_page') %}aria-current="page"{% endif %}>Генератор маркировок</a>
         </div>
         <div class="mb-2 text-muted">Основные таблицы</div>
         <div class="list-group list-group-flush mb-3">
@@ -72,6 +73,7 @@
             {% endfor %}
             <a class="list-group-item list-group-item-action {% if request.path == url_for('cards_page') %}active{% endif %}" href="{{ url_for('cards_page') }}" {% if request.path == url_for('cards_page') %}aria-current="page"{% endif %}>Карточки товаров</a>
             <a class="list-group-item list-group-item-action {% if request.path == url_for('edit_page') %}active{% endif %}" href="{{ url_for('edit_page') }}" {% if request.path == url_for('edit_page') %}aria-current="page"{% endif %}>Редактировать</a>
+            <a class="list-group-item list-group-item-action {% if request.path == url_for('labels_page') %}active{% endif %}" href="{{ url_for('labels_page') }}" {% if request.path == url_for('labels_page') %}aria-current="page"{% endif %}>Генератор маркировок</a>
             <div class="list-group-item {% if tech_section_active %}active{% endif %}">
               <a class="d-flex justify-content-between align-items-center text-decoration-none" data-bs-toggle="collapse" href="#techTables" role="button" aria-expanded="{{ 'true' if tech_section_active else 'false' }}" aria-controls="techTables">
                 <span>Технические таблицы</span>

--- a/admin_ui/templates/cards.html
+++ b/admin_ui/templates/cards.html
@@ -67,6 +67,13 @@
     .field-block label{display:flex;justify-content:space-between;align-items:center;font-size:13px;color:var(--muted);letter-spacing:.02em;gap:12px}
     .local-field{display:flex;align-items:center;gap:10px;background:rgba(11,17,36,0.88);border:1px solid rgba(255,255,255,0.07);border-radius:14px;padding:10px 14px;min-width:0}
     .local-field input{flex:1 1 auto;background:transparent;border:none;color:var(--text);font-size:16px;outline:none;min-height:38px;min-width:0}
+    .manufacturer-block .manufacturer-control{display:flex;flex-direction:column;gap:8px}
+    .manufacturer-control select{width:100%;border-radius:12px;border:1px solid rgba(255,255,255,0.07);background:rgba(11,17,36,0.9);color:var(--text);padding:10px 12px;font-size:14px}
+    .manufacturer-control select:focus{outline:none;border-color:color-mix(in srgb,var(--brand-2) 35%,transparent);box-shadow:0 0 0 2px color-mix(in srgb,var(--brand-2) 12%,transparent)}
+    .manufacturer-control select:disabled{opacity:0.6;cursor:not-allowed}
+    .manufacturer-meta{display:flex;flex-direction:column;gap:4px;font-size:13px;color:var(--muted)}
+    .manufacturer-line span{opacity:0.7;margin-right:6px}
+    .manufacturer-empty{font-style:italic;color:var(--muted)}
     .field-status{font-size:13px;color:var(--muted);white-space:nowrap;letter-spacing:.02em;min-width:84px;text-align:right}
     .field-status[data-state="dirty"]{color:var(--warn)}
     .field-status[data-state="saving"]{color:var(--brand-2)}
@@ -333,6 +340,10 @@
     const HUB_CODE = 'SKL-0';
     const WRITE_OFF_DST = 'HALL';
     const SEARCH_LIMIT = 60;
+    let manufacturerList = [];
+    let manufacturerMap = new Map();
+    let manufacturerLoaded = false;
+    let manufacturerLoading = null;
 
     function escapeHtml(s){
       return (s||'').replace(/[&<>"']/g, c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[c]));
@@ -379,6 +390,111 @@
         return mapTitle;
       }
       return safeCode || 'локацию';
+    }
+
+    async function loadManufacturers(){
+      if(manufacturerLoaded){
+        return manufacturerList;
+      }
+      if(manufacturerLoading){
+        return manufacturerLoading;
+      }
+      manufacturerLoading = fetch('/api/manufacturers')
+        .then(res => {
+          if(!res.ok){ throw new Error('failed'); }
+          return res.json();
+        })
+        .then(items => {
+          manufacturerList = Array.isArray(items) ? items : [];
+          manufacturerMap = new Map(manufacturerList.map(item => [String(item.id), item]));
+          manufacturerLoaded = true;
+          return manufacturerList;
+        })
+        .catch(err => {
+          console.error('Не удалось загрузить производителей', err);
+          manufacturerLoaded = false;
+          manufacturerLoading = null;
+          manufacturerList = [];
+          manufacturerMap = new Map();
+          throw err;
+        });
+      return manufacturerLoading;
+    }
+
+    function manufacturerMetaHtml(data, brand){
+      if(data && data.name){
+        const parts = [`<div class="manufacturer-line"><span>Производитель:</span> ${escapeHtml(data.name)}</div>`];
+        if(data.country){
+          parts.push(`<div class="manufacturer-line"><span>Страна:</span> ${escapeHtml(data.country)}</div>`);
+        }
+        return parts.join('');
+      }
+      if(brand){
+        return `<div class="manufacturer-line">${escapeHtml(brand)}</div>`;
+      }
+      return '<div class="manufacturer-empty">Не указан</div>';
+    }
+
+    function populateManufacturerSelect(select, selectedId){
+      if(!select){ return; }
+      const current = selectedId != null && selectedId !== undefined ? String(selectedId) : '';
+      const opts = ['<option value="">Не указан</option>'];
+      manufacturerList.forEach(item => {
+        opts.push(`<option value="${item.id}">${escapeHtml(item.name)} (${escapeHtml(item.country)})</option>`);
+      });
+      select.innerHTML = opts.join('');
+      select.value = current;
+      select.dataset.current = current;
+    }
+
+    function updateManufacturerDisplay(pid, manufacturer, brand){
+      const meta = document.getElementById(`manufacturerMeta-${pid}`);
+      if(meta){
+        meta.innerHTML = manufacturerMetaHtml(manufacturer, brand);
+      }
+    }
+
+    function applyManufacturerWidgets(items){
+      if(!grid){ return; }
+      const list = Array.isArray(items) ? items : [];
+      const map = new Map(list.map(item => [String(item.id), item]));
+      grid.querySelectorAll('.js-manufacturer-select').forEach(select => {
+        const pid = parseInt(select.dataset.pid || '0', 10);
+        const data = map.get(String(pid));
+        const selected = data && data.manufacturer ? data.manufacturer.id : data ? data.manufacturer_id : null;
+        populateManufacturerSelect(select, selected);
+        updateManufacturerDisplay(pid, data ? data.manufacturer : null, data ? data.brand_country : '');
+        if(editModeToggle && !editModeToggle.checked){
+          select.disabled = true;
+        }
+      });
+    }
+
+    async function submitManufacturerChange(select, pid, value){
+      const previous = select.dataset.current || '';
+      const fd = new FormData();
+      fd.append('product_id', String(pid));
+      fd.append('manufacturer_id', value || '');
+      try{
+        const res = await fetch('/api/product/set_manufacturer', { method: 'POST', body: fd });
+        let js = {};
+        try { js = await res.json(); } catch(err){ js = {}; }
+        if(!res.ok || !js.ok){
+          throw new Error(js.error || 'failed');
+        }
+        select.dataset.current = value || '';
+        if(js.manufacturer && js.manufacturer.id && !manufacturerMap.has(String(js.manufacturer.id))){
+          manufacturerList.push(js.manufacturer);
+          manufacturerMap.set(String(js.manufacturer.id), js.manufacturer);
+          manufacturerList.sort((a,b)=>String(a.name || '').localeCompare(String(b.name || ''), 'ru'));
+          populateManufacturerSelect(select, js.manufacturer.id);
+        }
+        updateManufacturerDisplay(pid, js.manufacturer || null, js.brand_country || '');
+      } catch(err){
+        console.error(err);
+        window.alert('Не удалось сохранить производителя.');
+        select.value = previous;
+      }
     }
 
     function collectCardStocks(pid){
@@ -602,6 +718,10 @@
       const stockContent = stocks || '<div class="stock-empty">Нет наличия</div>';
       const placeholder = '<div class="media-placeholder">Без фото</div>';
       const image = it.photo_url ? `<img src="${escapeHtml(it.photo_url)}" alt="${display}">` : placeholder;
+      const manufacturerData = it.manufacturer || null;
+      const manufacturerId = manufacturerData ? manufacturerData.id : (it.manufacturer_id || null);
+      const manufacturerSelected = manufacturerId != null && manufacturerId !== undefined ? String(manufacturerId) : '';
+      const manufacturerMeta = manufacturerMetaHtml(manufacturerData, it.brand_country || '');
       return `
         <article class="product-card" id="card-${it.id}" data-pid="${it.id}">
           <div class="card-media">
@@ -619,6 +739,15 @@
               <label for="local-${it.id}">Локальное имя <span class="field-status" data-state="idle"></span></label>
               <div class="local-field">
                 <input id="local-${it.id}" class="js-local-input" type="text" value="${escapeHtml(rawLocal)}" data-pid="${it.id}" data-original="${escapeHtml(rawLocal.trim())}" data-fallback="${baseSafe}" autocomplete="off" spellcheck="false">
+              </div>
+            </div>
+            <div class="field-block manufacturer-block">
+              <label for="manufacturer-${it.id}">Производитель</label>
+              <div class="manufacturer-control">
+                <select id="manufacturer-${it.id}" class="js-manufacturer-select" data-pid="${it.id}" data-selected="${escapeHtml(manufacturerSelected)}" data-current="${escapeHtml(manufacturerSelected)}"></select>
+                <div class="manufacturer-meta" id="manufacturerMeta-${it.id}">
+                  ${manufacturerMeta}
+                </div>
               </div>
             </div>
             <div class="stocks-block" id="stocks-${it.id}">
@@ -658,7 +787,7 @@
       return await r.json();
     }
 
-    function render(items){
+    async function render(items){
       if(!items.length){
         grid.innerHTML = '<div class="cards-empty">Ничего не нашли. Попробуйте скорректировать запрос.</div>';
       } else {
@@ -667,6 +796,12 @@
       if(editModeToggle){
         setEditMode(editModeToggle.checked);
       }
+      try {
+        await loadManufacturers();
+      } catch(err) {
+        // keep silent; selects will stay with fallback option
+      }
+      applyManufacturerWidgets(items);
     }
 
     function clearSuggestions(){
@@ -685,6 +820,9 @@
       });
       grid.querySelectorAll('button[data-act="adj"]').forEach(btn => {
         btn.disabled = !active;
+      });
+      grid.querySelectorAll('.js-manufacturer-select').forEach(sel => {
+        sel.disabled = !active;
       });
     }
 
@@ -706,7 +844,7 @@
         fetchItems(params),
         q ? fetch(`/api/products/search?q=${encodeURIComponent(q)}&limit=15`).then(r=>r.json()) : []
       ]);
-      render(items);
+      await render(items);
       clearSuggestions();
       (sugg || []).forEach(item => {
         const btn = document.createElement('button');
@@ -745,6 +883,19 @@
         clearSuggestions();
       }
     });
+
+    if(grid){
+      grid.addEventListener('change', function(ev){
+        const select = ev.target.closest('.js-manufacturer-select');
+        if(!select){ return; }
+        if(select.disabled){ return; }
+        const pid = parseInt(select.dataset.pid || '0', 10);
+        if(!pid){
+          return;
+        }
+        submitManufacturerChange(select, pid, select.value);
+      });
+    }
 
     if(filterNoLocal){
       filterNoLocal.addEventListener('change', function(){

--- a/admin_ui/templates/labels.html
+++ b/admin_ui/templates/labels.html
@@ -1,0 +1,458 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="labels-shell">
+  <div class="labels-head">
+    <div>
+      <h3>Генератор маркировок</h3>
+      <p>Выберите до 18 карточек товаров, чтобы сформировать лист маркировок для печати. На экране размещается сетка 6×3, а итоговый макет разворачивается в формат 3×6 для экономии вертикального пространства.</p>
+    </div>
+    <div class="labels-actions">
+      <div class="labels-counter" aria-live="polite">Выбрано: <span id="labelsCount">0</span>/18</div>
+      <button type="button" id="labelsPrint" class="labels-print" disabled>Открыть макет для печати</button>
+    </div>
+  </div>
+  <div class="labels-body">
+    <div class="labels-search">
+      <label for="labelsSearch">Поиск по карточкам</label>
+      <input type="search" id="labelsSearch" placeholder="Название или локальное имя" autocomplete="off" spellcheck="false">
+      <div class="labels-hint">Нажмите на слот или выберите карту, чтобы заполнить сетку. Локальные имена и производители сохраняются автоматически.</div>
+      <div class="labels-suggest" id="labelsSuggest" role="listbox"></div>
+    </div>
+    <div class="labels-grid" id="labelsGrid">
+      {% for idx in range(18) %}
+      <div class="label-slot" data-slot="{{ idx }}" tabindex="0">
+        <div class="slot-placeholder">Слот {{ idx + 1 }} · нажмите, чтобы выбрать карточку</div>
+        <div class="slot-card" hidden>
+          <div class="slot-card-head">
+            <div>
+              <div class="slot-title" id="slotTitle-{{ idx }}"></div>
+              <div class="slot-article" id="slotArticle-{{ idx }}"></div>
+            </div>
+            <button type="button" class="slot-remove" data-act="remove" aria-label="Убрать карточку">×</button>
+          </div>
+          <div class="slot-card-body">
+            <div class="slot-field">
+              <label for="slotLocal-{{ idx }}">Локальное имя <span class="field-status" data-state="idle"></span></label>
+              <input type="text" id="slotLocal-{{ idx }}" class="slot-local" data-slot="{{ idx }}" autocomplete="off" spellcheck="false">
+            </div>
+            <div class="slot-field manufacturer-block">
+              <label for="slotManufacturer-{{ idx }}">Производитель</label>
+              <div class="manufacturer-control">
+                <select id="slotManufacturer-{{ idx }}" class="slot-manufacturer" data-slot="{{ idx }}"></select>
+                <div class="manufacturer-meta" id="slotManufacturerMeta-{{ idx }}"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+</div>
+
+<style>
+  .labels-shell{display:flex;flex-direction:column;gap:20px}
+  .labels-head{display:flex;flex-wrap:wrap;justify-content:space-between;gap:16px;align-items:flex-start}
+  .labels-head h3{margin:0;font-size:clamp(1.8rem,3vw,2.4rem)}
+  .labels-head p{margin:4px 0 0;color:var(--muted);max-width:620px}
+  .labels-actions{display:flex;align-items:center;gap:12px}
+  .labels-counter{font-size:14px;color:var(--muted)}
+  .labels-print{border-radius:12px;border:1px solid rgba(255,255,255,0.18);background:rgba(34,211,238,0.2);color:var(--text);padding:10px 18px;font-weight:600;cursor:pointer;transition:opacity .2s ease,transform .2s ease}
+  .labels-print:disabled{opacity:.4;cursor:not-allowed}
+  .labels-print:not(:disabled):hover{transform:translateY(-1px)}
+  .labels-body{display:flex;flex-direction:column;gap:18px}
+  .labels-search{display:flex;flex-direction:column;gap:8px}
+  .labels-search label{font-size:13px;letter-spacing:.08em;text-transform:uppercase;color:var(--muted)}
+  .labels-search input{border-radius:14px;border:1px solid rgba(255,255,255,0.08);background:rgba(13,18,36,0.8);color:var(--text);padding:12px 16px;font-size:16px}
+  .labels-hint{font-size:13px;color:var(--muted)}
+  .labels-suggest{position:relative;border-radius:14px;border:1px solid rgba(255,255,255,0.08);background:rgba(13,18,36,0.78);display:none;flex-direction:column;max-height:260px;overflow:auto}
+  .labels-suggest.is-open{display:flex}
+  .labels-suggest button{border:none;background:transparent;color:var(--text);padding:10px 14px;text-align:left;display:flex;flex-direction:column;gap:4px;cursor:pointer}
+  .labels-suggest button span{font-size:12px;color:var(--muted)}
+  .labels-suggest button:hover,.labels-suggest button:focus{background:color-mix(in srgb,var(--brand-2) 18%,transparent);outline:none}
+  .labels-grid{display:grid;grid-template-columns:repeat(6,minmax(0,1fr));gap:12px}
+  .label-slot{position:relative;border:1px dashed rgba(255,255,255,0.14);border-radius:16px;min-height:220px;padding:14px;background:rgba(13,18,36,0.6);display:flex;flex-direction:column;gap:12px;cursor:pointer;transition:border-color .2s ease,box-shadow .2s ease}
+  .label-slot.is-active{border-color:color-mix(in srgb,var(--brand-2) 45%,transparent);box-shadow:0 12px 28px rgba(0,0,0,0.35)}
+  .label-slot:focus{outline:none;border-color:color-mix(in srgb,var(--brand-2) 40%,transparent)}
+  .slot-placeholder{margin:auto 0;color:var(--muted);text-align:center;line-height:1.5}
+  .slot-card{display:flex;flex-direction:column;gap:12px;cursor:default}
+  .slot-card-head{display:flex;justify-content:space-between;gap:10px;align-items:flex-start}
+  .slot-title{font-weight:600;font-size:15px;line-height:1.4}
+  .slot-article{font-size:12px;color:var(--muted)}
+  .slot-remove{border:none;border-radius:999px;background:rgba(255,255,255,0.12);color:var(--text);width:28px;height:28px;line-height:1;font-size:18px;cursor:pointer}
+  .slot-remove:hover{background:rgba(255,99,132,0.35)}
+  .slot-card-body{display:flex;flex-direction:column;gap:12px}
+  .slot-field{display:flex;flex-direction:column;gap:6px}
+  .slot-field label{font-size:13px;color:var(--muted);display:flex;justify-content:space-between;align-items:center}
+  .slot-local{border-radius:12px;border:1px solid rgba(255,255,255,0.08);background:rgba(11,17,36,0.88);color:var(--text);padding:10px 12px;font-size:15px}
+  .slot-local:focus{outline:none;border-color:color-mix(in srgb,var(--brand-2) 40%,transparent);box-shadow:0 0 0 2px color-mix(in srgb,var(--brand-2) 16%,transparent)}
+  .field-status{font-size:12px;color:var(--muted);min-width:60px;text-align:right}
+  .field-status[data-state="saving"]{color:var(--brand-2)}
+  .field-status[data-state="saved"]{color:var(--ok)}
+  .field-status[data-state="error"]{color:var(--bad)}
+  @media(max-width:1100px){
+    .labels-grid{grid-template-columns:repeat(3,minmax(0,1fr))}
+  }
+  @media(max-width:720px){
+    .labels-grid{grid-template-columns:repeat(2,minmax(0,1fr))}
+    .label-slot{min-height:0}
+  }
+  @media(max-width:520px){
+    .labels-grid{grid-template-columns:repeat(1,minmax(0,1fr))}
+  }
+</style>
+
+<script>
+(function(){
+  const TOTAL_SLOTS = 18;
+  const grid = document.getElementById('labelsGrid');
+  const slots = Array.from(grid.querySelectorAll('.label-slot'));
+  const searchInput = document.getElementById('labelsSearch');
+  const suggestBox = document.getElementById('labelsSuggest');
+  const printBtn = document.getElementById('labelsPrint');
+  const counterEl = document.getElementById('labelsCount');
+  let activeSlot = 0;
+  const state = {
+    slots: new Array(TOTAL_SLOTS).fill(null),
+    debounce: new Map(),
+    pending: new Map(),
+    searchTimer: null,
+  };
+
+  function escapeHtml(s){
+    return (s || '').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[c]));
+  }
+
+  let manufacturerList = [];
+  let manufacturerMap = new Map();
+  let manufacturerLoaded = false;
+  let manufacturerLoading = null;
+
+  async function loadManufacturers(){
+    if(manufacturerLoaded){ return manufacturerList; }
+    if(manufacturerLoading){ return manufacturerLoading; }
+    manufacturerLoading = fetch('/api/manufacturers')
+      .then(res => { if(!res.ok){ throw new Error('failed'); } return res.json(); })
+      .then(items => {
+        manufacturerList = Array.isArray(items) ? items : [];
+        manufacturerMap = new Map(manufacturerList.map(item => [String(item.id), item]));
+        manufacturerLoaded = true;
+        return manufacturerList;
+      })
+      .catch(err => {
+        console.error('Не удалось загрузить производителей', err);
+        manufacturerLoaded = false;
+        manufacturerLoading = null;
+        manufacturerList = [];
+        manufacturerMap = new Map();
+        throw err;
+      });
+    return manufacturerLoading;
+  }
+
+  function manufacturerMetaHtml(data, brand){
+    if(data && data.name){
+      const lines = [`<div class="manufacturer-line"><span>Производитель:</span> ${escapeHtml(data.name)}</div>`];
+      if(data.country){
+        lines.push(`<div class="manufacturer-line"><span>Страна:</span> ${escapeHtml(data.country)}</div>`);
+      }
+      return lines.join('');
+    }
+    if(brand){
+      return `<div class="manufacturer-line">${escapeHtml(brand)}</div>`;
+    }
+    return '<div class="manufacturer-empty">Не указан</div>';
+  }
+
+  function updateSlotManufacturerDisplay(index, manufacturer, brand){
+    const meta = document.getElementById(`slotManufacturerMeta-${index}`);
+    if(meta){
+      meta.innerHTML = manufacturerMetaHtml(manufacturer, brand);
+    }
+  }
+
+  function populateManufacturerSelect(select, selectedId){
+    if(!select){ return; }
+    const current = selectedId != null && selectedId !== undefined ? String(selectedId) : '';
+    const opts = ['<option value="">Не указан</option>'];
+    manufacturerList.forEach(item => {
+      opts.push(`<option value="${item.id}">${escapeHtml(item.name)} (${escapeHtml(item.country)})</option>`);
+    });
+    select.innerHTML = opts.join('');
+    select.value = current;
+    select.dataset.current = current;
+  }
+
+  async function submitManufacturerChange(select, pid, value){
+    const previous = select.dataset.current || '';
+    const fd = new FormData();
+    fd.append('product_id', String(pid));
+    fd.append('manufacturer_id', value || '');
+    try {
+      const res = await fetch('/api/product/set_manufacturer', { method: 'POST', body: fd });
+      let js = {};
+      try { js = await res.json(); } catch(err){ js = {}; }
+      if(!res.ok || !js.ok){
+        throw new Error(js.error || 'failed');
+      }
+      const newManufacturer = js.manufacturer || null;
+      const brand = js.brand_country || '';
+      select.dataset.current = value || '';
+      if(newManufacturer && newManufacturer.id){
+        manufacturerMap.set(String(newManufacturer.id), newManufacturer);
+        if(!manufacturerList.some(item => item.id === newManufacturer.id)){
+          manufacturerList.push(newManufacturer);
+          manufacturerList.sort((a,b) => String(a.name || '').localeCompare(String(b.name || ''), 'ru'));
+        }
+        populateManufacturerSelect(select, newManufacturer.id);
+      }
+      state.slots.forEach(card => {
+        if(card && card.id === pid){
+          card.manufacturer = newManufacturer;
+          card.manufacturer_id = newManufacturer ? newManufacturer.id : null;
+          card.brand_country = brand;
+        }
+      });
+      const slotIndex = parseInt(select.dataset.slot || '-1', 10);
+      if(!Number.isNaN(slotIndex) && slotIndex >= 0){
+        updateSlotManufacturerDisplay(slotIndex, newManufacturer, brand);
+      } else {
+        state.slots.forEach((card, idx) => {
+          if(card && card.id === pid){
+            updateSlotManufacturerDisplay(idx, newManufacturer, brand);
+          }
+        });
+      }
+    } catch(err){
+      console.error(err);
+      window.alert('Не удалось сохранить производителя.');
+      select.value = previous;
+    }
+  }
+
+  function setActiveSlot(index){
+    activeSlot = Math.max(0, Math.min(TOTAL_SLOTS - 1, index));
+    slots.forEach((slot, i) => {
+      slot.classList.toggle('is-active', i === activeSlot);
+    });
+  }
+
+  function updateCounter(){
+    const count = state.slots.filter(Boolean).length;
+    counterEl.textContent = String(count);
+    printBtn.disabled = count === 0;
+  }
+
+  function setStatus(input, stateName, text){
+    const status = input.closest('.slot-field')?.querySelector('.field-status');
+    if(status){
+      status.dataset.state = stateName;
+      status.textContent = text || '';
+    }
+  }
+
+  function renderSlot(index){
+    const slotEl = slots[index];
+    const card = state.slots[index];
+    const placeholder = slotEl.querySelector('.slot-placeholder');
+    const cardEl = slotEl.querySelector('.slot-card');
+    if(!card){
+      placeholder.hidden = false;
+      cardEl.hidden = true;
+      slotEl.dataset.pid = '';
+      return;
+    }
+    placeholder.hidden = true;
+    cardEl.hidden = false;
+    slotEl.dataset.pid = String(card.id);
+    const titleEl = document.getElementById(`slotTitle-${index}`);
+    const articleEl = document.getElementById(`slotArticle-${index}`);
+    if(titleEl){
+      const local = (card.local_name || '').trim();
+      const base = (card.name || '').trim();
+      titleEl.textContent = local || base || `#${card.id}`;
+    }
+    if(articleEl){
+      articleEl.textContent = card.article ? `Артикул: ${card.article}` : '';
+    }
+    const localInput = document.getElementById(`slotLocal-${index}`);
+    if(localInput){
+      localInput.value = card.local_name || '';
+      localInput.dataset.pid = String(card.id);
+      localInput.dataset.original = (card.local_name || '').trim();
+      setStatus(localInput, 'idle', '');
+    }
+    const select = document.getElementById(`slotManufacturer-${index}`);
+    if(select){
+      select.dataset.pid = String(card.id);
+      select.dataset.current = card.manufacturer && card.manufacturer.id ? String(card.manufacturer.id) : '';
+      select.dataset.slot = String(index);
+      loadManufacturers().then(() => {
+        populateManufacturerSelect(select, card.manufacturer ? card.manufacturer.id : card.manufacturer_id);
+      }).catch(() => {
+        populateManufacturerSelect(select, card.manufacturer ? card.manufacturer.id : card.manufacturer_id);
+      });
+    }
+    updateSlotManufacturerDisplay(index, card.manufacturer || null, card.brand_country || '');
+  }
+
+  function renderAll(){
+    state.slots.forEach((_, idx) => renderSlot(idx));
+    updateCounter();
+  }
+
+  function assignCardToSlot(index, card){
+    state.slots[index] = card;
+    renderSlot(index);
+    updateCounter();
+  }
+
+  function removeSlot(index){
+    state.slots[index] = null;
+    renderSlot(index);
+    updateCounter();
+  }
+
+  function firstEmptySlot(){
+    const idx = state.slots.findIndex(item => !item);
+    return idx === -1 ? activeSlot : idx;
+  }
+
+  async function searchCards(query){
+    const params = new URLSearchParams();
+    params.set('q', query || '');
+    params.set('limit', '60');
+    const res = await fetch(`/api/cards/search?${params.toString()}`);
+    return await res.json();
+  }
+
+  function showSuggestions(items){
+    suggestBox.innerHTML = '';
+    if(!items.length){
+      suggestBox.classList.remove('is-open');
+      return;
+    }
+    items.forEach(item => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      const title = escapeHtml((item.local_name && item.local_name.trim()) || item.name || `#${item.id}`);
+      const article = item.article ? `<span>${escapeHtml(item.article)}</span>` : '';
+      btn.innerHTML = `${title}${article}`;
+      btn.addEventListener('click', () => {
+        const target = firstEmptySlot();
+        assignCardToSlot(target, item);
+        setActiveSlot(target);
+        suggestBox.classList.remove('is-open');
+      });
+      suggestBox.appendChild(btn);
+    });
+    suggestBox.classList.add('is-open');
+  }
+
+  async function handleSearch(){
+    const q = searchInput.value.trim();
+    const items = await searchCards(q);
+    showSuggestions(items);
+  }
+
+  function scheduleSearch(){
+    clearTimeout(state.searchTimer);
+    state.searchTimer = setTimeout(handleSearch, 250);
+  }
+
+  searchInput.addEventListener('input', scheduleSearch);
+  searchInput.addEventListener('focus', function(){
+    if(suggestBox.childElementCount){
+      suggestBox.classList.add('is-open');
+    }
+  });
+  document.addEventListener('click', function(ev){
+    if(!searchInput.contains(ev.target) && !suggestBox.contains(ev.target)){
+      suggestBox.classList.remove('is-open');
+    }
+  });
+
+  slots.forEach((slot, index) => {
+    slot.addEventListener('click', function(ev){
+      if(ev.target.closest('.slot-remove')){
+        removeSlot(index);
+        return;
+      }
+      setActiveSlot(index);
+      if(!state.slots[index]){
+        handleSearch();
+      }
+    });
+    slot.addEventListener('keydown', function(ev){
+      if(ev.key === 'Enter' || ev.key === ' '){
+        ev.preventDefault();
+        setActiveSlot(index);
+        if(!state.slots[index]){
+          handleSearch();
+        }
+      }
+      if(ev.key === 'Delete'){ removeSlot(index); }
+    });
+  });
+
+  grid.addEventListener('input', function(ev){
+    const input = ev.target.closest('.slot-local');
+    if(!input){ return; }
+    const pid = parseInt(input.dataset.pid || '0', 10);
+    if(!pid){ return; }
+    setStatus(input, 'saving', '');
+    clearTimeout(state.debounce.get(input));
+    const timer = setTimeout(async () => {
+      const value = input.value.trim();
+      const fd = new FormData();
+      fd.append('product_id', String(pid));
+      fd.append('local_name', value);
+      try{
+        const res = await fetch('/api/product/set_local_name', { method: 'POST', body: fd });
+        if(!res.ok){ throw new Error('save failed'); }
+        state.slots.forEach(card => {
+          if(card && card.id === pid){
+            card.local_name = value;
+          }
+        });
+        state.slots.forEach((card, idx) => {
+          if(card && card.id === pid){
+            const titleEl = document.getElementById(`slotTitle-${idx}`);
+            if(titleEl){
+              const base = (card.name || '').trim();
+              titleEl.textContent = value || base || `#${pid}`;
+            }
+          }
+        });
+        input.dataset.original = value;
+        setStatus(input, 'saved', '');
+        setTimeout(() => setStatus(input, 'idle', ''), 1200);
+      } catch(err){
+        console.error(err);
+        setStatus(input, 'error', 'Ошибка');
+      }
+    }, 400);
+    state.debounce.set(input, timer);
+  });
+
+  grid.addEventListener('change', function(ev){
+    const select = ev.target.closest('.slot-manufacturer');
+    if(!select){ return; }
+    const pid = parseInt(select.dataset.pid || '0', 10);
+    if(!pid){ return; }
+    submitManufacturerChange(select, pid, select.value);
+  });
+
+  printBtn.addEventListener('click', function(){
+    const ids = state.slots.filter(Boolean).map(card => card.id);
+    if(!ids.length){ return; }
+    const url = `/labels/print?ids=${ids.join(',')}`;
+    window.open(url, '_blank', 'noopener');
+  });
+
+  setActiveSlot(0);
+  renderAll();
+  loadManufacturers().catch(() => {});
+})();
+</script>
+{% endblock %}

--- a/admin_ui/templates/labels_print.html
+++ b/admin_ui/templates/labels_print.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <meta charset="utf-8">
+    <title>Маркировки для печати</title>
+    <style>
+      @page { size: A4; margin: 1cm; }
+      * { box-sizing: border-box; }
+      body { font-family: 'Inter', 'Segoe UI', sans-serif; background:#fff; color:#000; margin:0; padding:0; }
+      .print-actions { display:flex; justify-content:flex-end; padding:12px 16px; background:#f4f4f4; border-bottom:1px solid #ddd; }
+      .print-actions button { padding:8px 14px; font-size:14px; border-radius:6px; border:1px solid #444; background:#fff; cursor:pointer; }
+      .labels-print-grid { display:grid; grid-template-columns: repeat(3, 7cm); gap:0.8cm; justify-content:center; padding:16px; }
+      .print-label { width:7cm; min-height:4.8cm; border:1px solid #000; padding:0.35cm; display:flex; flex-direction:column; gap:0.18cm; font-size:11pt; line-height:1.35; }
+      .print-label strong { font-size:12pt; }
+      .label-title { font-weight:600; font-size:12.5pt; text-transform:none; }
+      .label-article { font-size:10pt; }
+      .label-line { font-size:11pt; }
+      @media print {
+        .print-actions { display:none; }
+        body { margin:0; }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="print-actions">
+      <button type="button" onclick="window.print()">Печать</button>
+    </div>
+    <div class="labels-print-grid">
+      {% if not items %}
+        <div class="print-label" style="grid-column: span 3; text-align:center; justify-content:center;">
+          <strong>Нет выбранных карточек</strong>
+          <div>Вернитесь в генератор и добавьте товары.</div>
+        </div>
+      {% else %}
+        {% for item in items %}
+          <div class="print-label">
+            <div class="label-title">{{ item.local_name or item.name or ('#' ~ item.id) }}</div>
+            {% if item.article %}<div class="label-article">Артикул: {{ item.article }}</div>{% endif %}
+            {% if item.manufacturer %}
+              <div class="label-line">Производитель: {{ item.manufacturer.name }}</div>
+              <div class="label-line">Страна: {{ item.manufacturer.country }}</div>
+            {% elif item.brand_country %}
+              <div class="label-line">{{ item.brand_country }}</div>
+            {% endif %}
+            <div class="label-line">Дата изготовления: {{ manufacture_date }}</div>
+            <div class="label-line">Дата вскрытия тары: {{ open_date }}</div>
+            <div class="label-line">Срок годности: {{ expiry_months }} месяцев</div>
+            <div class="label-line">Условия хранения: {{ storage_text }}</div>
+          </div>
+        {% endfor %}
+      {% endif %}
+    </div>
+  </body>
+</html>

--- a/app/db.py
+++ b/app/db.py
@@ -47,6 +47,15 @@ def init_db():
     Path("data").mkdir(exist_ok=True)
     conn = db()
     with conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS manufacturer(
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
+                country TEXT NOT NULL
+            );
+            """
+        )
         conn.execute("""
         CREATE TABLE IF NOT EXISTS product(
             id INTEGER PRIMARY KEY,
@@ -59,7 +68,9 @@ def init_db():
             archived INTEGER NOT NULL DEFAULT 0,
             archived_at TEXT,
             last_restock_at TEXT,
-            created_at TEXT DEFAULT (datetime('now'))
+            created_at TEXT DEFAULT (datetime('now')),
+            manufacturer_id INTEGER,
+            FOREIGN KEY (manufacturer_id) REFERENCES manufacturer(id) ON DELETE SET NULL
         );
         """)
         conn.execute("""
@@ -380,6 +391,13 @@ def init_db():
         pass
     try:
         conn.execute("ALTER TABLE product ADD COLUMN last_restock_at TEXT")
+    except sqlite3.OperationalError:
+        pass
+    # Миграция: связь с производителем
+    try:
+        conn.execute(
+            "ALTER TABLE product ADD COLUMN manufacturer_id INTEGER REFERENCES manufacturer(id) ON DELETE SET NULL"
+        )
     except sqlite3.OperationalError:
         pass
     # Миграция: столбцы name/local_name в stock (для внешней админки)

--- a/app/services/product_merge.py
+++ b/app/services/product_merge.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import sqlite3
 
-FIELD_KEYS = ("article", "name", "brand_country", "local_name")
+FIELD_KEYS = ("article", "name", "brand_country", "local_name", "manufacturer_id")
 MERGE_MODES = {"a", "b", "merge"}
 PHOTO_MODES = {"a", "b", "merge"}
 
@@ -79,6 +79,41 @@ def _resolve_field(field: str, mode: str, a_value: Any, b_value: Any) -> Tuple[s
     if _has_value(a_value):
         return _coerce_text(a_value), "a"
     return "", "b"
+
+
+def _resolve_manufacturer(mode: str, a_value: Any, b_value: Any) -> Tuple[Optional[int], str]:
+    if mode not in MERGE_MODES:
+        mode = "a"
+
+    def normalize(value: Any) -> Optional[int]:
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    a_id = normalize(a_value)
+    b_id = normalize(b_value)
+
+    if mode == "merge":
+        if a_id is not None:
+            return a_id, "a"
+        if b_id is not None:
+            return b_id, "b"
+        return None, "merge"
+    if mode == "a":
+        if a_id is not None:
+            return a_id, "a"
+        if b_id is not None:
+            return b_id, "b"
+        return None, "a"
+    # mode == "b"
+    if b_id is not None:
+        return b_id, "b"
+    if a_id is not None:
+        return a_id, "a"
+    return None, "b"
 
 
 def _resolve_photo(mode: str, base: Dict[str, Any], other: Dict[str, Any]) -> Tuple[Optional[str], Optional[str], str]:
@@ -284,7 +319,19 @@ def apply_merge(
         for key in FIELD_KEYS:
             default_mode = "merge" if key in {"name", "local_name"} else "a"
             mode = field_modes.get(key, default_mode)
-            value, applied = _resolve_field(key, mode, base_before.get(key), other_before.get(key))
+            if key == "manufacturer_id":
+                value, applied = _resolve_manufacturer(
+                    mode,
+                    base_before.get(key),
+                    other_before.get(key),
+                )
+            else:
+                value, applied = _resolve_field(
+                    key,
+                    mode,
+                    base_before.get(key),
+                    other_before.get(key),
+                )
             resolved[key] = value
             applied_modes[key] = applied
         photo_mode = field_modes.get("photo", "a")
@@ -337,7 +384,7 @@ def apply_merge(
         conn.execute(
             """
             UPDATE product
-            SET article=?, name=?, brand_country=?, local_name=?,
+            SET article=?, name=?, brand_country=?, local_name=?, manufacturer_id=?,
                 photo_file_id=?, photo_path=?, archived=0, archived_at=NULL
             WHERE id=?
             """,
@@ -346,6 +393,7 @@ def apply_merge(
                 resolved.get("name"),
                 resolved.get("brand_country"),
                 resolved.get("local_name"),
+                resolved.get("manufacturer_id"),
                 file_id,
                 path,
                 source_a_id,
@@ -484,6 +532,7 @@ def apply_merge(
                 "name": resolved.get("name"),
                 "brand_country": resolved.get("brand_country"),
                 "local_name": resolved.get("local_name"),
+                "manufacturer_id": resolved.get("manufacturer_id"),
                 "photo_file_id": file_id,
                 "photo_path": path,
             },
@@ -532,7 +581,7 @@ def undo_merge(conn: sqlite3.Connection, merge_id: int) -> Dict[str, Any]:
         conn.execute(
             """
             UPDATE product
-            SET article=?, name=?, brand_country=?, local_name=?,
+            SET article=?, name=?, brand_country=?, local_name=?, manufacturer_id=?,
                 photo_file_id=?, photo_path=?, archived=?, archived_at=?
             WHERE id=?
             """,
@@ -541,6 +590,7 @@ def undo_merge(conn: sqlite3.Connection, merge_id: int) -> Dict[str, Any]:
                 base_before.get("name"),
                 base_before.get("brand_country"),
                 base_before.get("local_name"),
+                base_before.get("manufacturer_id"),
                 base_before.get("photo_file_id"),
                 base_before.get("photo_path"),
                 int(base_before.get("archived") or 0),
@@ -551,7 +601,7 @@ def undo_merge(conn: sqlite3.Connection, merge_id: int) -> Dict[str, Any]:
         conn.execute(
             """
             UPDATE product
-            SET article=?, name=?, brand_country=?, local_name=?,
+            SET article=?, name=?, brand_country=?, local_name=?, manufacturer_id=?,
                 photo_file_id=?, photo_path=?, archived=?, archived_at=?
             WHERE id=?
             """,
@@ -560,6 +610,7 @@ def undo_merge(conn: sqlite3.Connection, merge_id: int) -> Dict[str, Any]:
                 other_before.get("name"),
                 other_before.get("brand_country"),
                 other_before.get("local_name"),
+                other_before.get("manufacturer_id"),
                 other_before.get("photo_file_id"),
                 other_before.get("photo_path"),
                 int(other_before.get("archived") or 0),


### PR DESCRIPTION
## Summary
- add manufacturer catalog table and wire product merge and browse logic to display manufacturer name and country
- allow editing cards to select a manufacturer with autosave and show the chosen country throughout the UI
- create a label generator workflow with selection grid, printable layout, and navigation entry

## Testing
- pytest tests/test_product_merge.py

------
https://chatgpt.com/codex/tasks/task_b_68d4a13dd944832cb33ce52e95f957d9