### PR TITLE
Add domain services for stock, notifications, and import processing

### DIFF
--- a/dvorik/services/__init__.py
+++ b/dvorik/services/__init__.py
@@ -1,0 +1,5 @@
+"""Service layer helpers tying domain and infrastructure together."""
+
+from . import notify, schedule, stock
+
+__all__ = ["notify", "schedule", "stock"]

--- a/dvorik/services/imports/__init__.py
+++ b/dvorik/services/imports/__init__.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import csv
+import hashlib
+import io
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, List, Mapping, Sequence
+
+from .strategies import ColumnMapping, detect_columns, parse_csv, parse_sheet
+
+__all__ = ["ImportBatch", "ImportFacade", "NormalisedRow", "normalise_rows"]
+
+
+NormalisedRow = Mapping[str, Any]
+
+
+@dataclass(slots=True)
+class ImportBatch:
+    """Result of parsing an import file."""
+
+    import_type: str
+    original_name: str
+    rows: List[Mapping[str, Any]]
+    columns: ColumnMapping
+    source_hash: str
+
+    def normalised_rows(self) -> List[NormalisedRow]:
+        return list(normalise_rows(self.rows, self.columns))
+
+    def to_csv(self, *, delimiter: str = ";") -> str:
+        normalised = self.normalised_rows()
+        if not normalised:
+            return ""
+        headers = sorted(normalised[0].keys())
+        buffer = io.StringIO()
+        writer = csv.DictWriter(buffer, fieldnames=headers, delimiter=delimiter)
+        writer.writeheader()
+        for row in normalised:
+            writer.writerow({key: row.get(key) for key in headers})
+        buffer.seek(0)
+        return buffer.read()
+
+
+class ImportFacade:
+    """High level entry point for import processing."""
+
+    def __init__(self, storage_dir: str | Path | None = None) -> None:
+        self._storage_dir = Path(storage_dir) if storage_dir else None
+        if self._storage_dir is not None:
+            self._storage_dir.mkdir(parents=True, exist_ok=True)
+
+    def from_csv(
+        self,
+        source: Any,
+        *,
+        original_name: str,
+        encoding: str = "utf-8",
+        delimiter: str | None = None,
+    ) -> ImportBatch:
+        rows = parse_csv(source, encoding=encoding, delimiter=delimiter)
+        columns = detect_columns(rows)
+        data_hash = _hash_rows(rows)
+        return ImportBatch(
+            import_type="csv",
+            original_name=original_name,
+            rows=rows,
+            columns=columns,
+            source_hash=data_hash,
+        )
+
+    def from_excel(
+        self,
+        source: Any,
+        *,
+        original_name: str,
+        sheet_name: str | None = None,
+    ) -> ImportBatch:
+        rows = parse_sheet(source, sheet_name=sheet_name)
+        columns = detect_columns(rows)
+        data_hash = _hash_rows(rows)
+        return ImportBatch(
+            import_type="excel",
+            original_name=original_name,
+            rows=rows,
+            columns=columns,
+            source_hash=data_hash,
+        )
+
+    def store_normalised(self, batch: ImportBatch, *, filename: str | None = None) -> Path:
+        if self._storage_dir is None:
+            raise RuntimeError("ImportFacade was not configured with storage directory")
+
+        target_name = filename or f"{batch.source_hash}.csv"
+        target_path = self._storage_dir / target_name
+        normalised = list(batch.normalised_rows())
+        if not normalised:
+            target_path.write_text("", encoding="utf-8")
+            return target_path
+
+        headers = sorted(normalised[0].keys())
+        with target_path.open("w", encoding="utf-8", newline="") as handle:
+            writer = csv.DictWriter(handle, fieldnames=headers, delimiter=";")
+            writer.writeheader()
+            for row in normalised:
+                writer.writerow({key: row.get(key) for key in headers})
+        return target_path
+
+
+def normalise_rows(
+    rows: Sequence[Mapping[str, Any]],
+    columns: ColumnMapping,
+) -> Iterable[NormalisedRow]:
+    mapping = columns.as_dict()
+    if not mapping:
+        for row in rows:
+            yield row
+        return
+
+    for row in rows:
+        projected = {canonical: row.get(source_column) for canonical, source_column in mapping.items()}
+        yield projected
+
+
+def _hash_rows(rows: Sequence[Mapping[str, Any]]) -> str:
+    hasher = hashlib.sha256()
+    for row in rows:
+        for key in sorted(row.keys()):
+            value = row.get(key)
+            hasher.update(str(key).encode("utf-8"))
+            hasher.update(str(value).encode("utf-8"))
+    return hasher.hexdigest()

