### PR TITLE
Fix label generator nomenclature names and layout

### DIFF
--- a/admin_ui/server.py
+++ b/admin_ui/server.py
@@ -45,12 +45,26 @@ class Column:
 
 _SAFE_NAME_RX = re.compile(r"[^A-Za-z0-9А-Яа-я_.\-]+")
 
+_DIAMOND_CHARS = "◇◆⬥⬦⬧⬨⬩⬪⬫⬬⬭⬮⬯⟐⋄♢♦◊⧫"
+_DIAMOND_SPLIT_RE = re.compile(rf"\s*[{re.escape(_DIAMOND_CHARS)}]+\s*")
+
 
 def _sanitize_filename(name: str) -> str:
     basename = Path(name).name
     cleaned = _SAFE_NAME_RX.sub("_", basename)
     cleaned = cleaned.strip("._")
     return cleaned or "upload"
+
+
+def _primary_product_name(name: Optional[str]) -> str:
+    """Return the main nomenclature name for a product, respecting diamond splits."""
+    if not name:
+        return ""
+    text = str(name).strip()
+    if not text:
+        return ""
+    parts = [part.strip(" \u00b7·-–—") for part in _DIAMOND_SPLIT_RE.split(text) if part.strip()]
+    return parts[0] if parts else text
 
 
 def _strip_display_exceptions(name: Optional[str], phrases: Sequence[str]) -> str:
@@ -217,6 +231,7 @@ def _product_detail(conn, pid: int) -> Optional[Dict[str, Any]]:
     if not row:
         return None
     data = dict(row)
+    data["nomenclature_name"] = _primary_product_name(row["name"])
     ppath = (row["photo_path"] or "").strip()
     photo_url = None
     if ppath and os.path.isfile(ppath):
@@ -1797,6 +1812,7 @@ def create_app() -> Flask:
                 "id": pid,
                 "article": r["article"],
                 "name": r["name"],
+                "nomenclature_name": _primary_product_name(r["name"]),
                 "local_name": r["local_name"],
                 "brand_country": r["brand_country"] if "brand_country" in r.keys() else None,
                 "manufacturer_id": r["manufacturer_id"] if "manufacturer_id" in r.keys() else None,

--- a/admin_ui/templates/labels.html
+++ b/admin_ui/templates/labels.html
@@ -119,6 +119,25 @@
     searchTimer: null,
   };
 
+  const DIAMOND_SPLIT_RE = /\s*[◇◆⬥⬦⬧⬨⬩⬪⬫⬬⬭⬮⬯⟐⋄♢♦◊⧫]+\s*/u;
+
+  function nomenclatureName(card){
+    if(!card){ return ''; }
+    const serverValue = typeof card.nomenclature_name === 'string' ? card.nomenclature_name.trim() : '';
+    if(serverValue){ return serverValue; }
+    const raw = typeof card.name === 'string' ? card.name.trim() : '';
+    if(!raw){ return ''; }
+    const parts = raw.split(DIAMOND_SPLIT_RE).map(part => part.trim()).filter(Boolean);
+    return parts.length ? parts[0] : raw;
+  }
+
+  function ensureNomenclature(card){
+    if(!card || typeof card !== 'object'){ return ''; }
+    const value = nomenclatureName(card);
+    card.nomenclature_name = value;
+    return value;
+  }
+
   function escapeHtml(s){
     return (s || '').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[c]));
   }
@@ -268,9 +287,8 @@
     const titleEl = document.getElementById(`slotTitle-${index}`);
     const articleEl = document.getElementById(`slotArticle-${index}`);
     if(titleEl){
-      const local = (card.local_name || '').trim();
-      const base = (card.name || '').trim();
-      titleEl.textContent = local || base || `#${card.id}`;
+      const primary = ensureNomenclature(card) || (card.local_name || '').trim() || (card.name || '').trim();
+      titleEl.textContent = primary || `#${card.id}`;
     }
     if(articleEl){
       articleEl.textContent = card.article ? `Артикул: ${card.article}` : '';
@@ -335,9 +353,18 @@
     items.forEach(item => {
       const btn = document.createElement('button');
       btn.type = 'button';
-      const title = escapeHtml((item.local_name && item.local_name.trim()) || item.name || `#${item.id}`);
-      const article = item.article ? `<span>${escapeHtml(item.article)}</span>` : '';
-      btn.innerHTML = `${title}${article}`;
+      const primaryRaw = nomenclatureName(item) || (item.name || '').trim() || (item.local_name || '').trim() || `#${item.id}`;
+      const primary = escapeHtml(primaryRaw);
+      const details = [];
+      const local = (item.local_name || '').trim();
+      if(local && local !== primaryRaw){
+        details.push(escapeHtml(local));
+      }
+      if(item.article){
+        details.push(escapeHtml(item.article));
+      }
+      const meta = details.length ? `<span>${details.join(' · ')}</span>` : '';
+      btn.innerHTML = `${primary}${meta}`;
       btn.addEventListener('click', () => {
         const target = firstEmptySlot();
         assignCardToSlot(target, item);
@@ -413,15 +440,6 @@
         state.slots.forEach(card => {
           if(card && card.id === pid){
             card.local_name = value;
-          }
-        });
-        state.slots.forEach((card, idx) => {
-          if(card && card.id === pid){
-            const titleEl = document.getElementById(`slotTitle-${idx}`);
-            if(titleEl){
-              const base = (card.name || '').trim();
-              titleEl.textContent = value || base || `#${pid}`;
-            }
           }
         });
         input.dataset.original = value;

--- a/admin_ui/templates/labels_print.html
+++ b/admin_ui/templates/labels_print.html
@@ -9,7 +9,7 @@
       body { font-family: 'Inter', 'Segoe UI', sans-serif; background:#fff; color:#000; margin:0; padding:0; }
       .print-actions { display:flex; justify-content:flex-end; padding:12px 16px; background:#f4f4f4; border-bottom:1px solid #ddd; }
       .print-actions button { padding:8px 14px; font-size:14px; border-radius:6px; border:1px solid #444; background:#fff; cursor:pointer; }
-      .labels-print-grid { display:grid; grid-template-columns: repeat(3, 7cm); gap:0.8cm; justify-content:center; padding:16px; }
+      .labels-print-grid { display:grid; grid-template-columns: repeat(3, 7cm); gap:0; justify-content:center; padding:0; }
       .print-label { width:7cm; min-height:4.8cm; border:1px solid #000; padding:0.35cm; display:flex; flex-direction:column; gap:0.18cm; font-size:11pt; line-height:1.35; }
       .print-label strong { font-size:12pt; }
       .label-title { font-weight:600; font-size:12.5pt; text-transform:none; }
@@ -34,7 +34,7 @@
       {% else %}
         {% for item in items %}
           <div class="print-label">
-            <div class="label-title">{{ item.local_name or item.name or ('#' ~ item.id) }}</div>
+            <div class="label-title">{{ item.nomenclature_name or item.name or ('#' ~ item.id) }}</div>
             {% if item.article %}<div class="label-article">Артикул: {{ item.article }}</div>{% endif %}
             {% if item.manufacturer %}
               <div class="label-line">Производитель: {{ item.manufacturer.name }}</div>


### PR DESCRIPTION
## Summary
- derive primary nomenclature names on the server that respect diamond splitters and expose them to the label UI
- update the label picker to display the nomenclature name while still allowing local-name edits
- tighten the print layout so label cells touch without gaps and use the nomenclature title when printing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d4bedaf21c832cac417d447e1ebecc