### PR TITLE
Implement superadmin console management UI

### DIFF
--- a/dvorik/admin/blueprints/superadmin.py
+++ b/dvorik/admin/blueprints/superadmin.py
@@ -1,10 +1,647 @@
 from __future__ import annotations
 
-from flask import Blueprint
+import json
+import logging
+from typing import Any
+
+import sqlite3
+
+from flask import Blueprint, Response, has_request_context, redirect, render_template, request, url_for
+
+from dvorik.db.conn import db
+
+logger = logging.getLogger(__name__)
 
 blueprint = Blueprint("superadmin", __name__, url_prefix="/superadmin")
 
 
 @blueprint.get("/")
 def dashboard() -> str:
-    return "Superadmin placeholder"
+    """Render the management console overview."""
+
+    data = _fetch_dashboard_data()
+    return render_template(
+        "superadmin/dashboard.html",
+        widgets=data["widgets"],
+        widget_instances=data["widget_instances"],
+        menu_entries=data["menu_entries"],
+        queries=data["queries"],
+        jobs=data["jobs"],
+        schedule_types=("daily", "cron"),
+    )
+
+
+@blueprint.post("/widgets/save")
+def save_widget() -> Response:
+    """Create or update a widget definition."""
+
+    widget_id = _parse_int(request.form.get("id"))
+    module = _clean_text(request.form.get("module"))
+    name = _clean_text(request.form.get("name"))
+    title = _clean_text(request.form.get("title"))
+    if not module or not name or not title:
+        return _redirect_to_dashboard("widgets", status="error", error="Module, name and title are required.")
+
+    description = _clean_text(request.form.get("description"))
+    entrypoint = _clean_text(request.form.get("entrypoint"))
+    config_schema = _clean_text(request.form.get("config_schema"))
+
+    payload = {
+        "module": module,
+        "name": name,
+        "title": title,
+        "description": description,
+        "entrypoint": entrypoint,
+        "config_schema": config_schema,
+    }
+
+    conn = db()
+    try:
+        with conn:
+            if widget_id is not None:
+                cursor = conn.execute(
+                    """
+                    UPDATE ui_widget
+                    SET module = ?, name = ?, title = ?, description = ?, entrypoint = ?, config_schema = ?
+                    WHERE id = ?
+                    """,
+                    (module, name, title, description, entrypoint, config_schema, widget_id),
+                )
+                if cursor.rowcount == 0:
+                    return _redirect_to_dashboard("widgets", status="error", error="Widget was not found.")
+                _log_audit(conn, "update", "ui_widget", widget_id, payload)
+            else:
+                cursor = conn.execute(
+                    """
+                    INSERT INTO ui_widget(module, name, title, description, entrypoint, config_schema)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (module, name, title, description, entrypoint, config_schema),
+                )
+                new_id = int(cursor.lastrowid)
+                _log_audit(conn, "create", "ui_widget", new_id, payload)
+    except sqlite3.Error as exc:  # pragma: no cover - defensive programming
+        logger.exception("Failed to save widget definition")
+        return _redirect_to_dashboard("widgets", status="error", error=_format_error(exc))
+    finally:
+        conn.close()
+
+    return _redirect_to_dashboard("widgets", status="saved")
+
+
+@blueprint.post("/widgets/delete")
+def delete_widget() -> Response:
+    """Delete a widget definition."""
+
+    widget_id = _parse_int(request.form.get("id"))
+    if widget_id is None:
+        return _redirect_to_dashboard("widgets", status="error", error="Widget id is required for deletion.")
+
+    conn = db()
+    try:
+        with conn:
+            cursor = conn.execute("DELETE FROM ui_widget WHERE id = ?", (widget_id,))
+            if cursor.rowcount == 0:
+                return _redirect_to_dashboard("widgets", status="error", error="Widget was not found.")
+            _log_audit(conn, "delete", "ui_widget", widget_id, {"deleted": True})
+    except sqlite3.Error as exc:  # pragma: no cover - defensive programming
+        logger.exception("Failed to delete widget definition")
+        return _redirect_to_dashboard("widgets", status="error", error=_format_error(exc))
+    finally:
+        conn.close()
+
+    return _redirect_to_dashboard("widgets", status="deleted")
+
+
+@blueprint.post("/widget-instances/save")
+def save_widget_instance() -> Response:
+    """Create or update a widget instance."""
+
+    instance_id = _parse_int(request.form.get("id"))
+    widget_id = _parse_int(request.form.get("widget_id"))
+    zone = _clean_text(request.form.get("zone"))
+    if widget_id is None or not zone:
+        return _redirect_to_dashboard(
+            "widget-instances",
+            status="error",
+            error="Widget, zone and position are required.",
+        )
+
+    try:
+        position = _parse_required_int(request.form.get("position"), field="position")
+    except ValueError as exc:
+        return _redirect_to_dashboard("widget-instances", status="error", error=str(exc))
+
+    config_json = _clean_text(request.form.get("config_json"))
+    enabled = 1 if request.form.get("enabled") else 0
+
+    payload = {
+        "widget_id": widget_id,
+        "zone": zone,
+        "position": position,
+        "config_json": config_json,
+        "enabled": bool(enabled),
+    }
+
+    conn = db()
+    try:
+        with conn:
+            if instance_id is not None:
+                cursor = conn.execute(
+                    """
+                    UPDATE ui_widget_instance
+                    SET widget_id = ?, zone = ?, position = ?, config_json = ?, enabled = ?
+                    WHERE id = ?
+                    """,
+                    (widget_id, zone, position, config_json, enabled, instance_id),
+                )
+                if cursor.rowcount == 0:
+                    return _redirect_to_dashboard("widget-instances", status="error", error="Widget instance was not found.")
+                _log_audit(conn, "update", "ui_widget_instance", instance_id, payload)
+            else:
+                cursor = conn.execute(
+                    """
+                    INSERT INTO ui_widget_instance(widget_id, zone, position, config_json, enabled)
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (widget_id, zone, position, config_json, enabled),
+                )
+                new_id = int(cursor.lastrowid)
+                _log_audit(conn, "create", "ui_widget_instance", new_id, payload)
+    except sqlite3.Error as exc:  # pragma: no cover - defensive programming
+        logger.exception("Failed to save widget instance")
+        return _redirect_to_dashboard("widget-instances", status="error", error=_format_error(exc))
+    finally:
+        conn.close()
+
+    return _redirect_to_dashboard("widget-instances", status="saved")
+
+
+@blueprint.post("/widget-instances/delete")
+def delete_widget_instance() -> Response:
+    """Remove a widget instance."""
+
+    instance_id = _parse_int(request.form.get("id"))
+    if instance_id is None:
+        return _redirect_to_dashboard("widget-instances", status="error", error="Instance id is required for deletion.")
+
+    conn = db()
+    try:
+        with conn:
+            cursor = conn.execute("DELETE FROM ui_widget_instance WHERE id = ?", (instance_id,))
+            if cursor.rowcount == 0:
+                return _redirect_to_dashboard(
+                    "widget-instances",
+                    status="error",
+                    error="Widget instance was not found.",
+                )
+            _log_audit(conn, "delete", "ui_widget_instance", instance_id, {"deleted": True})
+    except sqlite3.Error as exc:  # pragma: no cover - defensive programming
+        logger.exception("Failed to delete widget instance")
+        return _redirect_to_dashboard("widget-instances", status="error", error=_format_error(exc))
+    finally:
+        conn.close()
+
+    return _redirect_to_dashboard("widget-instances", status="deleted")
+
+
+@blueprint.post("/menu/save")
+def save_menu_entry() -> Response:
+    """Create or update a menu entry."""
+
+    entry_id = _parse_int(request.form.get("id"))
+    slug = _clean_text(request.form.get("slug"))
+    title = _clean_text(request.form.get("title"))
+    if not slug or not title:
+        return _redirect_to_dashboard("menu", status="error", error="Slug and title are required.")
+
+    url_value = _clean_text(request.form.get("url"))
+    icon = _clean_text(request.form.get("icon"))
+    target = _clean_text(request.form.get("target"))
+    try:
+        position = _parse_required_int(request.form.get("position"), field="position")
+    except ValueError as exc:
+        return _redirect_to_dashboard("menu", status="error", error=str(exc))
+
+    parent_id = _parse_int(request.form.get("parent_id"))
+    visible = 1 if request.form.get("visible") else 0
+
+    payload = {
+        "slug": slug,
+        "title": title,
+        "url": url_value,
+        "icon": icon,
+        "target": target,
+        "position": position,
+        "parent_id": parent_id,
+        "visible": bool(visible),
+    }
+
+    conn = db()
+    try:
+        with conn:
+            if entry_id is not None:
+                cursor = conn.execute(
+                    """
+                    UPDATE ui_menu
+                    SET slug = ?, title = ?, url = ?, icon = ?, parent_id = ?, position = ?, target = ?, visible = ?
+                    WHERE id = ?
+                    """,
+                    (slug, title, url_value, icon, parent_id, position, target, visible, entry_id),
+                )
+                if cursor.rowcount == 0:
+                    return _redirect_to_dashboard("menu", status="error", error="Menu entry was not found.")
+                _log_audit(conn, "update", "ui_menu", entry_id, payload)
+            else:
+                cursor = conn.execute(
+                    """
+                    INSERT INTO ui_menu(slug, title, url, icon, parent_id, position, target, visible)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (slug, title, url_value, icon, parent_id, position, target, visible),
+                )
+                new_id = int(cursor.lastrowid)
+                _log_audit(conn, "create", "ui_menu", new_id, payload)
+    except sqlite3.Error as exc:  # pragma: no cover - defensive programming
+        logger.exception("Failed to save menu entry")
+        return _redirect_to_dashboard("menu", status="error", error=_format_error(exc))
+    finally:
+        conn.close()
+
+    return _redirect_to_dashboard("menu", status="saved")
+
+
+@blueprint.post("/menu/delete")
+def delete_menu_entry() -> Response:
+    """Remove a menu entry."""
+
+    entry_id = _parse_int(request.form.get("id"))
+    if entry_id is None:
+        return _redirect_to_dashboard("menu", status="error", error="Entry id is required for deletion.")
+
+    conn = db()
+    try:
+        with conn:
+            cursor = conn.execute("DELETE FROM ui_menu WHERE id = ?", (entry_id,))
+            if cursor.rowcount == 0:
+                return _redirect_to_dashboard("menu", status="error", error="Menu entry was not found.")
+            _log_audit(conn, "delete", "ui_menu", entry_id, {"deleted": True})
+    except sqlite3.Error as exc:  # pragma: no cover - defensive programming
+        logger.exception("Failed to delete menu entry")
+        return _redirect_to_dashboard("menu", status="error", error=_format_error(exc))
+    finally:
+        conn.close()
+
+    return _redirect_to_dashboard("menu", status="deleted")
+
+
+@blueprint.post("/queries/save")
+def save_query() -> Response:
+    """Create or update a stored SQL query."""
+
+    key = _clean_text(request.form.get("key"))
+    sql_text = _clean_text(request.form.get("sql"))
+    if not key or not sql_text:
+        return _redirect_to_dashboard("queries", status="error", error="Key and SQL are required.")
+
+    description = _clean_text(request.form.get("description"))
+    original_key = _clean_text(request.form.get("original_key"))
+    is_update = bool(original_key)
+    if not is_update:
+        original_key = key
+
+    payload = {
+        "key": key,
+        "sql": sql_text,
+        "description": description,
+    }
+
+    conn = db()
+    try:
+        with conn:
+            if is_update:
+                cursor = conn.execute(
+                    """
+                    UPDATE query_registry
+                    SET key = ?, sql = ?, description = ?
+                    WHERE key = ?
+                    """,
+                    (key, sql_text, description, original_key),
+                )
+                if cursor.rowcount == 0:
+                    return _redirect_to_dashboard("queries", status="error", error="Query entry was not found.")
+                _log_audit(conn, "update", "query_registry", key, payload)
+            else:
+                conn.execute(
+                    """
+                    INSERT INTO query_registry(key, sql, description)
+                    VALUES (?, ?, ?)
+                    """,
+                    (key, sql_text, description),
+                )
+                _log_audit(conn, "create", "query_registry", key, payload)
+    except sqlite3.Error as exc:  # pragma: no cover - defensive programming
+        logger.exception("Failed to save query entry")
+        return _redirect_to_dashboard("queries", status="error", error=_format_error(exc))
+    finally:
+        conn.close()
+
+    return _redirect_to_dashboard("queries", status="saved")
+
+
+@blueprint.post("/queries/delete")
+def delete_query() -> Response:
+    """Delete a stored SQL query."""
+
+    key = _clean_text(request.form.get("key"))
+    if not key:
+        return _redirect_to_dashboard("queries", status="error", error="Key is required for deletion.")
+
+    conn = db()
+    try:
+        with conn:
+            cursor = conn.execute("DELETE FROM query_registry WHERE key = ?", (key,))
+            if cursor.rowcount == 0:
+                return _redirect_to_dashboard("queries", status="error", error="Query entry was not found.")
+            _log_audit(conn, "delete", "query_registry", key, {"deleted": True})
+    except sqlite3.Error as exc:  # pragma: no cover - defensive programming
+        logger.exception("Failed to delete query entry")
+        return _redirect_to_dashboard("queries", status="error", error=_format_error(exc))
+    finally:
+        conn.close()
+
+    return _redirect_to_dashboard("queries", status="deleted")
+
+
+@blueprint.post("/jobs/save")
+def save_job() -> Response:
+    """Create or update a scheduled job."""
+
+    job_id = _parse_int(request.form.get("id"))
+    name = _clean_text(request.form.get("name"))
+    schedule_type = _clean_text(request.form.get("schedule_type"))
+    if not name or not schedule_type:
+        return _redirect_to_dashboard("jobs", status="error", error="Name and schedule type are required.")
+
+    if schedule_type not in {"daily", "cron"}:
+        return _redirect_to_dashboard("jobs", status="error", error="Schedule type must be either 'daily' or 'cron'.")
+
+    schedule_expression = _clean_text(request.form.get("schedule_expression"))
+    task_module = _clean_text(request.form.get("task_module"))
+    task_name = _clean_text(request.form.get("task_name"))
+    if not task_module or not task_name:
+        return _redirect_to_dashboard("jobs", status="error", error="Task module and task name are required.")
+
+    next_run_at = _clean_text(request.form.get("next_run_at"))
+    last_run_at = _clean_text(request.form.get("last_run_at"))
+    config_json = _clean_text(request.form.get("config_json"))
+    enabled = 1 if request.form.get("enabled") else 0
+
+    payload = {
+        "name": name,
+        "schedule_type": schedule_type,
+        "schedule_expression": schedule_expression,
+        "task_module": task_module,
+        "task_name": task_name,
+        "next_run_at": next_run_at,
+        "last_run_at": last_run_at,
+        "config_json": config_json,
+        "enabled": bool(enabled),
+    }
+
+    conn = db()
+    try:
+        with conn:
+            if job_id is not None:
+                cursor = conn.execute(
+                    """
+                    UPDATE scheduled_job
+                    SET name = ?, schedule_type = ?, schedule_expression = ?, next_run_at = ?, last_run_at = ?,
+                        task_module = ?, task_name = ?, config_json = ?, enabled = ?
+                    WHERE id = ?
+                    """,
+                    (
+                        name,
+                        schedule_type,
+                        schedule_expression,
+                        next_run_at,
+                        last_run_at,
+                        task_module,
+                        task_name,
+                        config_json,
+                        enabled,
+                        job_id,
+                    ),
+                )
+                if cursor.rowcount == 0:
+                    return _redirect_to_dashboard("jobs", status="error", error="Scheduled job was not found.")
+                _log_audit(conn, "update", "scheduled_job", job_id, payload)
+            else:
+                cursor = conn.execute(
+                    """
+                    INSERT INTO scheduled_job(
+                        name, schedule_type, schedule_expression, next_run_at, last_run_at,
+                        task_module, task_name, config_json, enabled
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        name,
+                        schedule_type,
+                        schedule_expression,
+                        next_run_at,
+                        last_run_at,
+                        task_module,
+                        task_name,
+                        config_json,
+                        enabled,
+                    ),
+                )
+                new_id = int(cursor.lastrowid)
+                _log_audit(conn, "create", "scheduled_job", new_id, payload)
+    except sqlite3.Error as exc:  # pragma: no cover - defensive programming
+        logger.exception("Failed to save scheduled job")
+        return _redirect_to_dashboard("jobs", status="error", error=_format_error(exc))
+    finally:
+        conn.close()
+
+    return _redirect_to_dashboard("jobs", status="saved")
+
+
+@blueprint.post("/jobs/delete")
+def delete_job() -> Response:
+    """Delete a scheduled job."""
+
+    job_id = _parse_int(request.form.get("id"))
+    if job_id is None:
+        return _redirect_to_dashboard("jobs", status="error", error="Job id is required for deletion.")
+
+    conn = db()
+    try:
+        with conn:
+            cursor = conn.execute("DELETE FROM scheduled_job WHERE id = ?", (job_id,))
+            if cursor.rowcount == 0:
+                return _redirect_to_dashboard("jobs", status="error", error="Scheduled job was not found.")
+            _log_audit(conn, "delete", "scheduled_job", job_id, {"deleted": True})
+    except sqlite3.Error as exc:  # pragma: no cover - defensive programming
+        logger.exception("Failed to delete scheduled job")
+        return _redirect_to_dashboard("jobs", status="error", error=_format_error(exc))
+    finally:
+        conn.close()
+
+    return _redirect_to_dashboard("jobs", status="deleted")
+
+
+def _fetch_dashboard_data() -> dict[str, list[sqlite3.Row]]:
+    conn = db()
+    try:
+        widgets = list(
+            conn.execute(
+                """
+                SELECT id, module, name, title, description, entrypoint, config_schema
+                FROM ui_widget
+                ORDER BY module ASC, name ASC
+                """
+            ).fetchall()
+        )
+
+        widget_instances = list(
+            conn.execute(
+                """
+                SELECT
+                    wi.id,
+                    wi.widget_id,
+                    wi.zone,
+                    wi.position,
+                    wi.config_json,
+                    wi.enabled,
+                    w.module AS widget_module,
+                    w.name AS widget_name,
+                    w.title AS widget_title
+                FROM ui_widget_instance AS wi
+                LEFT JOIN ui_widget AS w ON w.id = wi.widget_id
+                ORDER BY wi.zone ASC, wi.position ASC, wi.id ASC
+                """
+            ).fetchall()
+        )
+
+        menu_entries = list(
+            conn.execute(
+                """
+                SELECT id, slug, title, url, icon, parent_id, position, target, visible
+                FROM ui_menu
+                ORDER BY COALESCE(parent_id, 0) ASC, position ASC, id ASC
+                """
+            ).fetchall()
+        )
+
+        queries = list(
+            conn.execute(
+                """
+                SELECT key, sql, description, updated_at
+                FROM query_registry
+                ORDER BY key ASC
+                """
+            ).fetchall()
+        )
+
+        jobs = list(
+            conn.execute(
+                """
+                SELECT id, name, schedule_type, schedule_expression, next_run_at, last_run_at,
+                       task_module, task_name, config_json, enabled
+                FROM scheduled_job
+                ORDER BY name ASC
+                """
+            ).fetchall()
+        )
+    finally:
+        conn.close()
+
+    return {
+        "widgets": widgets,
+        "widget_instances": widget_instances,
+        "menu_entries": menu_entries,
+        "queries": queries,
+        "jobs": jobs,
+    }
+
+
+def _redirect_to_dashboard(anchor: str | None, *, status: str, error: str | None = None) -> Response:
+    params: dict[str, str] = {"status": status}
+    if error:
+        params["error"] = _truncate(error)
+    location = url_for("superadmin.dashboard", **params)
+    if anchor:
+        location = f"{location}#{anchor}"
+    return redirect(location)
+
+
+def _parse_int(value: str | None) -> int | None:
+    if value is None:
+        return None
+    value = value.strip()
+    if not value:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def _parse_required_int(value: str | None, *, field: str) -> int:
+    if value is None:
+        raise ValueError(f"{field.capitalize()} must be an integer.")
+    value = value.strip()
+    if not value:
+        raise ValueError(f"{field.capitalize()} must be an integer.")
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise ValueError(f"{field.capitalize()} must be an integer.") from exc
+
+
+def _clean_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _log_audit(conn: sqlite3.Connection, action: str, entity: str, entity_id: int | str | None, payload: dict[str, Any]) -> None:
+    record: dict[str, Any] = dict(payload)
+    if has_request_context():
+        record.setdefault("remote_addr", request.remote_addr)
+        actor_username = request.headers.get("X-Actor")
+    else:  # pragma: no cover - defensive
+        actor_username = None
+    conn.execute(
+        """
+        INSERT INTO audit_log(actor_id, actor_username, action, entity, entity_id, payload_json)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (
+            None,
+            actor_username,
+            action,
+            entity,
+            str(entity_id) if entity_id is not None else None,
+            json.dumps(record, ensure_ascii=False),
+        ),
+    )
+
+
+def _format_error(exc: Exception) -> str:
+    message = str(exc).strip()
+    if not message:
+        message = exc.__class__.__name__
+    return _truncate(message)
+
+
+def _truncate(message: str, limit: int = 200) -> str:
+    if len(message) <= limit:
+        return message
+    return f"{message[: limit - 1]}…"
+
+
+__all__ = ["blueprint"]

--- a/dvorik/admin/templates/superadmin/dashboard.html
+++ b/dvorik/admin/templates/superadmin/dashboard.html
@@ -1,0 +1,669 @@
+{% extends "base.html" %}
+
+{% block title %}Superadmin Console · Dvorik{% endblock %}
+{% block header_title %}Superadmin Console{% endblock %}
+{% block header_subtitle %}
+  <p class="header-subtitle">Manage widgets, navigation, SQL overrides, and scheduled jobs.</p>
+{% endblock %}
+
+{% block base_styles %}
+  {{ super() }}
+  .header-subtitle {
+    margin: 0;
+    color: var(--text-muted);
+  }
+
+  .status-banner {
+    margin-bottom: 1.5rem;
+    padding: 1rem 1.25rem;
+    border-radius: 14px;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .status-banner--success {
+    background: rgba(34, 197, 94, 0.12);
+    color: #166534;
+  }
+
+  .status-banner--error {
+    background: rgba(239, 68, 68, 0.12);
+    color: #991b1b;
+  }
+
+  .superadmin-grid {
+    display: grid;
+    gap: 2.5rem;
+  }
+
+  .superadmin-section {
+    background: var(--surface);
+    border-radius: 20px;
+    box-shadow: var(--shadow);
+    padding: 2rem;
+  }
+
+  .superadmin-section header {
+    margin-bottom: 1.5rem;
+  }
+
+  .superadmin-section h2 {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 600;
+  }
+
+  .superadmin-section p {
+    margin: 0.35rem 0 0;
+    color: var(--text-muted);
+  }
+
+  .crud-form {
+    display: grid;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+    padding: 1.25rem;
+    border-radius: 16px;
+    border: 1px solid var(--border-soft);
+    background: var(--surface-muted);
+  }
+
+  .crud-form:last-child {
+    margin-bottom: 0;
+  }
+
+  .crud-form__row {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
+
+  .crud-form label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+  }
+
+  .crud-form input,
+  .crud-form select,
+  .crud-form textarea {
+    width: 100%;
+    border-radius: 12px;
+    border: 1px solid var(--border-soft);
+    background: var(--surface);
+    color: inherit;
+    font: inherit;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .crud-form textarea {
+    min-height: 6rem;
+    resize: vertical;
+  }
+
+  .crud-form__checkbox {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 600;
+    color: var(--text-muted);
+  }
+
+  .crud-form__checkbox input {
+    width: auto;
+    accent-color: var(--accent);
+  }
+
+  .crud-form__meta {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+  }
+
+  .form-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+  }
+
+  .button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+    border-radius: 12px;
+    padding: 0.65rem 1.15rem;
+    font-weight: 600;
+    border: none;
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+  }
+
+  .button--primary {
+    background: var(--accent);
+    color: #fff;
+    box-shadow: 0 10px 18px rgba(79, 70, 229, 0.18);
+  }
+
+  .button--muted {
+    background: var(--surface);
+    border: 1px solid var(--border-soft);
+  }
+
+  .button--danger {
+    background: #dc2626;
+    color: #fff;
+  }
+
+  .button:hover,
+  .button:focus-visible {
+    transform: translateY(-1px);
+  }
+
+  .empty-state {
+    margin: 0;
+    padding: 1rem 1.25rem;
+    border-radius: 14px;
+    border: 1px dashed var(--border-soft);
+    color: var(--text-muted);
+    background: rgba(79, 70, 229, 0.05);
+  }
+
+  details.create-toggle summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: var(--accent);
+  }
+
+  details.create-toggle {
+    margin-top: 1.5rem;
+  }
+
+  .section-divider {
+    margin: 2rem 0 1rem;
+    border: none;
+    border-top: 1px solid var(--border-soft);
+  }
+
+  @media (max-width: 720px) {
+    .superadmin-section {
+      padding: 1.5rem;
+    }
+
+    .crud-form {
+      padding: 1rem;
+    }
+  }
+{% endblock %}
+
+{% block content %}
+  {% set status = request.args.get('status') %}
+  {% set error = request.args.get('error') %}
+  {% if status or error %}
+    <div class="status-banner {% if error %}status-banner--error{% else %}status-banner--success{% endif %}">
+      {% if error %}
+        {{ error }}
+      {% elif status == 'saved' %}
+        Changes saved successfully.
+      {% elif status == 'deleted' %}
+        Entry removed.
+      {% else %}
+        Operation completed.
+      {% endif %}
+    </div>
+  {% endif %}
+
+  <div class="superadmin-grid">
+    <section id="widgets" class="superadmin-section">
+      <header>
+        <h2>Widget catalog</h2>
+        <p>Register reusable widgets that can be placed on dashboard zones.</p>
+      </header>
+
+      {% if widgets %}
+        {% for widget in widgets %}
+          <form class="crud-form" method="post" action="{{ url_for('superadmin.save_widget') }}">
+            <input type="hidden" name="id" value="{{ widget['id'] }}">
+            <div class="crud-form__row">
+              <label>Module
+                <input type="text" name="module" value="{{ widget['module'] }}" required>
+              </label>
+              <label>Name
+                <input type="text" name="name" value="{{ widget['name'] }}" required>
+              </label>
+              <label>Title
+                <input type="text" name="title" value="{{ widget['title'] }}" required>
+              </label>
+            </div>
+            <div class="crud-form__row">
+              <label>Entrypoint
+                <input type="text" name="entrypoint" value="{{ widget['entrypoint'] or '' }}">
+              </label>
+              <label>Config schema
+                <textarea name="config_schema" rows="3">{{ widget['config_schema'] or '' }}</textarea>
+              </label>
+            </div>
+            <label>Description
+              <textarea name="description" rows="3">{{ widget['description'] or '' }}</textarea>
+            </label>
+            <div class="form-actions">
+              <button class="button button--primary" type="submit">Save widget</button>
+              <button
+                class="button button--danger"
+                type="submit"
+                formaction="{{ url_for('superadmin.delete_widget') }}"
+                formmethod="post"
+                formnovalidate
+              >Delete</button>
+            </div>
+          </form>
+        {% endfor %}
+      {% else %}
+        <p class="empty-state">No widget definitions yet.</p>
+      {% endif %}
+
+      <details class="create-toggle">
+        <summary>Add new widget</summary>
+        <form class="crud-form" method="post" action="{{ url_for('superadmin.save_widget') }}">
+          <div class="crud-form__row">
+            <label>Module
+              <input type="text" name="module" placeholder="dvorik.admin.widgets.builtin" required>
+            </label>
+            <label>Name
+              <input type="text" name="name" placeholder="LowStockWidget" required>
+            </label>
+            <label>Title
+              <input type="text" name="title" placeholder="Low stock" required>
+            </label>
+          </div>
+          <div class="crud-form__row">
+            <label>Entrypoint
+              <input type="text" name="entrypoint" placeholder="register">
+            </label>
+            <label>Config schema
+              <textarea name="config_schema" rows="3" placeholder='{"type": "object"}'></textarea>
+            </label>
+          </div>
+          <label>Description
+            <textarea name="description" rows="3" placeholder="Describe what the widget does."></textarea>
+          </label>
+          <div class="form-actions">
+            <button class="button button--primary" type="submit">Create widget</button>
+          </div>
+        </form>
+      </details>
+    </section>
+
+    <section id="widget-instances" class="superadmin-section">
+      <header>
+        <h2>Widget instances</h2>
+        <p>Attach widgets to dashboard zones and control their ordering.</p>
+      </header>
+
+      {% if widget_instances %}
+        {% for instance in widget_instances %}
+          <form class="crud-form" method="post" action="{{ url_for('superadmin.save_widget_instance') }}">
+            <input type="hidden" name="id" value="{{ instance['id'] }}">
+            <div class="crud-form__row">
+              <label>Widget
+                <select name="widget_id" required>
+                  <option value="">-- Choose widget --</option>
+                  {% for widget in widgets %}
+                    <option value="{{ widget['id'] }}" {% if widget['id'] == instance['widget_id'] %}selected{% endif %}>
+                      {{ widget['title'] }} · {{ widget['module'] }}.{{ widget['name'] }}
+                    </option>
+                  {% endfor %}
+                </select>
+              </label>
+              <label>Zone
+                <input type="text" name="zone" value="{{ instance['zone'] }}" required>
+              </label>
+              <label>Position
+                <input type="number" name="position" value="{{ instance['position'] }}" required>
+              </label>
+            </div>
+            <label>Config JSON
+              <textarea name="config_json" rows="3">{{ instance['config_json'] or '' }}</textarea>
+            </label>
+            <label class="crud-form__checkbox">
+              <input type="checkbox" name="enabled" value="1" {% if instance['enabled'] %}checked{% endif %}>
+              Enabled
+            </label>
+            <div class="form-actions">
+              <button class="button button--primary" type="submit">Save instance</button>
+              <button
+                class="button button--danger"
+                type="submit"
+                formaction="{{ url_for('superadmin.delete_widget_instance') }}"
+                formmethod="post"
+                formnovalidate
+              >Delete</button>
+            </div>
+            <p class="crud-form__meta">{{ instance['widget_title'] or 'Unlinked widget' }}</p>
+          </form>
+        {% endfor %}
+      {% else %}
+        <p class="empty-state">No widget placements configured.</p>
+      {% endif %}
+
+      <details class="create-toggle">
+        <summary>Add new placement</summary>
+        <form class="crud-form" method="post" action="{{ url_for('superadmin.save_widget_instance') }}">
+          <div class="crud-form__row">
+            <label>Widget
+              <select name="widget_id" required>
+                <option value="">-- Choose widget --</option>
+                {% for widget in widgets %}
+                  <option value="{{ widget['id'] }}">
+                    {{ widget['title'] }} · {{ widget['module'] }}.{{ widget['name'] }}
+                  </option>
+                {% endfor %}
+              </select>
+            </label>
+            <label>Zone
+              <input type="text" name="zone" placeholder="home.main" required>
+            </label>
+            <label>Position
+              <input type="number" name="position" value="0" required>
+            </label>
+          </div>
+          <label>Config JSON
+            <textarea name="config_json" rows="3" placeholder='{"limit": 5}'></textarea>
+          </label>
+          <label class="crud-form__checkbox">
+            <input type="checkbox" name="enabled" value="1" checked>
+            Enabled
+          </label>
+          <div class="form-actions">
+            <button class="button button--primary" type="submit">Create placement</button>
+          </div>
+        </form>
+      </details>
+    </section>
+
+    <section id="menu" class="superadmin-section">
+      <header>
+        <h2>Navigation menu</h2>
+        <p>Compose the admin offcanvas navigation structure.</p>
+      </header>
+
+      {% if menu_entries %}
+        {% for entry in menu_entries %}
+          <form class="crud-form" method="post" action="{{ url_for('superadmin.save_menu_entry') }}">
+            <input type="hidden" name="id" value="{{ entry['id'] }}">
+            <div class="crud-form__row">
+              <label>Slug
+                <input type="text" name="slug" value="{{ entry['slug'] }}" required>
+              </label>
+              <label>Title
+                <input type="text" name="title" value="{{ entry['title'] }}" required>
+              </label>
+              <label>URL
+                <input type="text" name="url" value="{{ entry['url'] or '' }}">
+              </label>
+            </div>
+            <div class="crud-form__row">
+              <label>Icon
+                <input type="text" name="icon" value="{{ entry['icon'] or '' }}" placeholder="Emoji or icon code">
+              </label>
+              <label>Parent
+                <select name="parent_id">
+                  <option value="">— No parent —</option>
+                  {% for candidate in menu_entries %}
+                    {% if candidate['id'] != entry['id'] %}
+                      <option value="{{ candidate['id'] }}" {% if candidate['id'] == entry['parent_id'] %}selected{% endif %}>
+                        {{ candidate['title'] }} ({{ candidate['slug'] }})
+                      </option>
+                    {% endif %}
+                  {% endfor %}
+                </select>
+              </label>
+              <label>Position
+                <input type="number" name="position" value="{{ entry['position'] }}" required>
+              </label>
+            </div>
+            <div class="crud-form__row">
+              <label>Target
+                <input type="text" name="target" value="{{ entry['target'] or '' }}" placeholder="_blank">
+              </label>
+              <label class="crud-form__checkbox">
+                <input type="checkbox" name="visible" value="1" {% if entry['visible'] %}checked{% endif %}>
+                Visible
+              </label>
+            </div>
+            <div class="form-actions">
+              <button class="button button--primary" type="submit">Save entry</button>
+              <button
+                class="button button--danger"
+                type="submit"
+                formaction="{{ url_for('superadmin.delete_menu_entry') }}"
+                formmethod="post"
+                formnovalidate
+              >Delete</button>
+            </div>
+          </form>
+        {% endfor %}
+      {% else %}
+        <p class="empty-state">No custom menu entries defined. Fallback menu is used.</p>
+      {% endif %}
+
+      <details class="create-toggle">
+        <summary>Add new menu item</summary>
+        <form class="crud-form" method="post" action="{{ url_for('superadmin.save_menu_entry') }}">
+          <div class="crud-form__row">
+            <label>Slug
+              <input type="text" name="slug" placeholder="superadmin" required>
+            </label>
+            <label>Title
+              <input type="text" name="title" placeholder="Superadmin" required>
+            </label>
+            <label>URL
+              <input type="text" name="url" placeholder="/superadmin">
+            </label>
+          </div>
+          <div class="crud-form__row">
+            <label>Icon
+              <input type="text" name="icon" placeholder="🛠">
+            </label>
+            <label>Parent
+              <select name="parent_id">
+                <option value="">— No parent —</option>
+                {% for candidate in menu_entries %}
+                  <option value="{{ candidate['id'] }}">{{ candidate['title'] }} ({{ candidate['slug'] }})</option>
+                {% endfor %}
+              </select>
+            </label>
+            <label>Position
+              <input type="number" name="position" value="0" required>
+            </label>
+          </div>
+          <div class="crud-form__row">
+            <label>Target
+              <input type="text" name="target" placeholder="_self">
+            </label>
+            <label class="crud-form__checkbox">
+              <input type="checkbox" name="visible" value="1" checked>
+              Visible
+            </label>
+          </div>
+          <div class="form-actions">
+            <button class="button button--primary" type="submit">Create entry</button>
+          </div>
+        </form>
+      </details>
+    </section>
+
+    <section id="queries" class="superadmin-section">
+      <header>
+        <h2>Query registry</h2>
+        <p>Override SQL statements used by repositories or admin tables.</p>
+      </header>
+
+      {% if queries %}
+        {% for query in queries %}
+          <form class="crud-form" method="post" action="{{ url_for('superadmin.save_query') }}">
+            <input type="hidden" name="original_key" value="{{ query['key'] }}">
+            <label>Key
+              <input type="text" name="key" value="{{ query['key'] }}" required>
+            </label>
+            <label>SQL
+              <textarea name="sql" rows="6" required>{{ query['sql'] }}</textarea>
+            </label>
+            <label>Description
+              <textarea name="description" rows="3">{{ query['description'] or '' }}</textarea>
+            </label>
+            {% if query['updated_at'] %}
+              <p class="crud-form__meta">Updated: {{ query['updated_at'] }}</p>
+            {% endif %}
+            <div class="form-actions">
+              <button class="button button--primary" type="submit">Save query</button>
+              <button
+                class="button button--danger"
+                type="submit"
+                formaction="{{ url_for('superadmin.delete_query') }}"
+                formmethod="post"
+                formnovalidate
+              >Delete</button>
+            </div>
+          </form>
+        {% endfor %}
+      {% else %}
+        <p class="empty-state">No overrides configured. Built-in SQL will be used.</p>
+      {% endif %}
+
+      <details class="create-toggle">
+        <summary>Add new override</summary>
+        <form class="crud-form" method="post" action="{{ url_for('superadmin.save_query') }}">
+          <label>Key
+            <input type="text" name="key" placeholder="repo.product.low_stock" required>
+          </label>
+          <label>SQL
+            <textarea name="sql" rows="6" placeholder="SELECT * FROM product" required></textarea>
+          </label>
+          <label>Description
+            <textarea name="description" rows="3" placeholder="Explain the override intent."></textarea>
+          </label>
+          <div class="form-actions">
+            <button class="button button--primary" type="submit">Create override</button>
+          </div>
+        </form>
+      </details>
+    </section>
+
+    <section id="jobs" class="superadmin-section">
+      <header>
+        <h2>Scheduled jobs</h2>
+        <p>Configure background jobs executed by the scheduler.</p>
+      </header>
+
+      {% if jobs %}
+        {% for job in jobs %}
+          <form class="crud-form" method="post" action="{{ url_for('superadmin.save_job') }}">
+            <input type="hidden" name="id" value="{{ job['id'] }}">
+            <div class="crud-form__row">
+              <label>Name
+                <input type="text" name="name" value="{{ job['name'] }}" required>
+              </label>
+              <label>Schedule type
+                <select name="schedule_type" required>
+                  {% for schedule in schedule_types %}
+                    <option value="{{ schedule }}" {% if job['schedule_type'] == schedule %}selected{% endif %}>{{ schedule|capitalize }}</option>
+                  {% endfor %}
+                </select>
+              </label>
+              <label>Schedule expression
+                <input type="text" name="schedule_expression" value="{{ job['schedule_expression'] or '' }}" placeholder="0 9 * * *">
+              </label>
+            </div>
+            <div class="crud-form__row">
+              <label>Task module
+                <input type="text" name="task_module" value="{{ job['task_module'] }}" required>
+              </label>
+              <label>Task name
+                <input type="text" name="task_name" value="{{ job['task_name'] }}" required>
+              </label>
+            </div>
+            <div class="crud-form__row">
+              <label>Next run at
+                <input type="text" name="next_run_at" value="{{ job['next_run_at'] or '' }}" placeholder="2024-05-01 09:00">
+              </label>
+              <label>Last run at
+                <input type="text" name="last_run_at" value="{{ job['last_run_at'] or '' }}">
+              </label>
+            </div>
+            <label>Config JSON
+              <textarea name="config_json" rows="4">{{ job['config_json'] or '' }}</textarea>
+            </label>
+            <label class="crud-form__checkbox">
+              <input type="checkbox" name="enabled" value="1" {% if job['enabled'] %}checked{% endif %}>
+              Enabled
+            </label>
+            <div class="form-actions">
+              <button class="button button--primary" type="submit">Save job</button>
+              <button
+                class="button button--danger"
+                type="submit"
+                formaction="{{ url_for('superadmin.delete_job') }}"
+                formmethod="post"
+                formnovalidate
+              >Delete</button>
+            </div>
+          </form>
+        {% endfor %}
+      {% else %}
+        <p class="empty-state">No scheduled jobs defined.</p>
+      {% endif %}
+
+      <details class="create-toggle">
+        <summary>Add new job</summary>
+        <form class="crud-form" method="post" action="{{ url_for('superadmin.save_job') }}">
+          <div class="crud-form__row">
+            <label>Name
+              <input type="text" name="name" placeholder="imports.daily_digest" required>
+            </label>
+            <label>Schedule type
+              <select name="schedule_type" required>
+                {% for schedule in schedule_types %}
+                  <option value="{{ schedule }}">{{ schedule|capitalize }}</option>
+                {% endfor %}
+              </select>
+            </label>
+            <label>Schedule expression
+              <input type="text" name="schedule_expression" placeholder="0 6 * * *">
+            </label>
+          </div>
+          <div class="crud-form__row">
+            <label>Task module
+              <input type="text" name="task_module" placeholder="dvorik.services.notify" required>
+            </label>
+            <label>Task name
+              <input type="text" name="task_name" placeholder="send_daily_digests" required>
+            </label>
+          </div>
+          <div class="crud-form__row">
+            <label>Next run at
+              <input type="text" name="next_run_at" placeholder="2024-05-01 06:00">
+            </label>
+            <label>Last run at
+              <input type="text" name="last_run_at">
+            </label>
+          </div>
+          <label>Config JSON
+            <textarea name="config_json" rows="4" placeholder='{"limit": 20}'></textarea>
+          </label>
+          <label class="crud-form__checkbox">
+            <input type="checkbox" name="enabled" value="1" checked>
+            Enabled
+          </label>
+          <div class="form-actions">
+            <button class="button button--primary" type="submit">Create job</button>
+          </div>
+        </form>
+      </details>
+    </section>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- replace the placeholder superadmin blueprint with CRUD endpoints for widgets, menu entries, query registry overrides, and scheduled jobs
- add a styled dashboard template that surfaces forms for managing each resource and reports operation status

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68dcae0080c08326845974a3b618d72a