--- a/dvorik/services/imports/strategies/__init__.py
+++ b/dvorik/services/imports/strategies/__init__.py
@@ -1,0 +1,13 @@
+"""Parsing strategies used by the import facade."""
+
+from .column_detect import ColumnMapping, detect_columns
+from .csv_parse import parse_csv, sniff_delimiter
+from .sheet_parse import parse_sheet
+
+__all__ = [
+    "ColumnMapping",
+    "detect_columns",
+    "parse_csv",
+    "parse_sheet",
+    "sniff_delimiter",
+]

--- a/dvorik/services/imports/strategies/column_detect.py
+++ b/dvorik/services/imports/strategies/column_detect.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import dataclasses
+import unicodedata
+from collections.abc import Iterable, Sequence
+from typing import Mapping, MutableMapping
+
+_CANONICAL_ALIASES: Mapping[str, tuple[str, ...]] = {
+    "article": ("article", "sku", "артикул", "код", "vendorcode", "vendor_code"),
+    "name": ("name", "product", "наименование", "товар", "title"),
+    "qty": ("qty", "quantity", "кол-во", "amount", "count", "количество"),
+    "price": ("price", "cost", "цена", "стоимость", "unitprice"),
+    "barcode": ("barcode", "штрихкод", "ean", "ean13"),
+}
+
+
+def _normalise(text: str) -> str:
+    value = unicodedata.normalize("NFKD", text)
+    return "".join(ch for ch in value.lower() if ch.isalnum())
+
+
+@dataclasses.dataclass(slots=True, frozen=True)
+class ColumnMapping:
+    """Mapping between canonical column names and the actual source headers."""
+
+    article: str | None = None
+    name: str | None = None
+    qty: str | None = None
+    price: str | None = None
+    barcode: str | None = None
+
+    def as_dict(self) -> Mapping[str, str]:
+        data = dataclasses.asdict(self)
+        return {key: value for key, value in data.items() if value}
+
+    def apply(self, row: Mapping[str, object]) -> MutableMapping[str, object]:
+        """Project ``row`` according to the mapping returning canonical keys."""
+
+        result: MutableMapping[str, object] = {}
+        for canonical, column in self.as_dict().items():
+            result[canonical] = row.get(column)
+        return result
+
+
+def detect_columns(
+    rows_or_headers: Sequence[Mapping[str, object]] | Iterable[str],
+) -> ColumnMapping:
+    """Detect column mapping either from headers or the first row of data."""
+
+    headers: Iterable[str]
+    if isinstance(rows_or_headers, Sequence) and rows_or_headers:
+        first_item = rows_or_headers[0]
+        if isinstance(first_item, Mapping):
+            headers = first_item.keys()
+        else:
+            headers = (str(value) for value in rows_or_headers)  # type: ignore[assignment]
+    else:
+        headers = (str(value) for value in rows_or_headers)
+
+    normalised = {_normalise(header): header for header in headers}
+    mapping: dict[str, str] = {}
+
+    for canonical, aliases in _CANONICAL_ALIASES.items():
+        for alias in aliases:
+            header = normalised.get(alias)
+            if header:
+                mapping[canonical] = header
+                break
+
+    return ColumnMapping(**mapping)
+
+
+__all__ = ["ColumnMapping", "detect_columns"]

