### PR TITLE
Adjust printable labels layout

### DIFF
--- a/admin_ui/templates/labels_print.html
+++ b/admin_ui/templates/labels_print.html
@@ -9,12 +9,13 @@
       body { font-family: 'Inter', 'Segoe UI', sans-serif; background:#fff; color:#000; margin:0; padding:0; }
       .print-actions { display:flex; justify-content:flex-end; padding:12px 16px; background:#f4f4f4; border-bottom:1px solid #ddd; }
       .print-actions button { padding:8px 14px; font-size:14px; border-radius:6px; border:1px solid #444; background:#fff; cursor:pointer; }
-      .labels-print-grid { display:grid; grid-template-columns: repeat(3, 7cm); gap:0; justify-content:center; padding:0; }
-      .print-label { width:7cm; min-height:4.8cm; border:1px solid #000; padding:0.35cm; display:flex; flex-direction:column; gap:0.18cm; font-size:11pt; line-height:1.35; }
-      .print-label strong { font-size:12pt; }
-      .label-title { font-weight:600; font-size:12.5pt; text-transform:none; }
-      .label-article { font-size:10pt; }
-      .label-line { font-size:11pt; }
+      .labels-print-grid { display:grid; grid-template-columns: repeat(3, 6.2cm); gap:0; justify-content:center; padding:0; }
+      .print-label { width:6.2cm; min-height:4.3cm; border:1px solid #000; padding:0.25cm; display:flex; flex-direction:column; gap:0.12cm; font-size:9.5pt; line-height:1.25; }
+      .print-label strong { font-size:10.5pt; }
+      .label-title { font-weight:600; font-size:11pt; text-transform:none; outline:none; }
+      .label-title[contenteditable="true"] { cursor:text; }
+      .label-title:focus { outline:1px dashed #888; outline-offset:2px; }
+      .label-line { font-size:9.5pt; }
       @media print {
         .print-actions { display:none; }
         body { margin:0; }
@@ -34,13 +35,12 @@
       {% else %}
         {% for item in items %}
           <div class="print-label">
-            <div class="label-title">{{ item.nomenclature_name or item.name or ('#' ~ item.id) }}</div>
-            {% if item.article %}<div class="label-article">Артикул: {{ item.article }}</div>{% endif %}
-            {% if item.manufacturer %}
-              <div class="label-line">Производитель: {{ item.manufacturer.name }}</div>
+            <div class="label-title" contenteditable="true" spellcheck="false">{{ item.nomenclature_name or item.name or ('#' ~ item.id) }}</div>
+            <div class="label-line">Производитель:{% if item.manufacturer %} {{ item.manufacturer.name }}{% endif %}</div>
+            {% if item.manufacturer and item.manufacturer.country %}
               <div class="label-line">Страна: {{ item.manufacturer.country }}</div>
             {% elif item.brand_country %}
-              <div class="label-line">{{ item.brand_country }}</div>
+              <div class="label-line">Страна: {{ item.brand_country }}</div>
             {% endif %}
             <div class="label-line">Дата изготовления: {{ manufacture_date }}</div>
             <div class="label-line">Дата вскрытия тары: {{ open_date }}</div>


### PR DESCRIPTION
## Summary
- shrink printable label cards and typography to fit three columns on A4 pages
- show manufacturer information in place of articles and allow editing label titles before printing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d4e1ea3970832ca5e48601a72e079b