### PR TITLE
Adjust label grid to 3x5 layout and update print formatting

### DIFF
--- a/admin_ui/templates/labels.html
+++ b/admin_ui/templates/labels.html
@@ -4,10 +4,10 @@
   <div class="labels-head">
     <div>
       <h3>Генератор маркировок</h3>
-      <p>Выберите до 18 карточек товаров, чтобы сформировать лист маркировок для печати. На экране размещается сетка 6×3, а итоговый макет разворачивается в формат 3×6 для экономии вертикального пространства.</p>
+      <p>Выберите до 15 карточек товаров, чтобы сформировать лист маркировок для печати. На экране размещается сетка 5×3, а итоговый макет разворачивается в формат 3×5 для экономии вертикального пространства.</p>
     </div>
     <div class="labels-actions">
-      <div class="labels-counter" aria-live="polite">Выбрано: <span id="labelsCount">0</span>/18</div>
+      <div class="labels-counter" aria-live="polite">Выбрано: <span id="labelsCount">0</span>/15</div>
       <button type="button" id="labelsPrint" class="labels-print" disabled>Открыть макет для печати</button>
     </div>
   </div>
@@ -19,7 +19,7 @@
       <div class="labels-suggest" id="labelsSuggest" role="listbox"></div>
     </div>
     <div class="labels-grid" id="labelsGrid">
-      {% for idx in range(18) %}
+      {% for idx in range(15) %}
       <div class="label-slot" data-slot="{{ idx }}" tabindex="0">
         <div class="slot-placeholder">Слот {{ idx + 1 }} · нажмите, чтобы выбрать карточку</div>
         <div class="slot-card" hidden>
@@ -64,7 +64,7 @@
   .labels-suggest button{border:none;background:transparent;color:var(--text);padding:10px 14px;text-align:left;display:flex;flex-direction:column;gap:4px;cursor:pointer}
   .labels-suggest button span{font-size:12px;color:var(--muted)}
   .labels-suggest button:hover,.labels-suggest button:focus{background:color-mix(in srgb,var(--brand-2) 18%,transparent);outline:none}
-  .labels-grid{display:grid;grid-template-columns:repeat(6,minmax(0,1fr));gap:12px}
+  .labels-grid{display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:12px}
   .label-slot{position:relative;border:1px dashed rgba(255,255,255,0.14);border-radius:16px;min-height:220px;padding:14px;background:rgba(13,18,36,0.6);display:flex;flex-direction:column;gap:12px;cursor:pointer;transition:border-color .2s ease,box-shadow .2s ease}
   .label-slot.is-active{border-color:color-mix(in srgb,var(--brand-2) 45%,transparent);box-shadow:0 12px 28px rgba(0,0,0,0.35)}
   .label-slot:focus{outline:none;border-color:color-mix(in srgb,var(--brand-2) 40%,transparent)}
@@ -94,7 +94,7 @@
 
 <script>
 (function(){
-  const TOTAL_SLOTS = 18;
+  const TOTAL_SLOTS = 15;
   const grid = document.getElementById('labelsGrid');
   const slots = Array.from(grid.querySelectorAll('.label-slot'));
   const searchInput = document.getElementById('labelsSearch');

--- a/admin_ui/templates/labels_print.html
+++ b/admin_ui/templates/labels_print.html
@@ -6,11 +6,12 @@
     <style>
       @page { size: A4; margin: 1cm; }
       * { box-sizing: border-box; }
+      html, body { height:100%; }
       body { font-family: 'Inter', 'Segoe UI', sans-serif; background:#fff; color:#000; margin:0; padding:0; }
       .print-actions { display:flex; justify-content:flex-end; padding:12px 16px; background:#f4f4f4; border-bottom:1px solid #ddd; }
       .print-actions button { padding:8px 14px; font-size:14px; border-radius:6px; border:1px solid #444; background:#fff; cursor:pointer; }
-      .labels-print-grid { display:grid; grid-template-columns: repeat(3, 6.2cm); gap:0; justify-content:center; padding:0; }
-      .print-label { width:6.2cm; min-height:4.3cm; border:1px solid #000; padding:0.25cm; display:flex; flex-direction:column; gap:0; font-size:10pt; line-height:0.8; }
+      .labels-print-grid { display:grid; grid-template-columns:repeat(3, 1fr); grid-template-rows:repeat(5, 1fr); gap:0; justify-content:center; padding:0; width:190mm; height:calc(297mm - 20mm); margin:0 auto; }
+      .print-label { width:100%; height:calc((297mm - 20mm) / 5); border:1px solid #000; padding:0.25cm; display:flex; flex-direction:column; gap:0; font-size:10pt; line-height:0.8; }
       .print-label strong { font-size:10pt; }
       .label-title { font-weight:700; font-size:10pt; text-transform:none; outline:none; line-height:1.1; margin:0; }
       .label-title[contenteditable="true"] { cursor:text; }
@@ -26,6 +27,7 @@
     <div class="print-actions">
       <button type="button" onclick="window.print()">Печать</button>
     </div>
+    {% set total_slots = 15 %}
     <div class="labels-print-grid">
       {% if not items %}
         <div class="print-label" style="grid-column: span 3; text-align:center; justify-content:center;">
@@ -36,18 +38,21 @@
         {% for item in items %}
           <div class="print-label">
             <div class="label-title" contenteditable="true" spellcheck="false" title="Можно отредактировать название перед печатью">{{ item.print_title or item.nomenclature_name or item.name or ('#' ~ item.id) }}</div>
-            <div class="label-line">Производитель:{% if item.manufacturer %} {{ item.manufacturer.name }}{% endif %}</div>
-            {% if item.manufacturer and item.manufacturer.country %}
-              <div class="label-line">Страна: {{ item.manufacturer.country }}</div>
-            {% elif item.brand_country %}
-              <div class="label-line">Страна: {{ item.brand_country }}</div>
-            {% endif %}
+            {% set manufacturer_name = item.manufacturer.name if item.manufacturer else '' %}
+            {% set country_name = (item.manufacturer.country if item.manufacturer and item.manufacturer.country else item.brand_country) %}
+            <div class="label-line">Производитель:{% if manufacturer_name %} {{ manufacturer_name }}{% endif %}{% if country_name %}{% if manufacturer_name %} /{% endif %} {{ country_name }}{% endif %}</div>
             <div class="label-line">Дата изготовления: {{ manufacture_date }}</div>
             <div class="label-line">Дата вскрытия тары: {{ open_date }}</div>
             <div class="label-line">Срок годности: {{ expiry_months }} месяцев</div>
             <div class="label-line">Условия хранения: {{ storage_text }}</div>
           </div>
         {% endfor %}
+        {% set remaining = total_slots - (items|length) %}
+        {% if remaining > 0 %}
+          {% for _ in range(remaining) %}
+            <div class="print-label"></div>
+          {% endfor %}
+        {% endif %}
       {% endif %}
     </div>
   </body>


### PR DESCRIPTION
## Summary
- update the label generator to use a 5×3 grid (15 slots) instead of 6×3
- revise the printable layout to a fixed 3×5 sheet without bottom padding and fill empty slots
- show the country next to the manufacturer with a slash instead of a separate "Страна" line

## Testing
- not run (templates change only)


------
https://chatgpt.com/codex/tasks/task_b_68d4fb037b90832cacd91941b6445569