--- a/dvorik/services/imports/strategies/csv_parse.py
+++ b/dvorik/services/imports/strategies/csv_parse.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import csv
+import io
+from collections.abc import Iterable
+from typing import Any, List, Mapping
+
+__all__ = ["parse_csv", "sniff_delimiter"]
+
+
+def sniff_delimiter(sample: str) -> str:
+    """Try to detect a delimiter from the provided ``sample`` text."""
+
+    try:
+        dialect = csv.Sniffer().sniff(sample, delimiters=",;\t|:")
+        return dialect.delimiter
+    except csv.Error:
+        return ","
+
+
+def _prepare_stream(source: Any, *, encoding: str) -> io.TextIOBase:
+    if isinstance(source, io.TextIOBase):
+        source.seek(0)
+        return source
+    if isinstance(source, (bytes, bytearray)):
+        text = source.decode(encoding)
+        return io.StringIO(text)
+    if hasattr(source, "read"):
+        data = source.read()
+        if isinstance(data, bytes):
+            text = data.decode(encoding)
+        else:
+            text = str(data)
+        return io.StringIO(text)
+    if isinstance(source, str):
+        return io.StringIO(source)
+    raise TypeError("Unsupported CSV source type")
+
+
+def parse_csv(
+    source: Any,
+    *,
+    encoding: str = "utf-8",
+    delimiter: str | None = None,
+    normalize_headers: bool = True,
+) -> List[Mapping[str, Any]]:
+    """Parse CSV data returning a list of dictionaries."""
+
+    stream = _prepare_stream(source, encoding=encoding)
+    sample = stream.read(2048)
+    stream.seek(0)
+    csv_delimiter = delimiter or sniff_delimiter(sample)
+
+    reader = csv.DictReader(stream, delimiter=csv_delimiter)
+    rows: List[Mapping[str, Any]] = []
+
+    headers: Iterable[str] = reader.fieldnames or []
+    if normalize_headers:
+        header_map = {
+            header: header.strip() if isinstance(header, str) else header
+            for header in headers
+        }
+    else:
+        header_map = {header: header for header in headers}
+
+    for raw_row in reader:
+        cleaned_row = {
+            header_map.get(key, key): value
+            for key, value in raw_row.items()
+            if key is not None
+        }
+        rows.append(cleaned_row)
+
+    stream.seek(0)
+    return rows

--- a/dvorik/services/imports/strategies/sheet_parse.py
+++ b/dvorik/services/imports/strategies/sheet_parse.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import io
+from collections.abc import Iterable
+from typing import Any, Dict, List, Mapping
+
+from openpyxl import load_workbook
+
+__all__ = ["parse_sheet"]
+
+
+def parse_sheet(
+    source: Any,
+    *,
+    sheet_name: str | None = None,
+    header_row: int = 1,
+    trim_headers: bool = True,
+) -> List[Mapping[str, Any]]:
+    """Parse an Excel sheet into a list of dictionaries."""
+
+    workbook = _load_workbook(source)
+    try:
+        worksheet = workbook[sheet_name] if sheet_name else workbook.active
+        rows = list(worksheet.iter_rows(values_only=True))
+    finally:
+        workbook.close()
+
+    if not rows:
+        return []
+
+    header_index = max(header_row - 1, 0)
+    headers_row = rows[header_index]
+    headers = _normalise_headers(headers_row, trim=trim_headers)
+
+    data_rows = rows[header_index + 1 :]
+    parsed: List[Mapping[str, Any]] = []
+    for row in data_rows:
+        if row is None:
+            continue
+        values = list(row)
+        if all(value is None or value == "" for value in values):
+            continue
+        record: Dict[str, Any] = {}
+        for idx, header in enumerate(headers):
+            if header is None:
+                continue
+            record[header] = values[idx] if idx < len(values) else None
+        parsed.append(record)
+
+    return parsed
+
+
+def _load_workbook(source: Any):
+    if isinstance(source, (bytes, bytearray)):
+        return load_workbook(io.BytesIO(source), read_only=True, data_only=True)
+    if hasattr(source, "read"):
+        data = source.read()
+        if isinstance(data, (bytes, bytearray)):
+            return load_workbook(io.BytesIO(data), read_only=True, data_only=True)
+        raise TypeError("Excel source must provide bytes-like data")
+    if isinstance(source, str):
+        return load_workbook(filename=source, read_only=True, data_only=True)
+    raise TypeError("Unsupported Excel source type")
+
+
+def _normalise_headers(headers: Iterable[Any], *, trim: bool) -> List[str | None]:
+    normalised: List[str | None] = []
+    for index, header in enumerate(headers, start=1):
+        if header is None:
+            normalised.append(f"column_{index}")
+            continue
+        header_text = str(header)
+        normalised.append(header_text.strip() if trim else header_text)
+    return normalised

