### PR TITLE
Implement event bus for rebuild phase 1.1

### DIFF
--- a/dvorik/__init__.py
+++ b/dvorik/__init__.py
@@ -1,0 +1,3 @@
+"""New modular implementation of the Dvorik project."""
+
+__all__ = ["__doc__"]

--- a/dvorik/core/__init__.py
+++ b/dvorik/core/__init__.py
@@ -1,0 +1,3 @@
+"""Core infrastructure for the Dvorik rebuild."""
+
+__all__ = []

--- a/dvorik/core/events.py
+++ b/dvorik/core/events.py
@@ -1,0 +1,91 @@
+"""Simple event bus supporting sync and async subscribers."""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+from collections import defaultdict
+from typing import Any, Callable, Dict, List
+
+logger = logging.getLogger(__name__)
+
+Subscriber = Callable[..., Any]
+
+
+class _EventRegistry:
+    """Registry storing subscribers grouped by event name."""
+
+    def __init__(self) -> None:
+        self._callbacks: Dict[str, List[Subscriber]] = defaultdict(list)
+
+    def subscribe(self, event: str, callback: Subscriber) -> None:
+        if callback in self._callbacks[event]:
+            return
+        self._callbacks[event].append(callback)
+
+    def unsubscribe(self, event: str, callback: Subscriber) -> None:
+        callbacks = self._callbacks.get(event)
+        if not callbacks:
+            return
+        try:
+            callbacks.remove(callback)
+        except ValueError:
+            return
+        if not callbacks:
+            self._callbacks.pop(event, None)
+
+    def get_callbacks(self, event: str) -> List[Subscriber]:
+        return list(self._callbacks.get(event, ()))
+
+    def clear(self) -> None:
+        self._callbacks.clear()
+
+
+_registry = _EventRegistry()
+
+
+def subscribe(event: str, callback: Subscriber) -> None:
+    """Subscribe ``callback`` to ``event`` notifications."""
+
+    if not callable(callback):
+        raise TypeError("callback must be callable")
+    _registry.subscribe(event, callback)
+
+
+def unsubscribe(event: str, callback: Subscriber) -> None:
+    """Remove ``callback`` subscription for ``event`` (no-op if missing)."""
+
+    _registry.unsubscribe(event, callback)
+
+
+async def publish(event: str, *args: Any, **kwargs: Any) -> None:
+    """Publish ``event`` data to all registered subscribers."""
+
+    callbacks = _registry.get_callbacks(event)
+    if not callbacks:
+        return
+
+    await asyncio.gather(
+        *(_invoke_callback(event, callback, *args, **kwargs) for callback in callbacks),
+        return_exceptions=False,
+    )
+
+
+async def _invoke_callback(
+    event: str, callback: Subscriber, *args: Any, **kwargs: Any
+) -> None:
+    try:
+        result = callback(*args, **kwargs)
+        if inspect.isawaitable(result):
+            await result  # type: ignore[func-returns-value]
+    except Exception:  # pragma: no cover - logged for observability
+        logger.exception("Error in event subscriber", extra={"event": event, "callback": repr(callback)})
+
+
+def _clear_subscribers() -> None:
+    """Testing helper to reset the registry."""
+
+    _registry.clear()
+
+
+__all__ = ["publish", "subscribe", "unsubscribe"]

--- a/tests/rebuild/test_events.py
+++ b/tests/rebuild/test_events.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import asyncio
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from dvorik.core import events
+
+
+@pytest.fixture(autouse=True)
+def clear_event_bus():
+    events._clear_subscribers()
+    yield
+    events._clear_subscribers()
+
+
+def test_publish_notifies_sync_and_async_subscribers():
+    results = []
+
+    def sync_handler(value):
+        results.append(("sync", value))
+
+    async def async_handler(value):
+        results.append(("async", value))
+
+    events.subscribe("demo", sync_handler)
+    events.subscribe("demo", async_handler)
+
+    asyncio.run(events.publish("demo", 7))
+
+    assert ("sync", 7) in results
+    assert ("async", 7) in results
+    assert len(results) == 2
+
+
+def test_unsubscribe_removes_handler():
+    called = False
+
+    def handler():
+        nonlocal called
+        called = True
+
+    events.subscribe("demo", handler)
+    events.unsubscribe("demo", handler)
+
+    asyncio.run(events.publish("demo"))
+
+    assert called is False


### PR DESCRIPTION
## Summary
- add the foundational `dvorik` package namespace for the rebuild workstream
- implement an async-aware event bus with subscribe, unsubscribe, and publish helpers
- cover the event bus with tests ensuring sync and async subscribers fire and can be removed

## Testing
- pytest tests/rebuild/test_events.py

------
https://chatgpt.com/codex/tasks/task_e_68dc6754998c8326ae4ec780f668985c