### PR TITLE
Implement admin Flask app factory

### DIFF
--- a/dvorik/admin/__init__.py
+++ b/dvorik/admin/__init__.py
@@ -1,0 +1,5 @@
+"""Admin web application package for the rebuilt Dvorik system."""
+
+from .server import create_app
+
+__all__ = ["create_app"]

--- a/dvorik/admin/blueprints/__init__.py
+++ b/dvorik/admin/blueprints/__init__.py
@@ -1,0 +1,3 @@
+"""Blueprint stubs for the admin server."""
+
+__all__ = ["home", "superadmin", "tables", "supply"]

--- a/dvorik/admin/blueprints/home.py
+++ b/dvorik/admin/blueprints/home.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from flask import Blueprint
+
+blueprint = Blueprint("home", __name__)
+
+
+@blueprint.get("/")
+def index() -> str:
+    return "Home placeholder"

--- a/dvorik/admin/blueprints/superadmin.py
+++ b/dvorik/admin/blueprints/superadmin.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from flask import Blueprint
+
+blueprint = Blueprint("superadmin", __name__, url_prefix="/superadmin")
+
+
+@blueprint.get("/")
+def dashboard() -> str:
+    return "Superadmin placeholder"

--- a/dvorik/admin/blueprints/supply.py
+++ b/dvorik/admin/blueprints/supply.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from flask import Blueprint
+
+blueprint = Blueprint("supply", __name__, url_prefix="/supply")
+
+
+@blueprint.get("/")
+def supply_home() -> str:
+    return "Supply placeholder"

--- a/dvorik/admin/blueprints/tables.py
+++ b/dvorik/admin/blueprints/tables.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from flask import Blueprint
+
+blueprint = Blueprint("tables", __name__, url_prefix="/tables")
+
+
+@blueprint.get("/")
+def list_tables() -> str:
+    return "Tables placeholder"

--- a/dvorik/admin/server.py
+++ b/dvorik/admin/server.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Iterable
+
+from flask import Blueprint, Flask
+
+from dvorik.core.config import Config, get_config
+from dvorik.core.plugins import load_plugins
+from dvorik.db import init_db
+
+logger = logging.getLogger(__name__)
+
+
+def create_app(*, config: Config | None = None) -> Flask:
+    """Create and configure the Flask application for the admin UI."""
+
+    config = config or get_config()
+
+    package_root = Path(__file__).resolve().parent
+    app = Flask(
+        "dvorik.admin",
+        template_folder=str(package_root / "templates"),
+        static_folder=str(package_root / "static"),
+    )
+    app.config["DVORIK_CONFIG"] = config
+
+    _initialise_database()
+    _register_builtin_components()
+    _register_blueprints(app)
+
+    @app.get("/health")
+    def healthcheck() -> tuple[dict[str, str], int]:
+        """Return a simple JSON payload confirming the service is alive."""
+
+        return {"status": "ok"}, 200
+
+    return app
+
+
+def _initialise_database() -> None:
+    """Ensure the application database schema is created."""
+
+    try:
+        init_db()
+    except Exception:  # pragma: no cover - logged for visibility
+        logger.exception("Failed to initialise database schema")
+        raise
+
+
+def _register_builtin_components() -> None:
+    """Load plugins and register built-in widgets."""
+
+    load_plugins()
+
+    try:
+        from .widgets import register_builtin_widgets
+    except Exception:  # pragma: no cover - defensive, logged
+        logger.exception("Unable to import admin widgets")
+        raise
+
+    try:
+        register_builtin_widgets()
+    except Exception:  # pragma: no cover - defensive, logged
+        logger.exception("Failed to register admin widgets")
+        raise
+
+
+def _register_blueprints(app: Flask) -> None:
+    """Import and attach admin blueprints."""
+
+    for blueprint in _iter_blueprints():
+        app.register_blueprint(blueprint)
+
+
+def _iter_blueprints() -> Iterable[Blueprint]:
+    from .blueprints import home, superadmin, tables, supply
+
+    return (
+        home.blueprint,
+        superadmin.blueprint,
+        tables.blueprint,
+        supply.blueprint,
+    )
+
+
+def main() -> None:
+    """Run the development server."""
+
+    app = create_app()
+    config: Config = app.config["DVORIK_CONFIG"]
+    app.run(host="0.0.0.0", port=config.admin_port, debug=True)
+
+
+__all__ = ["create_app", "main"]
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution entry point
+    main()

--- a/dvorik/admin/widgets/__init__.py
+++ b/dvorik/admin/widgets/__init__.py
@@ -1,0 +1,13 @@
+"""Widget registration stubs for the admin interface."""
+
+
+def register_builtin_widgets() -> None:
+    """Hook for registering built-in widgets.
+
+    Ticket 4.1 only requires that the server imports this hook during
+    application initialisation. Concrete widget implementations will be
+    provided in subsequent tasks.
+    """
+
+    # No built-in widgets yet.
+    return None


### PR DESCRIPTION
## Summary
- add the dvorik.admin package with a Flask app factory that initialises the database, loads plugins, and exposes a /health endpoint
- stub out home, superadmin, tables, and supply blueprints alongside a widget registration hook for future tickets

## Testing
- python - <<'PY'
from dvorik.admin.server import create_app

app = create_app()
with app.test_client() as client:
    response = client.get('/health')
    print(response.status_code)
    print(response.json)
PY

------
https://chatgpt.com/codex/tasks/task_e_68dca4f91c0c8326abb860f17b28b05d