--- a/dvorik/services/notify.py
+++ b/dvorik/services/notify.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import Awaitable, Callable, Mapping, MutableMapping, Sequence
+
+from dvorik.core import events
+from dvorik.domain.models import LowStockRecord
+from dvorik.domain.ports import StockRepo
+
+logger = logging.getLogger(__name__)
+
+_NotifyCallback = Callable[[Mapping[str, object]], Awaitable[None] | None]
+
+_STOCK_ADJUSTED_EVENT = "stock.adjusted"
+_STOCK_MOVED_EVENT = "stock.moved"
+_DAILY_TICK_EVENT = "scheduler.daily"
+
+
+def _execute_callback(callback: _NotifyCallback, payload: Mapping[str, object]) -> Awaitable[None] | None:
+    try:
+        result = callback(payload)
+        if inspect.isawaitable(result):
+            return result  # type: ignore[return-value]
+        return None
+    except Exception:  # pragma: no cover - notification failures must be logged
+        logger.exception("Notification callback failed", extra={"payload": dict(payload)})
+        return None
+
+
+def notify_instant_thresholds(
+    stock_repo: StockRepo,
+    callback: _NotifyCallback,
+    *,
+    threshold: float,
+    limit: int = 50,
+) -> Callable[[], None]:
+    """Subscribe to stock adjustments and notify when below ``threshold``.
+
+    Returns a callable that unsubscribes the listener.
+    """
+
+    async def _handler(**payload: object) -> None:
+        qty_after = float(payload.get("qty_after", 0))
+        if qty_after > threshold:
+            return
+
+        product_id = payload.get("product_id")
+        location_code = payload.get("location_code")
+        if not isinstance(product_id, int) or not isinstance(location_code, str):
+            return
+
+        low_stock_records = stock_repo.low_stock(threshold=threshold, limit=limit)
+        record = next(
+            (
+                item
+                for item in low_stock_records
+                if item.product.id == product_id and item.location.code == location_code
+            ),
+            None,
+        )
+        if record is None:
+            return
+
+        notification_payload: MutableMapping[str, object] = {
+            "type": "threshold",
+            "product_id": product_id,
+            "location_code": location_code,
+            "qty_after": qty_after,
+            "threshold": threshold,
+            "record": record,
+        }
+        awaitable = _execute_callback(callback, notification_payload)
+        if awaitable is not None:
+            await awaitable
+
+    events.subscribe(_STOCK_ADJUSTED_EVENT, _handler)
+
+    def _unsubscribe() -> None:
+        events.unsubscribe(_STOCK_ADJUSTED_EVENT, _handler)
+
+    return _unsubscribe
+
+
+def notify_instant_to_skl(
+    callback: _NotifyCallback,
+    *,
+    hub_code: str = "SKL-0",
+) -> Callable[[], None]:
+    """Subscribe to stock move events that target the hub location."""
+
+    async def _handler(**payload: object) -> None:
+        if payload.get("to_location") != hub_code:
+            return
+
+        notification_payload: MutableMapping[str, object] = {
+            "type": "to_skl",
+            "product_id": payload.get("product_id"),
+            "from_location": payload.get("from_location"),
+            "to_location": payload.get("to_location"),
+            "qty": payload.get("qty"),
+        }
+        awaitable = _execute_callback(callback, notification_payload)
+        if awaitable is not None:
+            await awaitable
+
+    events.subscribe(_STOCK_MOVED_EVENT, _handler)
+
+    def _unsubscribe() -> None:
+        events.unsubscribe(_STOCK_MOVED_EVENT, _handler)
+
+    return _unsubscribe
+
+
+def send_daily_digests(
+    stock_repo: StockRepo,
+    callback: _NotifyCallback,
+    *,
+    threshold: float,
+    limit: int = 200,
+) -> Callable[[], None]:
+    """Subscribe to the scheduler tick and emit daily stock digests."""
+
+    async def _handler(**_: object) -> None:
+        low_stock_records: Sequence[LowStockRecord] = stock_repo.low_stock(
+            threshold=threshold, limit=limit
+        )
+        if not low_stock_records:
+            return
+
+        payload: Mapping[str, object] = {
+            "type": "daily_digest",
+            "threshold": threshold,
+            "records": tuple(low_stock_records),
+        }
+        awaitable = _execute_callback(callback, payload)
+        if awaitable is not None:
+            await awaitable
+
+    events.subscribe(_DAILY_TICK_EVENT, _handler)
+
+    def _unsubscribe() -> None:
+        events.unsubscribe(_DAILY_TICK_EVENT, _handler)
+
+    return _unsubscribe
+
+
+__all__ = [
+    "notify_instant_thresholds",
+    "notify_instant_to_skl",
+    "send_daily_digests",
+]

