### PR TITLE
Add migration runner scaffold

### DIFF
--- a/dvorik/db/__init__.py
+++ b/dvorik/db/__init__.py
@@ -1,5 +1,6 @@
 """Database helpers for the new Dvorik implementation."""
 
 from .conn import db
+from .migrations import init_db
 
-__all__ = ["db"]
+__all__ = ["db", "init_db"]

--- a/dvorik/db/migrations.py
+++ b/dvorik/db/migrations.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import logging
+import sqlite3
+from typing import Iterable
+
+from .conn import db
+
+logger = logging.getLogger(__name__)
+
+# Placeholder collection for schema creation statements. Ticket 2.3 will
+# populate the list with concrete DDL definitions.
+_SCHEMA_SCRIPTS: Iterable[str] = ()
+
+
+def _run_script(conn: sqlite3.Connection, script: str) -> None:
+    """Execute a migration script handling common SQLite errors."""
+
+    if not script.strip():
+        return
+
+    try:
+        conn.executescript(script)
+    except sqlite3.OperationalError as exc:  # pragma: no cover - defensive
+        logger.warning("Skipping migration script due to sqlite error: %s", exc)
+
+
+def init_db(connection: sqlite3.Connection | None = None) -> None:
+    """Initialise the SQLite schema ensuring idempotency."""
+
+    owns_connection = connection is None
+    conn = connection if connection is not None else db()
+
+    try:
+        with conn:
+            for script in _SCHEMA_SCRIPTS:
+                _run_script(conn, script)
+    finally:
+        if owns_connection:
+            conn.close()
+
+
+__all__ = ["init_db"]


### PR DESCRIPTION
## Summary
- add a migrations module that iterates schema scripts while tolerating repeated runs
- export the new `init_db` helper from the `dvorik.db` package

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc9d7f062c8326a999cc661c0f32e1