### PR TITLE
Adjust label print layout spacing and sizing

### DIFF
--- a/admin_ui/templates/labels_print.html
+++ b/admin_ui/templates/labels_print.html
@@ -10,13 +10,13 @@
       body { font-family: 'Inter', 'Segoe UI', sans-serif; background:#fff; color:#000; margin:0; padding:0; }
       .print-actions { display:flex; justify-content:flex-end; padding:12px 16px; background:#f4f4f4; border-bottom:1px solid #ddd; }
       .print-actions button { padding:8px 14px; font-size:14px; border-radius:6px; border:1px solid #444; background:#fff; cursor:pointer; }
-      .labels-print-grid { display:grid; grid-template-columns:repeat(3, 1fr); grid-template-rows:repeat(5, 1fr); gap:0; justify-content:center; padding:0; width:190mm; height:calc(297mm - 20mm); margin:0 auto; }
-      .print-label { width:100%; height:calc((297mm - 20mm) / 5); border:1px solid #000; padding:0.25cm; display:flex; flex-direction:column; gap:0; font-size:10pt; line-height:0.8; }
+      .labels-print-grid { display:grid; grid-template-columns:repeat(3, 1fr); grid-template-rows:repeat(5, auto); gap:0; justify-content:center; padding:0; width:190mm; margin:0 auto; }
+      .print-label { width:100%; border:1px solid #000; padding:0.25cm; display:flex; flex-direction:column; gap:0; font-size:10pt; line-height:0.9; }
       .print-label strong { font-size:10pt; }
-      .label-title { font-weight:700; font-size:10pt; text-transform:none; outline:none; line-height:1.1; margin:0; }
+      .label-title { font-weight:700; font-size:10pt; text-transform:none; outline:none; line-height:1.2; margin:0 0 0.3em; text-align:center; }
       .label-title[contenteditable="true"] { cursor:text; }
       .label-title:focus { outline:1px dashed #888; outline-offset:2px; }
-      .label-line { font-size:10pt; line-height:0.8; margin:0; }
+      .label-line { font-size:10pt; line-height:0.9; margin:0; }
       @media print {
         .print-actions { display:none; }
         body { margin:0; }


### PR DESCRIPTION
## Summary
- allow label rows to auto-size based on their tallest entry instead of a fixed height
- tighten label line spacing and add extra space between the title and producer line for readability
- center the editable label title within each print cell

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d513a06520832c8f1ec55e2303a0f8