--- a/dvorik/services/schedule.py
+++ b/dvorik/services/schedule.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import datetime as dt
+import sqlite3
+from collections.abc import Sequence
+from typing import Dict, List, Mapping, MutableMapping
+
+from dvorik.domain.models import ScheduleAssignment, ScheduleDay
+from dvorik.domain.ports import ScheduleRepo
+
+__all__ = ["ScheduleService"]
+
+
+class ScheduleService:
+    """Provides helpers to manage the staff schedule."""
+
+    def __init__(self, conn: sqlite3.Connection, repo: ScheduleRepo) -> None:
+        self._conn = conn
+        self._repo = repo
+
+    # ------------------------------------------------------------------
+    # Day management
+    # ------------------------------------------------------------------
+    def upsert_day(self, date: str, *, is_open: bool = True, notes: str | None = None) -> ScheduleDay:
+        """Create or update the ``schedule_day`` record for ``date``."""
+
+        with self._conn:
+            self._conn.execute(
+                """
+                INSERT INTO schedule_day(date, is_open, notes)
+                VALUES (:date, :is_open, :notes)
+                ON CONFLICT(date) DO UPDATE SET
+                    is_open = excluded.is_open,
+                    notes = excluded.notes
+                """,
+                {"date": date, "is_open": 1 if is_open else 0, "notes": notes},
+            )
+        day = self._repo.day(date)
+        if day is None:  # pragma: no cover - defensive fallback
+            day = ScheduleDay(date=date, is_open=is_open, notes=notes)
+        return day
+
+    # ------------------------------------------------------------------
+    # Assignment management
+    # ------------------------------------------------------------------
+    def assign_user(self, date: str, tg_id: int, *, source: str = "manual") -> None:
+        """Assign ``tg_id`` to ``date`` with the provided ``source`` label."""
+
+        self.upsert_day(date)
+        with self._conn:
+            self._conn.execute(
+                """
+                INSERT INTO schedule_assignment(date, tg_id, source)
+                VALUES (:date, :tg_id, :source)
+                ON CONFLICT(date, tg_id) DO UPDATE SET source = excluded.source
+                """,
+                {"date": date, "tg_id": tg_id, "source": source},
+            )
+
+    def remove_assignment(self, date: str, tg_id: int) -> None:
+        with self._conn:
+            self._conn.execute(
+                "DELETE FROM schedule_assignment WHERE date = :date AND tg_id = :tg_id",
+                {"date": date, "tg_id": tg_id},
+            )
+
+    def clear_day(self, date: str) -> None:
+        with self._conn:
+            self._conn.execute(
+                "DELETE FROM schedule_assignment WHERE date = :date",
+                {"date": date},
+            )
+
+    def assignments(self, start_date: str, end_date: str | None = None) -> Sequence[ScheduleAssignment]:
+        return self._repo.assignments(start_date, end_date)
+
+    def assignments_for_month(self, month: str) -> Sequence[ScheduleAssignment]:
+        return self._repo.assignments_for_month(month)
+
+    # ------------------------------------------------------------------
+    # Generation helpers
+    # ------------------------------------------------------------------
+    def generate_period(
+        self,
+        start_date: str,
+        *,
+        days: int,
+        pattern: Mapping[int, Sequence[int]],
+        source: str = "auto",
+    ) -> Sequence[ScheduleAssignment]:
+        """Generate assignments for ``days`` using a weekday ``pattern``."""
+
+        if days <= 0:
+            raise ValueError("days must be positive")
+
+        start = dt.date.fromisoformat(start_date)
+        for offset in range(days):
+            current = start + dt.timedelta(days=offset)
+            weekday = current.weekday()
+            target_date = current.isoformat()
+            tg_ids = pattern.get(weekday, ())
+
+            self.upsert_day(target_date)
+            with self._conn:
+                self._conn.execute(
+                    "DELETE FROM schedule_assignment WHERE date = :date AND source = :source",
+                    {"date": target_date, "source": source},
+                )
+                for tg_id in tg_ids:
+                    self._conn.execute(
+                        """
+                        INSERT OR REPLACE INTO schedule_assignment(date, tg_id, source)
+                        VALUES (:date, :tg_id, :source)
+                        """,
+                        {"date": target_date, "tg_id": tg_id, "source": source},
+                    )
+        end_date = (start + dt.timedelta(days=max(days - 1, 0))).isoformat()
+        return self._repo.assignments(start.isoformat(), end_date)
+
+    def ensure_anchor(self, start_date: str) -> None:
+        with self._conn:
+            self._conn.execute(
+                """
+                INSERT OR IGNORE INTO schedule_anchor(start_date)
+                VALUES (:start_date)
+                """,
+                {"start_date": start_date},
+            )
+
+    def remove_anchor(self, start_date: str) -> None:
+        with self._conn:
+            self._conn.execute(
+                "DELETE FROM schedule_anchor WHERE start_date = :start_date",
+                {"start_date": start_date},
+            )
+
+    # ------------------------------------------------------------------
+    # Aggregated helpers
+    # ------------------------------------------------------------------
+    def overview(self, start_date: str, end_date: str | None = None) -> MutableMapping[str, Sequence[int]]:
+        """Return assignments grouped by date between the provided bounds."""
+
+        assignments = self._repo.assignments(start_date, end_date)
+        grouped: Dict[str, List[int]] = {}
+        for item in assignments:
+            grouped.setdefault(item.date, []).append(item.tg_id)
+        return grouped

