### PR TITLE
Add dynamic admin menu offcanvas

### DIFF
--- a/dvorik/admin/blueprints/__init__.py
+++ b/dvorik/admin/blueprints/__init__.py
@@ -1,3 +1,3 @@
 """Blueprint stubs for the admin server."""
 
-__all__ = ["home", "superadmin", "tables", "supply"]
+__all__ = ["home", "menus", "superadmin", "tables", "supply"]

--- a/dvorik/admin/blueprints/menus.py
+++ b/dvorik/admin/blueprints/menus.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+import logging
+from typing import Iterable, Mapping
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+import logging
+from typing import Iterable, Mapping
+
+from flask import Blueprint
+import sqlite3
+
+from dvorik.db.conn import db
+
+logger = logging.getLogger(__name__)
+
+blueprint = Blueprint("menus", __name__)
+
+
+@dataclass(frozen=True, slots=True)
+class MenuEntry:
+    """Serializable representation of a navigation menu item."""
+
+    slug: str
+    title: str
+    url: str | None = None
+    icon: str | None = None
+    target: str | None = None
+    children: tuple["MenuEntry", ...] = ()
+
+
+@dataclass(slots=True)
+class _MenuNode:
+    """Internal mutable node used during tree construction."""
+
+    id: int
+    slug: str
+    title: str
+    url: str | None
+    icon: str | None
+    target: str | None
+    parent_id: int | None
+
+
+_FALLBACK_MENU: tuple[MenuEntry, ...] = (
+    MenuEntry(slug="dashboard", title="Dashboard", url="/"),
+    MenuEntry(slug="supply", title="Supply", url="/supply"),
+    MenuEntry(slug="tables", title="Tables", url="/tables"),
+    MenuEntry(slug="superadmin", title="Superadmin", url="/superadmin"),
+)
+
+
+@blueprint.app_context_processor
+def inject_menu() -> Mapping[str, object]:
+    """Provide navigation menu entries to all templates."""
+
+    menu_entries, is_dynamic = _load_menu_entries()
+    return {
+        "menu_entries": menu_entries,
+        "menu_is_dynamic": is_dynamic,
+    }
+
+
+def _load_menu_entries() -> tuple[tuple[MenuEntry, ...], bool]:
+    rows = _fetch_rows()
+    if not rows:
+        return _FALLBACK_MENU, False
+
+    tree = _build_tree(rows)
+    if not tree:
+        logger.info("Menu table contains only hidden or invalid entries; using fallback")
+        return _FALLBACK_MENU, False
+
+    return tree, True
+
+
+def _fetch_rows() -> list[sqlite3.Row]:
+    conn = db()
+    try:
+        cursor = conn.execute(
+            """
+            SELECT
+                id,
+                slug,
+                title,
+                url,
+                icon,
+                parent_id,
+                position,
+                target
+            FROM ui_menu
+            WHERE visible = 1
+            ORDER BY COALESCE(parent_id, 0) ASC, position ASC, title ASC, id ASC
+            """
+        )
+        return list(cursor.fetchall())
+    except sqlite3.Error:
+        logger.exception("Failed to fetch menu entries from database")
+        return []
+    finally:
+        conn.close()
+
+
+def _build_tree(rows: Iterable[sqlite3.Row]) -> tuple[MenuEntry, ...]:
+    nodes: dict[int, _MenuNode] = {}
+    children: defaultdict[int | None, list[int]] = defaultdict(list)
+
+    ids = {int(row["id"]) for row in rows}
+
+    for row in rows:
+        node = _MenuNode(
+            id=int(row["id"]),
+            slug=str(row["slug"]),
+            title=str(row["title"]),
+            url=str(row["url"]) if row["url"] is not None else None,
+            icon=str(row["icon"]) if row["icon"] else None,
+            target=str(row["target"]) if row["target"] else None,
+            parent_id=int(row["parent_id"]) if row["parent_id"] is not None else None,
+        )
+        nodes[node.id] = node
+
+        parent_id = node.parent_id
+        if parent_id not in ids:
+            parent_id = None
+        children[parent_id].append(node.id)
+
+    top_level_ids = children.get(None, [])
+    if not top_level_ids:
+        # No explicit top-level entries; treat all as top-level.
+        top_level_ids = list(nodes.keys())
+
+    visited: set[int] = set()
+
+    def build_entry(node_id: int, trail: tuple[int, ...] = ()) -> MenuEntry:
+        if node_id in trail:
+            logger.warning("Detected cyclic menu relationship: trail=%s", trail + (node_id,))
+            base = nodes[node_id]
+            return MenuEntry(
+                slug=base.slug,
+                title=base.title,
+                url=base.url,
+                icon=base.icon,
+                target=base.target,
+                children=(),
+            )
+
+        base = nodes[node_id]
+        child_entries = []
+        next_trail = trail + (node_id,)
+        for child_id in children.get(node_id, []):
+            child_entries.append(build_entry(child_id, next_trail))
+        visited.add(node_id)
+        return MenuEntry(
+            slug=base.slug,
+            title=base.title,
+            url=base.url,
+            icon=base.icon,
+            target=base.target,
+            children=tuple(child_entries),
+        )
+
+    entries = [build_entry(node_id) for node_id in top_level_ids if node_id in nodes]
+
+    # Include any orphaned nodes that were not reached via parent references.
+    if len(visited) != len(nodes):
+        for node_id in nodes:
+            if node_id not in visited:
+                entries.append(build_entry(node_id))
+
+    return tuple(entries)
+
+
+__all__ = ["blueprint", "MenuEntry"]

