### PR TITLE
Implement SQLite repository layer

### DIFF
--- a/dvorik/repo/__init__.py
+++ b/dvorik/repo/__init__.py
@@ -1,0 +1,13 @@
+"""Concrete repository implementations backed by SQLite."""
+
+from .product_repo import SQLiteProductRepo
+from .stock_repo import SQLiteStockRepo
+from .schedule_repo import SQLiteScheduleRepo
+from .import_repo import SQLiteImportLogRepo
+
+__all__ = [
+    "SQLiteProductRepo",
+    "SQLiteStockRepo",
+    "SQLiteScheduleRepo",
+    "SQLiteImportLogRepo",
+]

--- a/dvorik/repo/import_repo.py
+++ b/dvorik/repo/import_repo.py
@@ -1,0 +1,164 @@
+"""SQLite-backed implementation of :class:`~dvorik.domain.ports.ImportLogRepo`."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import asdict
+from typing import Any, Dict, Sequence
+
+from dvorik.db.query_registry import get_query
+from dvorik.domain.models import ImportLogEntry
+from dvorik.domain.ports import ImportLogRepo
+
+
+class SQLiteImportLogRepo(ImportLogRepo):
+    """Repository managing import log records."""
+
+    def __init__(self, conn: sqlite3.Connection):
+        self._conn = conn
+
+    def get(self, import_id: int) -> ImportLogEntry | None:
+        sql = get_query(
+            self._conn,
+            "repo.import.get",
+            """
+            SELECT
+                id,
+                original_name,
+                stored_path,
+                import_type,
+                source_hash,
+                normalized_csv,
+                normalized_hash,
+                supplier,
+                invoice,
+                items_count,
+                items_json,
+                reverted_at,
+                created_at
+            FROM import_log
+            WHERE id = :import_id
+            """,
+        )
+        cursor = self._conn.execute(sql, {"import_id": import_id})
+        row = cursor.fetchone()
+        if row is None:
+            return None
+        return _row_to_import_log(row)
+
+    def latest(self, limit: int = 20) -> Sequence[ImportLogEntry]:
+        sql = get_query(
+            self._conn,
+            "repo.import.latest",
+            """
+            SELECT
+                id,
+                original_name,
+                stored_path,
+                import_type,
+                source_hash,
+                normalized_csv,
+                normalized_hash,
+                supplier,
+                invoice,
+                items_count,
+                items_json,
+                reverted_at,
+                created_at
+            FROM import_log
+            ORDER BY created_at DESC, id DESC
+            LIMIT :limit
+            """,
+        )
+        cursor = self._conn.execute(sql, {"limit": max(1, int(limit))})
+        return [_row_to_import_log(row) for row in cursor.fetchall()]
+
+    def add(self, entry: ImportLogEntry) -> ImportLogEntry:
+        sql = get_query(
+            self._conn,
+            "repo.import.insert",
+            """
+            INSERT INTO import_log(
+                original_name,
+                stored_path,
+                import_type,
+                source_hash,
+                normalized_csv,
+                normalized_hash,
+                supplier,
+                invoice,
+                items_count,
+                items_json
+            )
+            VALUES (
+                :original_name,
+                :stored_path,
+                :import_type,
+                :source_hash,
+                :normalized_csv,
+                :normalized_hash,
+                :supplier,
+                :invoice,
+                :items_count,
+                :items_json
+            )
+            RETURNING *
+            """,
+        )
+        params = _import_entry_to_params(entry)
+        with self._conn:
+            cursor = self._conn.execute(sql, params)
+            row = cursor.fetchone()
+        if row is None:  # pragma: no cover - SQLite should always return row
+            raise RuntimeError("Failed to insert import log entry")
+        return _row_to_import_log(row)
+
+    def mark_reverted(self, import_id: int) -> None:
+        sql = get_query(
+            self._conn,
+            "repo.import.mark_reverted",
+            """
+            UPDATE import_log
+            SET reverted_at = COALESCE(reverted_at, datetime('now','localtime'))
+            WHERE id = :import_id
+            """,
+        )
+        with self._conn:
+            self._conn.execute(sql, {"import_id": import_id})
+
+
+def _row_to_import_log(row: sqlite3.Row) -> ImportLogEntry:
+    return ImportLogEntry(
+        id=row["id"],
+        original_name=row["original_name"],
+        stored_path=row["stored_path"],
+        import_type=row["import_type"],
+        source_hash=row["source_hash"],
+        normalized_csv=row["normalized_csv"],
+        normalized_hash=row["normalized_hash"],
+        supplier=row["supplier"],
+        invoice=row["invoice"],
+        items_count=int(row["items_count"] or 0),
+        items_json=row["items_json"],
+        reverted_at=row["reverted_at"],
+        created_at=row["created_at"],
+    )
+
+
+def _import_entry_to_params(entry: ImportLogEntry) -> Dict[str, Any]:
+    data = asdict(entry)
+    return {
+        "original_name": data["original_name"],
+        "stored_path": data["stored_path"],
+        "import_type": data["import_type"],
+        "source_hash": data["source_hash"],
+        "normalized_csv": data.get("normalized_csv"),
+        "normalized_hash": data.get("normalized_hash"),
+        "supplier": data.get("supplier"),
+        "invoice": data.get("invoice"),
+        "items_count": data.get("items_count", 0),
+        "items_json": data.get("items_json"),
+    }
+
+
+__all__ = ["SQLiteImportLogRepo"]

--- a/dvorik/repo/product_repo.py
+++ b/dvorik/repo/product_repo.py
@@ -1,0 +1,317 @@
+"""SQLite-backed implementation of :class:`~dvorik.domain.ports.ProductRepo`."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any, List, Mapping, Sequence
+
+from dvorik.db.query_registry import get_query
+from dvorik.domain.models import (
+    Manufacturer,
+    Product,
+    ProductDetail,
+    StockItem,
+    SupplierSku,
+)
+from dvorik.domain.ports import ProductRepo
+
+
+class SQLiteProductRepo(ProductRepo):
+    """Read-only repository for product catalogue data."""
+
+    def __init__(self, conn: sqlite3.Connection):
+        self._conn = conn
+
+    # ------------------------------------------------------------------
+    # Product listing and retrieval
+    # ------------------------------------------------------------------
+    def get(self, product_id: int) -> Product | None:
+        sql = get_query(
+            self._conn,
+            "repo.product.get",
+            """
+            SELECT
+                id,
+                article,
+                barcode,
+                name,
+                local_name,
+                description,
+                unit,
+                manufacturer_id,
+                price,
+                vat_rate,
+                is_new,
+                archived,
+                archived_at,
+                created_at,
+                updated_at,
+                last_restock_at,
+                photo_file_id,
+                photo_path
+            FROM product
+            WHERE id = :product_id
+            """,
+        )
+        cursor = self._conn.execute(sql, {"product_id": product_id})
+        row = cursor.fetchone()
+        if row is None:
+            return None
+        return _row_to_product(row)
+
+    def list(self, *, include_archived: bool = False) -> Sequence[Product]:
+        sql = get_query(
+            self._conn,
+            "repo.product.list",
+            """
+            SELECT
+                id,
+                article,
+                barcode,
+                name,
+                local_name,
+                description,
+                unit,
+                manufacturer_id,
+                price,
+                vat_rate,
+                is_new,
+                archived,
+                archived_at,
+                created_at,
+                updated_at,
+                last_restock_at,
+                photo_file_id,
+                photo_path
+            FROM product
+            WHERE (:include_archived = 1) OR archived = 0
+            ORDER BY name COLLATE NOCASE
+            """,
+        )
+        cursor = self._conn.execute(
+            sql,
+            {"include_archived": 1 if include_archived else 0},
+        )
+        return [_row_to_product(row) for row in cursor.fetchall()]
+
+    def search_fts(self, query: str, *, limit: int = 20) -> Sequence[Product]:
+        if not query.strip():
+            return []
+
+        sql = get_query(
+            self._conn,
+            "repo.product.search_fts",
+            """
+            SELECT
+                p.id,
+                p.article,
+                p.barcode,
+                p.name,
+                p.local_name,
+                p.description,
+                p.unit,
+                p.manufacturer_id,
+                p.price,
+                p.vat_rate,
+                p.is_new,
+                p.archived,
+                p.archived_at,
+                p.created_at,
+                p.updated_at,
+                p.last_restock_at,
+                p.photo_file_id,
+                p.photo_path
+            FROM product AS p
+            JOIN product_fts AS fts ON fts.rowid = p.id
+            WHERE fts MATCH :match
+            ORDER BY p.name COLLATE NOCASE
+            LIMIT :limit
+            """,
+        )
+        cursor = self._conn.execute(
+            sql,
+            {
+                "match": query,
+                "limit": max(1, int(limit)),
+            },
+        )
+        return [_row_to_product(row) for row in cursor.fetchall()]
+
+    def product_detail(self, product_id: int) -> ProductDetail | None:
+        sql = get_query(
+            self._conn,
+            "repo.product.detail",
+            """
+            SELECT
+                p.id AS product_id,
+                p.article AS product_article,
+                p.barcode AS product_barcode,
+                p.name AS product_name,
+                p.local_name AS product_local_name,
+                p.description AS product_description,
+                p.unit AS product_unit,
+                p.manufacturer_id AS product_manufacturer_id,
+                p.price AS product_price,
+                p.vat_rate AS product_vat_rate,
+                p.is_new AS product_is_new,
+                p.archived AS product_archived,
+                p.archived_at AS product_archived_at,
+                p.created_at AS product_created_at,
+                p.updated_at AS product_updated_at,
+                p.last_restock_at AS product_last_restock_at,
+                p.photo_file_id AS product_photo_file_id,
+                p.photo_path AS product_photo_path,
+                m.id AS manufacturer_id,
+                m.name AS manufacturer_name,
+                m.country AS manufacturer_country,
+                m.created_at AS manufacturer_created_at
+            FROM product AS p
+            LEFT JOIN manufacturer AS m ON m.id = p.manufacturer_id
+            WHERE p.id = :product_id
+            """,
+        )
+        cursor = self._conn.execute(sql, {"product_id": product_id})
+        row = cursor.fetchone()
+        if row is None:
+            return None
+
+        product = _row_to_product(
+            {
+                "id": row["product_id"],
+                "article": row["product_article"],
+                "barcode": row["product_barcode"],
+                "name": row["product_name"],
+                "local_name": row["product_local_name"],
+                "description": row["product_description"],
+                "unit": row["product_unit"],
+                "manufacturer_id": row["product_manufacturer_id"],
+                "price": row["product_price"],
+                "vat_rate": row["product_vat_rate"],
+                "is_new": row["product_is_new"],
+                "archived": row["product_archived"],
+                "archived_at": row["product_archived_at"],
+                "created_at": row["product_created_at"],
+                "updated_at": row["product_updated_at"],
+                "last_restock_at": row["product_last_restock_at"],
+                "photo_file_id": row["product_photo_file_id"],
+                "photo_path": row["product_photo_path"],
+            }
+        )
+
+        manufacturer = None
+        if row["manufacturer_id"] is not None:
+            manufacturer = Manufacturer(
+                id=row["manufacturer_id"],
+                name=row["manufacturer_name"],
+                country=row["manufacturer_country"],
+                created_at=row["manufacturer_created_at"],
+            )
+
+        supplier_skus = self._fetch_supplier_skus(product_id)
+        stock_items = self._fetch_stock_items(product_id)
+
+        return ProductDetail(
+            product=product,
+            manufacturer=manufacturer,
+            supplier_skus=tuple(supplier_skus),
+            stock_items=tuple(stock_items),
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _fetch_supplier_skus(self, product_id: int) -> List[SupplierSku]:
+        sql = get_query(
+            self._conn,
+            "repo.product.detail_supplier_skus",
+            """
+            SELECT
+                id,
+                product_id,
+                supplier_id,
+                code,
+                barcode,
+                pack_qty,
+                active,
+                created_at,
+                updated_at
+            FROM supplier_sku
+            WHERE product_id = :product_id
+            ORDER BY supplier_id, code COLLATE NOCASE
+            """,
+        )
+        cursor = self._conn.execute(sql, {"product_id": product_id})
+        return [_row_to_supplier_sku(row) for row in cursor.fetchall()]
+
+    def _fetch_stock_items(self, product_id: int) -> List[StockItem]:
+        sql = get_query(
+            self._conn,
+            "repo.product.detail_stock",
+            """
+            SELECT
+                product_id,
+                location_code,
+                qty_pack,
+                reserved_pack,
+                updated_at
+            FROM stock
+            WHERE product_id = :product_id
+            ORDER BY location_code
+            """,
+        )
+        cursor = self._conn.execute(sql, {"product_id": product_id})
+        return [_row_to_stock_item(row) for row in cursor.fetchall()]
+
+
+# ----------------------------------------------------------------------
+# Row conversion helpers
+# ----------------------------------------------------------------------
+def _row_to_product(row: sqlite3.Row | Mapping[str, Any]) -> Product:
+    data = dict(row)
+    return Product(
+        id=data["id"],
+        article=data.get("article"),
+        barcode=data.get("barcode"),
+        name=data["name"],
+        local_name=data.get("local_name"),
+        description=data.get("description"),
+        unit=data.get("unit"),
+        manufacturer_id=data.get("manufacturer_id"),
+        price=data.get("price"),
+        vat_rate=data.get("vat_rate"),
+        is_new=bool(data.get("is_new", 0)),
+        archived=bool(data.get("archived", 0)),
+        archived_at=data.get("archived_at"),
+        created_at=data.get("created_at"),
+        updated_at=data.get("updated_at"),
+        last_restock_at=data.get("last_restock_at"),
+        photo_file_id=data.get("photo_file_id"),
+        photo_path=data.get("photo_path"),
+    )
+
+
+def _row_to_supplier_sku(row: sqlite3.Row) -> SupplierSku:
+    return SupplierSku(
+        id=row["id"],
+        product_id=row["product_id"],
+        supplier_id=row["supplier_id"],
+        code=row["code"],
+        barcode=row["barcode"],
+        pack_qty=row["pack_qty"],
+        active=bool(row["active"]),
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def _row_to_stock_item(row: sqlite3.Row) -> StockItem:
+    return StockItem(
+        product_id=row["product_id"],
+        location_code=row["location_code"],
+        qty_pack=float(row["qty_pack"] or 0),
+        reserved_pack=float(row["reserved_pack"] or 0),
+        updated_at=row["updated_at"],
+    )
+
+
+__all__ = ["SQLiteProductRepo"]

--- a/dvorik/repo/schedule_repo.py
+++ b/dvorik/repo/schedule_repo.py
@@ -1,0 +1,137 @@
+"""SQLite-backed implementation of :class:`~dvorik.domain.ports.ScheduleRepo`."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Sequence
+
+from dvorik.db.query_registry import get_query
+from dvorik.domain.models import (
+    ScheduleAssignment,
+    ScheduleDay,
+    ScheduleTransferRequest,
+)
+from dvorik.domain.ports import ScheduleRepo
+
+
+class SQLiteScheduleRepo(ScheduleRepo):
+    """Repository exposing schedule read models."""
+
+    def __init__(self, conn: sqlite3.Connection):
+        self._conn = conn
+
+    def day(self, date: str) -> ScheduleDay | None:
+        sql = get_query(
+            self._conn,
+            "repo.schedule.day",
+            """
+            SELECT
+                date,
+                is_open,
+                notes
+            FROM schedule_day
+            WHERE date = :date
+            """,
+        )
+        cursor = self._conn.execute(sql, {"date": date})
+        row = cursor.fetchone()
+        if row is None:
+            return None
+        return ScheduleDay(
+            date=row["date"],
+            is_open=bool(row["is_open"]),
+            notes=row["notes"],
+        )
+
+    def assignments(self, start_date: str, end_date: str | None = None) -> Sequence[ScheduleAssignment]:
+        sql = get_query(
+            self._conn,
+            "repo.schedule.assignments_range",
+            """
+            SELECT
+                date,
+                tg_id,
+                source,
+                created_at
+            FROM schedule_assignment
+            WHERE date BETWEEN :start_date AND COALESCE(:end_date, :start_date)
+            ORDER BY date, tg_id
+            """,
+        )
+        cursor = self._conn.execute(
+            sql,
+            {"start_date": start_date, "end_date": end_date},
+        )
+        rows = cursor.fetchall()
+        return [
+            ScheduleAssignment(
+                date=row["date"],
+                tg_id=row["tg_id"],
+                source=row["source"],
+                created_at=row["created_at"],
+            )
+            for row in rows
+        ]
+
+    def assignments_for_month(self, month: str) -> Sequence[ScheduleAssignment]:
+        sql = get_query(
+            self._conn,
+            "repo.schedule.assignments_month",
+            """
+            SELECT
+                date,
+                tg_id,
+                source,
+                created_at
+            FROM schedule_assignment
+            WHERE substr(date, 1, 7) = :month
+            ORDER BY date, tg_id
+            """,
+        )
+        cursor = self._conn.execute(sql, {"month": month})
+        rows = cursor.fetchall()
+        return [
+            ScheduleAssignment(
+                date=row["date"],
+                tg_id=row["tg_id"],
+                source=row["source"],
+                created_at=row["created_at"],
+            )
+            for row in rows
+        ]
+
+    def transfer_requests(self, *, status: str | None = None) -> Sequence[ScheduleTransferRequest]:
+        sql = get_query(
+            self._conn,
+            "repo.schedule.transfer_requests",
+            """
+            SELECT
+                id,
+                date,
+                from_tg_id,
+                to_tg_id,
+                status,
+                created_at,
+                expires_at
+            FROM schedule_transfer_request
+            WHERE (:status IS NULL OR status = :status)
+            ORDER BY created_at DESC
+            """,
+        )
+        cursor = self._conn.execute(sql, {"status": status})
+        rows = cursor.fetchall()
+        return [
+            ScheduleTransferRequest(
+                id=row["id"],
+                date=row["date"],
+                from_tg_id=row["from_tg_id"],
+                to_tg_id=row["to_tg_id"],
+                status=row["status"],
+                created_at=row["created_at"],
+                expires_at=row["expires_at"],
+            )
+            for row in rows
+        ]
+
+
+__all__ = ["SQLiteScheduleRepo"]

--- a/dvorik/repo/stock_repo.py
+++ b/dvorik/repo/stock_repo.py
@@ -1,0 +1,196 @@
+"""SQLite-backed implementation of :class:`~dvorik.domain.ports.StockRepo`."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Sequence
+
+from dvorik.db.query_registry import get_query
+from dvorik.domain.models import (
+    Location,
+    LowStockRecord,
+    Product,
+    StockItem,
+    StockSnapshot,
+)
+from dvorik.domain.ports import StockRepo
+
+
+class SQLiteStockRepo(StockRepo):
+    """Repository exposing stock read models backed by SQLite."""
+
+    def __init__(self, conn: sqlite3.Connection):
+        self._conn = conn
+
+    def get_item(self, product_id: int, location_code: str) -> StockItem | None:
+        sql = get_query(
+            self._conn,
+            "repo.stock.get_item",
+            """
+            SELECT
+                product_id,
+                location_code,
+                qty_pack,
+                reserved_pack,
+                updated_at
+            FROM stock
+            WHERE product_id = :product_id AND location_code = :location_code
+            """,
+        )
+        cursor = self._conn.execute(
+            sql,
+            {"product_id": product_id, "location_code": location_code},
+        )
+        row = cursor.fetchone()
+        if row is None:
+            return None
+        return StockItem(
+            product_id=row["product_id"],
+            location_code=row["location_code"],
+            qty_pack=float(row["qty_pack"] or 0),
+            reserved_pack=float(row["reserved_pack"] or 0),
+            updated_at=row["updated_at"],
+        )
+
+    def stock_by_location(self, location_code: str | None = None) -> Sequence[StockSnapshot]:
+        sql = get_query(
+            self._conn,
+            "repo.stock.by_location",
+            """
+            SELECT
+                p.id AS product_id,
+                p.article AS product_article,
+                p.barcode AS product_barcode,
+                p.name AS product_name,
+                p.local_name AS product_local_name,
+                p.description AS product_description,
+                p.unit AS product_unit,
+                p.manufacturer_id AS product_manufacturer_id,
+                p.price AS product_price,
+                p.vat_rate AS product_vat_rate,
+                p.is_new AS product_is_new,
+                p.archived AS product_archived,
+                p.archived_at AS product_archived_at,
+                p.created_at AS product_created_at,
+                p.updated_at AS product_updated_at,
+                p.last_restock_at AS product_last_restock_at,
+                p.photo_file_id AS product_photo_file_id,
+                p.photo_path AS product_photo_path,
+                l.code AS location_code,
+                l.kind AS location_kind,
+                l.title AS location_title,
+                l.created_at AS location_created_at,
+                s.qty_pack AS stock_qty_pack,
+                s.reserved_pack AS stock_reserved_pack,
+                s.updated_at AS stock_updated_at
+            FROM stock AS s
+            JOIN product AS p ON p.id = s.product_id
+            JOIN location AS l ON l.code = s.location_code
+            WHERE (:location_code IS NULL OR l.code = :location_code)
+            ORDER BY l.code, p.name COLLATE NOCASE
+            """,
+        )
+        cursor = self._conn.execute(sql, {"location_code": location_code})
+        rows = cursor.fetchall()
+        return [_row_to_snapshot(row) for row in rows]
+
+    def low_stock(
+        self,
+        *,
+        threshold: float | None = None,
+        limit: int = 20,
+    ) -> Sequence[LowStockRecord]:
+        threshold_value = float(threshold) if threshold is not None else 0.0
+
+        sql = get_query(
+            self._conn,
+            "repo.stock.low_stock",
+            """
+            SELECT
+                p.id AS product_id,
+                p.article AS product_article,
+                p.barcode AS product_barcode,
+                p.name AS product_name,
+                p.local_name AS product_local_name,
+                p.description AS product_description,
+                p.unit AS product_unit,
+                p.manufacturer_id AS product_manufacturer_id,
+                p.price AS product_price,
+                p.vat_rate AS product_vat_rate,
+                p.is_new AS product_is_new,
+                p.archived AS product_archived,
+                p.archived_at AS product_archived_at,
+                p.created_at AS product_created_at,
+                p.updated_at AS product_updated_at,
+                p.last_restock_at AS product_last_restock_at,
+                p.photo_file_id AS product_photo_file_id,
+                p.photo_path AS product_photo_path,
+                l.code AS location_code,
+                l.kind AS location_kind,
+                l.title AS location_title,
+                l.created_at AS location_created_at,
+                s.qty_pack AS stock_qty_pack,
+                s.reserved_pack AS stock_reserved_pack
+            FROM stock AS s
+            JOIN product AS p ON p.id = s.product_id
+            JOIN location AS l ON l.code = s.location_code
+            WHERE s.qty_pack <= :threshold
+            ORDER BY s.qty_pack ASC, p.name COLLATE NOCASE
+            LIMIT :limit
+            """,
+        )
+        cursor = self._conn.execute(
+            sql,
+            {"threshold": threshold_value, "limit": max(1, int(limit))},
+        )
+        rows = cursor.fetchall()
+        snapshots = [_row_to_snapshot(row) for row in rows]
+        return [
+            LowStockRecord(
+                product=record.product,
+                location=record.location,
+                qty_pack=record.qty_pack,
+                threshold=threshold_value,
+            )
+            for record in snapshots
+        ]
+
+
+def _row_to_snapshot(row: sqlite3.Row) -> StockSnapshot:
+    product = Product(
+        id=row["product_id"],
+        article=row["product_article"],
+        barcode=row["product_barcode"],
+        name=row["product_name"],
+        local_name=row["product_local_name"],
+        description=row["product_description"],
+        unit=row["product_unit"],
+        manufacturer_id=row["product_manufacturer_id"],
+        price=row["product_price"],
+        vat_rate=row["product_vat_rate"],
+        is_new=bool(row["product_is_new"]),
+        archived=bool(row["product_archived"]),
+        archived_at=row["product_archived_at"],
+        created_at=row["product_created_at"],
+        updated_at=row["product_updated_at"],
+        last_restock_at=row["product_last_restock_at"],
+        photo_file_id=row["product_photo_file_id"],
+        photo_path=row["product_photo_path"],
+    )
+
+    location = Location(
+        code=row["location_code"],
+        kind=row["location_kind"],
+        title=row["location_title"],
+        created_at=row["location_created_at"],
+    )
+
+    return StockSnapshot(
+        product=product,
+        location=location,
+        qty_pack=float(row["stock_qty_pack"] or 0),
+        reserved_pack=float(row["stock_reserved_pack"] or 0),
+    )
+
+
+__all__ = ["SQLiteStockRepo"]


### PR DESCRIPTION
## Summary
- add SQLite-backed repository implementations for products, stock, schedules, and import logs that fetch SQL from the query registry
- expose the new repositories through the `dvorik.repo` package

## Testing
- python -m compileall dvorik

------
https://chatgpt.com/codex/tasks/task_e_68dca060e8288326b4de047a09befda4