### PR TITLE
Implement core registries

### DIFF
--- a/dvorik/core/registry.py
+++ b/dvorik/core/registry.py
@@ -2,7 +2,18 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Generic, Iterable, Iterator, MutableMapping, Tuple, TypeVar
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    Iterable,
+    Iterator,
+    MutableMapping,
+    Tuple,
+    TypeVar,
+    overload,
+)
 
 
 T = TypeVar("T")
@@ -13,7 +24,12 @@ class _Registry(Generic[T]):
 
     def __init__(self, name: str) -> None:
         self._name = name
-        self._items: Dict[str, T] = {}
+        self._store: Dict[str, T] = {}
+
+    def _storage(self) -> MutableMapping[str, T]:
+        """Return the backing storage used by the registry."""
+
+        return self._store
 
     def register(self, key: str, value: T, *, replace: bool = False) -> None:
         """Store ``value`` under ``key``.
@@ -29,59 +45,105 @@ class _Registry(Generic[T]):
             ``KeyError``. When ``True`` the previous value is silently replaced.
         """
 
-        if not replace and key in self._items:
+        storage = self._storage()
+
+        if not replace and key in storage:
             raise KeyError(f"{self._name} '{key}' is already registered")
-        self._items[key] = value
+        storage[key] = value
 
     def unregister(self, key: str) -> None:
         """Remove ``key`` from the registry (no-op if absent)."""
 
-        self._items.pop(key, None)
+        self._storage().pop(key, None)
 
     def get(self, key: str) -> T:
         """Return the value registered under ``key``."""
 
         try:
-            return self._items[key]
+            return self._storage()[key]
         except KeyError as exc:  # pragma: no cover - defensive message enrichment
             raise KeyError(f"{self._name} '{key}' is not registered") from exc
 
-    def ensure(self, key: str, default: T) -> T:
+    @overload
+    def ensure(self, key: str, default: T) -> T:  # pragma: no cover - typing helper
+        ...
+
+    @overload
+    def ensure(self, key: str, default: Callable[[], T]) -> T:  # pragma: no cover
+        ...
+
+    def ensure(self, key: str, default: T | Callable[[], T]) -> T:
         """Return an entry, storing ``default`` if the key was missing."""
 
-        return self._items.setdefault(key, default)
+        storage = self._storage()
+
+        if key in storage:
+            return storage[key]
+
+        value = default() if callable(default) else default
+        storage[key] = value
+        return value
 
     def keys(self) -> Iterable[str]:
-        return tuple(self._items.keys())
+        return tuple(self._storage().keys())
 
     def values(self) -> Iterable[T]:
-        return tuple(self._items.values())
+        return tuple(self._storage().values())
 
     def items(self) -> Iterable[Tuple[str, T]]:
-        return tuple(self._items.items())
+        return tuple(self._storage().items())
 
     def __contains__(self, key: object) -> bool:
-        return key in self._items
+        return key in self._storage()
 
     def __iter__(self) -> Iterator[str]:
-        return iter(self._items)
+        return iter(self._storage())
+
+    def __len__(self) -> int:
+        return len(self._storage())
+
+    def __getitem__(self, key: str) -> T:
+        return self.get(key)
 
     def clear(self) -> None:
-        self._items.clear()
+        self._storage().clear()
+
+    def snapshot(self) -> Dict[str, T]:
+        """Return a shallow copy of the registry contents."""
+
+        return dict(self._storage())
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f"<{self.__class__.__name__} name={self._name!r} entries={len(self)}>"
 
 
 class _QueryRegistry(_Registry[str]):
     """Registry for SQL snippets allowing defaults to be supplied."""
 
+    def __init__(self, name: str) -> None:
+        super().__init__(name)
+        self._bound: MutableMapping[str, str] | None = None
+
+    def bind_to(self, storage: MutableMapping[str, str] | None) -> None:
+        """Bind the registry to external storage (e.g. DB-backed mapping)."""
+
+        self._bound = storage
+
+    def _storage(self) -> MutableMapping[str, str]:
+        if self._bound is not None:
+            return self._bound
+        return super()._storage()
+
     def get(self, key: str, default: str | None = None) -> str:
+        storage = self._storage()
         if default is not None:
-            return self._items.get(key, default)
+            return storage.get(key, default)
         return super().get(key)
 
     def as_mapping(self) -> MutableMapping[str, str]:
         """Expose registry as a mutable mapping for DB layer integration."""
 
-        return self._items
+        return self._storage()
 
 
 MenuRegistry = _Registry[Any]("menu registry")

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,73 @@
+"""Unit tests for registry singletons."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from dvorik.core.registry import (
+    BotRouterRegistry,
+    JobRegistry,
+    MenuRegistry,
+    QueryRegistry,
+    WidgetRegistry,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_registries():
+    """Ensure registry state isolation between tests."""
+
+    for registry in (MenuRegistry, WidgetRegistry, BotRouterRegistry, JobRegistry):
+        registry.clear()
+    QueryRegistry.bind_to(None)
+    QueryRegistry.clear()
+    yield
+    for registry in (MenuRegistry, WidgetRegistry, BotRouterRegistry, JobRegistry):
+        registry.clear()
+    QueryRegistry.bind_to(None)
+    QueryRegistry.clear()
+
+
+def test_widget_registry_register_and_get():
+    WidgetRegistry.register("widget.home", {"name": "HomeWidget"})
+
+    assert WidgetRegistry.get("widget.home") == {"name": "HomeWidget"}
+    assert "widget.home" in WidgetRegistry
+    assert len(WidgetRegistry) == 1
+
+    with pytest.raises(KeyError):
+        WidgetRegistry.register("widget.home", {"name": "Duplicate"})
+
+
+def test_registry_ensure_supports_factories():
+    value = WidgetRegistry.ensure("widget.dynamic", lambda: {"computed": True})
+
+    assert value == {"computed": True}
+    assert WidgetRegistry.get("widget.dynamic") is value
+
+
+def test_query_registry_returns_defaults():
+    QueryRegistry.register("stock.low", "SELECT 1")
+
+    assert QueryRegistry.get("stock.low") == "SELECT 1"
+    assert QueryRegistry.get("missing", "SELECT 2") == "SELECT 2"
+
+
+def test_query_registry_bind_to_external_storage():
+    external: dict[str, str] = {}
+
+    QueryRegistry.bind_to(external)
+    QueryRegistry.register("custom.sql", "SELECT * FROM product")
+
+    assert external["custom.sql"] == "SELECT * FROM product"
+    assert QueryRegistry.as_mapping() is external
+
+    QueryRegistry.unregister("custom.sql")
+    assert external == {}


### PR DESCRIPTION
## Summary
- extend the registry helpers to provide richer APIs and support for external storage binding
- expose query registry binding for DB-backed mappings and add unit coverage for registry behaviour

## Testing
- pytest tests/test_registry.py

------
https://chatgpt.com/codex/tasks/task_e_68dc964ad02c83269f7243902ab65427