--- a/dvorik/admin/server.py
+++ b/dvorik/admin/server.py
@@ -75,9 +75,10 @@ def _register_blueprints(app: Flask) -> None:
 
 
 def _iter_blueprints() -> Iterable[Blueprint]:
-    from .blueprints import home, superadmin, tables, supply
+    from .blueprints import home, menus, superadmin, tables, supply
 
     return (
+        menus.blueprint,
         home.blueprint,
         superadmin.blueprint,
         tables.blueprint,

--- a/dvorik/admin/templates/base.html
+++ b/dvorik/admin/templates/base.html
@@ -42,6 +42,172 @@
         text-decoration: none;
       }
 
+      .menu-toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        border: 1px solid transparent;
+        border-radius: 14px;
+        padding: 0.6rem 1rem;
+        background: var(--surface);
+        color: var(--text-primary);
+        font-weight: 600;
+        cursor: pointer;
+        box-shadow: var(--shadow);
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      .menu-toggle:hover,
+      .menu-toggle:focus-visible {
+        transform: translateY(-1px);
+        box-shadow: 0 16px 30px rgba(79, 70, 229, 0.2);
+      }
+
+      .menu-toggle:active {
+        transform: translateY(0);
+        box-shadow: var(--shadow);
+      }
+
+      .menu-toggle__icon {
+        font-size: 1.1rem;
+      }
+
+      .menu-offcanvas {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        pointer-events: none;
+        z-index: 1000;
+      }
+
+      .menu-offcanvas__backdrop {
+        flex: 1;
+        background: rgba(15, 23, 42, 0.45);
+        opacity: 0;
+        transition: opacity 0.3s ease;
+      }
+
+      .menu-offcanvas__panel {
+        width: min(320px, 85vw);
+        background: var(--surface);
+        box-shadow: 0 30px 60px rgba(15, 23, 42, 0.25);
+        transform: translateX(-110%);
+        transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1);
+        padding: 2rem 1.75rem 2.5rem;
+        overflow-y: auto;
+        outline: none;
+      }
+
+      .menu-offcanvas.is-open {
+        pointer-events: auto;
+      }
+
+      .menu-offcanvas.is-open .menu-offcanvas__backdrop {
+        opacity: 1;
+      }
+
+      .menu-offcanvas.is-open .menu-offcanvas__panel {
+        transform: translateX(0);
+      }
+
+      .menu-offcanvas__header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        margin-bottom: 1.5rem;
+      }
+
+      .menu-offcanvas__title {
+        margin: 0;
+        font-size: 1.25rem;
+        font-weight: 600;
+      }
+
+      .menu-offcanvas__close {
+        border: none;
+        background: none;
+        color: var(--text-muted);
+        font-size: 1.5rem;
+        cursor: pointer;
+        line-height: 1;
+        padding: 0.25rem;
+        border-radius: 8px;
+      }
+
+      .menu-offcanvas__close:hover,
+      .menu-offcanvas__close:focus-visible {
+        background: var(--surface-muted);
+        color: var(--text-primary);
+      }
+
+      .menu-offcanvas__fallback {
+        margin: 0 0 1.5rem;
+        padding: 0.75rem 1rem;
+        border-radius: 12px;
+        background: rgba(79, 70, 229, 0.08);
+        color: var(--text-muted);
+        font-size: 0.9rem;
+      }
+
+      .menu-nav,
+      .menu-nav__children {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+      }
+
+      .menu-nav {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+      }
+
+      .menu-nav__children {
+        margin-top: 0.3rem;
+        margin-left: 0.75rem;
+        padding-left: 1rem;
+        border-left: 1px solid var(--border-soft);
+      }
+
+      .menu-nav__item {
+        display: flex;
+        flex-direction: column;
+        gap: 0.3rem;
+      }
+
+      .menu-nav__link {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        padding: 0.55rem 0.75rem;
+        border-radius: 12px;
+        color: inherit;
+        text-decoration: none;
+        transition: background 0.2s ease, transform 0.2s ease;
+      }
+
+      .menu-nav__link:hover,
+      .menu-nav__link:focus-visible {
+        background: var(--surface-muted);
+        transform: translateX(2px);
+      }
+
+      .menu-nav__icon {
+        font-size: 1.1rem;
+        color: var(--accent);
+      }
+
+      .menu-nav__title {
+        font-weight: 600;
+      }
+
+      @media (max-width: 640px) {
+        .menu-offcanvas__panel {
+          width: min(360px, 100vw);
+        }
+      }
+
       .app-container {
         max-width: 1200px;
         margin: 0 auto;
@@ -54,6 +220,25 @@
         justify-content: space-between;
         gap: 1.5rem;
         margin-bottom: 2.5rem;
+      }
+
+      .header-left {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        flex: 1 1 auto;
+        min-width: 0;
+      }
+
+      .header-right {
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 1rem;
+      }
+
+      .header-right:empty {
+        display: none;
       }
 
       .branding h1 {
@@ -130,18 +315,129 @@
     {% block head_extra %}{% endblock %}
   </head>
   <body class="{{ body_class|default('') }}">
+    {% macro render_menu(items, level=0) -%}
+      <ul class="menu-nav{% if level %} menu-nav__children{% endif %}">
+        {%- for item in items %}
+          <li class="menu-nav__item">
+            {%- set href = item.url or '#' -%}
+            <a class="menu-nav__link" href="{{ href }}"{% if item.target %} target="{{ item.target }}"{% endif %}>
+              {% if item.icon %}<span class="menu-nav__icon" aria-hidden="true">{{ item.icon }}</span>{% endif %}
+              <span class="menu-nav__title">{{ item.title }}</span>
+            </a>
+            {% if item.children %}
+              {{ render_menu(item.children, level + 1) }}
+            {% endif %}
+          </li>
+        {%- endfor %}
+      </ul>
+    {%- endmacro %}
+
+    <aside class="menu-offcanvas" data-menu-offcanvas>
+      <div class="menu-offcanvas__backdrop" data-menu-backdrop></div>
+      <div
+        class="menu-offcanvas__panel"
+        id="admin-menu-offcanvas"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Navigation menu"
+        tabindex="-1"
+        data-menu-panel
+      >
+        <header class="menu-offcanvas__header">
+          <h2 class="menu-offcanvas__title">Navigation</h2>
+          <button class="menu-offcanvas__close" type="button" aria-label="Close menu" data-menu-close>
+            &times;
+          </button>
+        </header>
+        {% if not menu_is_dynamic %}
+          <p class="menu-offcanvas__fallback">
+            Using default menu layout. Configure entries via the Superadmin console to customise navigation.
+          </p>
+        {% endif %}
+        {{ render_menu(menu_entries) }}
+      </div>
+    </aside>
+
     <div class="app-container">
       <header class="app-header">
-        <div class="branding">
-          <h1 class="app-title">{% block header_title %}Dvorik Admin{% endblock %}</h1>
-          {% block header_subtitle %}{% endblock %}
+        <div class="header-left">
+          <button
+            class="menu-toggle"
+            type="button"
+            data-menu-open
+            aria-controls="admin-menu-offcanvas"
+            aria-expanded="false"
+          >
+            <span class="menu-toggle__icon" aria-hidden="true">☰</span>
+            <span class="menu-toggle__label">Menu</span>
+          </button>
+          <div class="branding">
+            <h1 class="app-title">{% block header_title %}Dvorik Admin{% endblock %}</h1>
+            {% block header_subtitle %}{% endblock %}
+          </div>
         </div>
-        {% block header_actions %}{% endblock %}
+        <div class="header-right">
+          {%- block header_actions %}{% endblock -%}
+        </div>
       </header>
       <main class="app-main">
         {% block content %}{% endblock %}
       </main>
     </div>
+    <script>
+      (() => {
+        const offcanvas = document.querySelector('[data-menu-offcanvas]');
+        if (!offcanvas) {
+          return;
+        }
+
+        const panel = offcanvas.querySelector('[data-menu-panel]');
+        const backdrop = offcanvas.querySelector('[data-menu-backdrop]');
+        const openButtons = document.querySelectorAll('[data-menu-open]');
+        const closeButtons = offcanvas.querySelectorAll('[data-menu-close]');
+
+        const setExpanded = (value) => {
+          openButtons.forEach((btn) => btn.setAttribute('aria-expanded', String(value)));
+        };
+
+        const openMenu = () => {
+          offcanvas.classList.add('is-open');
+          setExpanded(true);
+          if (panel) {
+            panel.focus({ preventScroll: true });
+          }
+        };
+
+        const closeMenu = () => {
+          offcanvas.classList.remove('is-open');
+          setExpanded(false);
+        };
+
+        openButtons.forEach((btn) => {
+          btn.addEventListener('click', (event) => {
+            event.preventDefault();
+            openMenu();
+          });
+        });
+
+        closeButtons.forEach((btn) => {
+          btn.addEventListener('click', (event) => {
+            event.preventDefault();
+            closeMenu();
+          });
+        });
+
+        if (backdrop) {
+          backdrop.addEventListener('click', closeMenu);
+        }
+
+        document.addEventListener('keydown', (event) => {
+          if (event.key === 'Escape' && offcanvas.classList.contains('is-open')) {
+            closeMenu();
+          }
+        });
+      })();
+    </script>
     {% block body_scripts %}{% endblock %}
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add an admin menus blueprint that exposes database-driven navigation items with a fallback set
- wire the menus blueprint into the server so the menu context is always available
- redesign the base layout with an offcanvas navigation drawer powered by the menu context and keyboard-accessible toggles

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcac791158832685b7817a5bcffafd