--- a/dvorik/services/stock.py
+++ b/dvorik/services/stock.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from dvorik.core import events
+
+_STOCK_ADJUSTED_EVENT = "stock.adjusted"
+_STOCK_MOVED_EVENT = "stock.moved"
+
+
+@dataclass(slots=True)
+class StockChange:
+    """Represents a stock adjustment performed by the service."""
+
+    product_id: int
+    location_code: str
+    qty_before: float
+    qty_after: float
+    user_id: int | None = None
+
+    @property
+    def delta(self) -> float:
+        return self.qty_after - self.qty_before
+
+
+async def set_location_qty(
+    conn: sqlite3.Connection,
+    product_id: int,
+    location_code: str,
+    qty_pack: float,
+    *,
+    user_id: int | None = None,
+) -> StockChange:
+    """Set ``qty_pack`` for the product at the location.
+
+    The operation is idempotent.  A ``ValueError`` is raised if the provided
+    quantity is negative.  After updating the database the function publishes a
+    ``stock.adjusted`` event describing the delta.
+    """
+
+    if qty_pack < 0:
+        raise ValueError("Quantity must be non-negative")
+
+    qty_before = _get_current_qty(conn, product_id, location_code)
+    change = StockChange(
+        product_id=product_id,
+        location_code=location_code,
+        qty_before=qty_before,
+        qty_after=float(qty_pack),
+        user_id=user_id,
+    )
+
+    if abs(change.delta) < 1e-9:
+        # No change required — skip writes but still return the delta object.
+        return change
+
+    payload = {
+        "product_id": product_id,
+        "location_code": location_code,
+        "qty_before": change.qty_before,
+        "qty_after": change.qty_after,
+        "delta": change.delta,
+        "user_id": user_id,
+    }
+
+    with conn:
+        _upsert_stock(conn, product_id, location_code, change.qty_after)
+        _log_event(conn, "stock.set", payload)
+
+    await events.publish(_STOCK_ADJUSTED_EVENT, **payload)
+    return change
+
+
+async def move_specific(
+    conn: sqlite3.Connection,
+    product_id: int,
+    from_location: str,
+    to_location: str,
+    qty_pack: float,
+    *,
+    user_id: int | None = None,
+) -> Dict[str, StockChange]:
+    """Move ``qty_pack`` units of ``product_id`` between locations.
+
+    Returns a mapping containing the changes for both the origin and the
+    destination.  A ``ValueError`` is raised if the quantity is not positive or
+    if the source location does not have enough stock.
+    """
+
+    if qty_pack <= 0:
+        raise ValueError("Quantity to move must be positive")
+    if from_location == to_location:
+        raise ValueError("Source and destination locations must differ")
+
+    available = _get_current_qty(conn, product_id, from_location)
+    if available < qty_pack - 1e-9:
+        raise ValueError("Insufficient stock at source location")
+
+    from_before = available
+    to_before = _get_current_qty(conn, product_id, to_location)
+    from_after = from_before - qty_pack
+    to_after = to_before + qty_pack
+
+    changes = {
+        "from": StockChange(
+            product_id=product_id,
+            location_code=from_location,
+            qty_before=from_before,
+            qty_after=from_after,
+            user_id=user_id,
+        ),
+        "to": StockChange(
+            product_id=product_id,
+            location_code=to_location,
+            qty_before=to_before,
+            qty_after=to_after,
+            user_id=user_id,
+        ),
+    }
+
+    payload = {
+        "product_id": product_id,
+        "from_location": from_location,
+        "to_location": to_location,
+        "qty": float(qty_pack),
+        "from_before": from_before,
+        "from_after": from_after,
+        "to_before": to_before,
+        "to_after": to_after,
+        "user_id": user_id,
+    }
+
+    with conn:
+        _upsert_stock(conn, product_id, from_location, from_after)
+        _upsert_stock(conn, product_id, to_location, to_after)
+        _log_event(conn, "stock.move", payload)
+
+    await asyncio.gather(
+        events.publish(
+            _STOCK_ADJUSTED_EVENT,
+            product_id=product_id,
+            location_code=from_location,
+            qty_before=from_before,
+            qty_after=from_after,
+            delta=changes["from"].delta,
+            user_id=user_id,
+        ),
+        events.publish(
+            _STOCK_ADJUSTED_EVENT,
+            product_id=product_id,
+            location_code=to_location,
+            qty_before=to_before,
+            qty_after=to_after,
+            delta=changes["to"].delta,
+            user_id=user_id,
+        ),
+        events.publish(_STOCK_MOVED_EVENT, **payload),
+    )
+
+    return changes
+
+
+async def adjust_with_hub(
+    conn: sqlite3.Connection,
+    product_id: int,
+    location_code: str,
+    qty_pack: float,
+    *,
+    hub_code: str = "SKL-0",
+    user_id: int | None = None,
+) -> Dict[str, StockChange] | StockChange:
+    """Adjust a location quantity by balancing against the hub location.
+
+    If the requested quantity is higher than the current quantity, items are
+    moved from ``hub_code`` to the target location.  Otherwise the difference is
+    moved back to the hub.  When the target location already has the desired
+    quantity the hub remains untouched and the return value is a single
+    :class:`StockChange` describing the no-op.
+    """
+
+    if hub_code == location_code:
+        raise ValueError("Hub code must differ from target location")
+
+    current_qty = _get_current_qty(conn, product_id, location_code)
+    delta = float(qty_pack) - current_qty
+
+    if abs(delta) < 1e-9:
+        return StockChange(
+            product_id=product_id,
+            location_code=location_code,
+            qty_before=current_qty,
+            qty_after=current_qty,
+            user_id=user_id,
+        )
+
+    if delta > 0:
+        return await move_specific(
+            conn,
+            product_id,
+            hub_code,
+            location_code,
+            delta,
+            user_id=user_id,
+        )
+
+    return await move_specific(
+        conn,
+        product_id,
+        location_code,
+        hub_code,
+        abs(delta),
+        user_id=user_id,
+    )
+
+
+def _get_current_qty(conn: sqlite3.Connection, product_id: int, location_code: str) -> float:
+    cursor = conn.execute(
+        """
+        SELECT qty_pack
+        FROM stock
+        WHERE product_id = :product_id AND location_code = :location_code
+        """,
+        {"product_id": product_id, "location_code": location_code},
+    )
+    row = cursor.fetchone()
+    if not row:
+        return 0.0
+    value = row[0] if isinstance(row, tuple) else row["qty_pack"]
+    return float(value or 0)
+
+
+def _upsert_stock(
+    conn: sqlite3.Connection,
+    product_id: int,
+    location_code: str,
+    qty_pack: float,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO stock (product_id, location_code, qty_pack, updated_at)
+        VALUES (:product_id, :location_code, :qty_pack, datetime('now','localtime'))
+        ON CONFLICT(product_id, location_code)
+        DO UPDATE SET
+            qty_pack = excluded.qty_pack,
+            updated_at = datetime('now','localtime')
+        """,
+        {
+            "product_id": product_id,
+            "location_code": location_code,
+            "qty_pack": float(qty_pack),
+        },
+    )
+
+
+def _log_event(conn: sqlite3.Connection, event_type: str, payload: Dict[str, Any]) -> None:
+    conn.execute(
+        """
+        INSERT INTO event_log (event_type, product_id, location_code, user_id, delta, payload_json)
+        VALUES (:event_type, :product_id, :location_code, :user_id, :delta, :payload_json)
+        """,
+        {
+            "event_type": event_type,
+            "product_id": payload.get("product_id"),
+            "location_code": payload.get("location_code")
+            or payload.get("from_location")
+            or payload.get("to_location"),
+            "user_id": payload.get("user_id"),
+            "delta": payload.get("delta") or payload.get("qty"),
+            "payload_json": json.dumps(payload, ensure_ascii=False, sort_keys=True),
+        },
+    )
+
+
+__all__ = [
+    "StockChange",
+    "adjust_with_hub",
+    "move_specific",
+    "set_location_qty",
+]


### PR DESCRIPTION
## Summary
- implement asynchronous stock management helpers that update inventory, log events, and publish bus messages
- add notification helpers that subscribe to stock and scheduler events for threshold, hub, and daily digest workflows
- build import facade with CSV/Excel parsing strategies plus a schedule service for managing days and assignments

## Testing
- python -m compileall dvorik/services

------
https://chatgpt.com/codex/tasks/task_e_68dca1e0e6d88326a535929c3086f550