### PR TITLE
Add admin generic table browser UI

### DIFF
--- a/dvorik/admin/blueprints/tables.py
+++ b/dvorik/admin/blueprints/tables.py
@@ -1,10 +1,435 @@
 from __future__ import annotations
 
-from flask import Blueprint
+from dataclasses import dataclass
+import logging
+import re
+import sqlite3
+from typing import Iterable, Mapping, Sequence
+
+from flask import Blueprint, Response, abort, redirect, render_template, request, url_for
+
+from dvorik.db.conn import db
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class TableMeta:
+    """Metadata about a browsable database table."""
+
+    name: str
+    row_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class TableColumn:
+    """Description of a table column derived from PRAGMA information."""
+
+    name: str
+    declared_type: str
+    notnull: bool
+    default: str | None
+    primary_key: bool
+
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 blueprint = Blueprint("tables", __name__, url_prefix="/tables")
 
 
 @blueprint.get("/")
 def list_tables() -> str:
-    return "Tables placeholder"
+    """Display available database tables."""
+
+    tables = _fetch_browsable_tables()
+    status, message = _extract_status()
+    return render_template(
+        "tables/table.html",
+        tables=tables,
+        active_table=None,
+        columns=(),
+        rows=(),
+        page=1,
+        pages=1,
+        status=status,
+        message=message,
+    )
+
+
+@blueprint.get("/<table_name>/")
+def browse_table(table_name: str) -> str:
+    """Render rows for a specific database table."""
+
+    tables = _fetch_browsable_tables()
+    table = _get_table_meta(tables, table_name)
+
+    page = _parse_positive_int(request.args.get("page"), default=1)
+    per_page = 50
+    offset = (page - 1) * per_page
+
+    columns = _fetch_table_columns(table.name)
+    rows = _fetch_table_rows(table.name, columns, limit=per_page, offset=offset)
+
+    total_pages = max((table.row_count + per_page - 1) // per_page, 1)
+    has_prev = page > 1
+    has_next = page < total_pages
+    status, message = _extract_status()
+
+    return render_template(
+        "tables/table.html",
+        tables=tables,
+        active_table=table,
+        columns=columns,
+        rows=rows,
+        page=page,
+        pages=total_pages,
+        has_prev=has_prev,
+        has_next=has_next,
+        prev_page=page - 1 if has_prev else 1,
+        next_page=page + 1 if has_next else total_pages,
+        status=status,
+        message=message,
+    )
+
+
+@blueprint.get("/<table_name>/new")
+def new_row_form(table_name: str) -> str:
+    """Render the creation form for ``table_name``."""
+
+    tables = _fetch_browsable_tables()
+    table = _get_table_meta(tables, table_name)
+    columns = _fetch_table_columns(table.name)
+
+    return _render_form(
+        table=table,
+        columns=columns,
+        values={col.name: "" for col in columns},
+        errors={},
+        mode="create",
+    )
+
+
+@blueprint.post("/<table_name>/new")
+def create_row(table_name: str) -> Response | str:
+    """Insert a new record into ``table_name``."""
+
+    tables = _fetch_browsable_tables()
+    table = _get_table_meta(tables, table_name)
+    columns = _fetch_table_columns(table.name)
+
+    form_values = {col.name: request.form.get(col.name, "") for col in columns}
+    errors: dict[str, str] = {}
+    payload = []
+    field_names: list[str] = []
+
+    for column in columns:
+        raw_value = form_values[column.name]
+
+        if column.primary_key and not raw_value:
+            # Skip auto-generated primary keys when no value provided.
+            continue
+
+        value = _normalise_value(raw_value)
+        if value is None and column.notnull and column.default is None:
+            errors[column.name] = "Value is required."
+            continue
+
+        field_names.append(column.name)
+        payload.append(value)
+
+    if errors:
+        return _render_form(table, columns, form_values, errors, mode="create")
+
+    if field_names:
+        insert_sql = _build_insert_sql(table.name, field_names)
+    else:
+        insert_sql = f"INSERT INTO {_quote_identifier(table.name)} DEFAULT VALUES"
+
+    conn = db()
+    try:
+        with conn:
+            conn.execute(insert_sql, payload if field_names else ())
+    except sqlite3.Error as exc:
+        logger.exception("Failed to insert row into table %s", table.name)
+        errors["__form__"] = _format_error(exc)
+        return _render_form(table, columns, form_values, errors, mode="create")
+    finally:
+        conn.close()
+
+    return _redirect_to_table(table.name, status="created")
+
+
+@blueprint.get("/<table_name>/<int:rowid>/edit")
+def edit_row_form(table_name: str, rowid: int) -> str | Response:
+    """Render the edit form for ``rowid`` in ``table_name``."""
+
+    tables = _fetch_browsable_tables()
+    table = _get_table_meta(tables, table_name)
+    columns = _fetch_table_columns(table.name)
+
+    row = _fetch_single_row(table.name, rowid, columns)
+    if row is None:
+        return _redirect_to_table(table.name, status="error", message="Row was not found.")
+
+    values = {column.name: row[column.name] for column in columns}
+    return _render_form(table, columns, values, errors={}, mode="edit", rowid=rowid)
+
+
+@blueprint.post("/<table_name>/<int:rowid>/edit")
+def update_row(table_name: str, rowid: int) -> Response | str:
+    """Persist modifications to an existing row."""
+
+    tables = _fetch_browsable_tables()
+    table = _get_table_meta(tables, table_name)
+    columns = _fetch_table_columns(table.name)
+
+    form_values = {col.name: request.form.get(col.name, "") for col in columns}
+    assignments: list[str] = []
+    payload: list[object] = []
+    errors: dict[str, str] = {}
+
+    for column in columns:
+        if column.primary_key:
+            continue
+
+        raw_value = form_values[column.name]
+        value = _normalise_value(raw_value)
+        if value is None and column.notnull and column.default is None:
+            errors[column.name] = "Value is required."
+            continue
+
+        assignments.append(f"{_quote_identifier(column.name)} = ?")
+        payload.append(value)
+
+    if errors:
+        return _render_form(table, columns, form_values, errors, mode="edit", rowid=rowid)
+
+    if not assignments:
+        errors["__form__"] = "There are no editable columns for this table."
+        return _render_form(table, columns, form_values, errors, mode="edit", rowid=rowid)
+
+    payload.append(rowid)
+    update_sql = f"UPDATE {_quote_identifier(table.name)} SET {', '.join(assignments)} WHERE rowid = ?"
+
+    conn = db()
+    try:
+        with conn:
+            cursor = conn.execute(update_sql, payload)
+            if cursor.rowcount == 0:
+                return _redirect_to_table(table.name, status="error", message="Row was not found.")
+    except sqlite3.Error as exc:
+        logger.exception("Failed to update row %s in table %s", rowid, table.name)
+        errors["__form__"] = _format_error(exc)
+        return _render_form(table, columns, form_values, errors, mode="edit", rowid=rowid)
+    finally:
+        conn.close()
+
+    return _redirect_to_table(table.name, status="updated")
+
+
+@blueprint.post("/<table_name>/<int:rowid>/delete")
+def delete_row(table_name: str, rowid: int) -> Response:
+    """Remove a row from ``table_name`` identified by ``rowid``."""
+
+    tables = _fetch_browsable_tables()
+    table = _get_table_meta(tables, table_name)
+
+    conn = db()
+    try:
+        with conn:
+            cursor = conn.execute(
+                f"DELETE FROM {_quote_identifier(table.name)} WHERE rowid = ?",
+                (rowid,),
+            )
+            if cursor.rowcount == 0:
+                return _redirect_to_table(table.name, status="error", message="Row was not found.")
+    except sqlite3.Error as exc:
+        logger.exception("Failed to delete row %s in table %s", rowid, table.name)
+        return _redirect_to_table(table.name, status="error", message=_format_error(exc))
+    finally:
+        conn.close()
+
+    return _redirect_to_table(table.name, status="deleted")
+
+
+def _render_form(
+    table: TableMeta,
+    columns: Sequence[TableColumn],
+    values: Mapping[str, object | None],
+    errors: Mapping[str, str],
+    *,
+    mode: str,
+    rowid: int | None = None,
+) -> str:
+    """Render the create/edit form template."""
+
+    return render_template(
+        "tables/form.html",
+        table=table,
+        columns=columns,
+        values=values,
+        errors=errors,
+        mode=mode,
+        rowid=rowid,
+    )
+
+
+def _fetch_browsable_tables() -> tuple[TableMeta, ...]:
+    conn = db()
+    try:
+        rows = conn.execute(
+            """
+            SELECT name, sql
+            FROM sqlite_master
+            WHERE type = 'table'
+              AND name NOT LIKE 'sqlite_%'
+            ORDER BY name
+            """,
+        ).fetchall()
+
+        tables: list[TableMeta] = []
+        for row in rows:
+            name = str(row["name"])
+            definition = (row["sql"] or "").upper()
+            if "VIRTUAL TABLE" in definition:
+                continue
+
+            count = _count_rows(conn, name)
+            tables.append(TableMeta(name=name, row_count=count))
+
+        return tuple(tables)
+    finally:
+        conn.close()
+
+
+def _count_rows(conn: sqlite3.Connection, table: str) -> int:
+    try:
+        cursor = conn.execute(
+            f"SELECT COUNT(*) FROM {_quote_identifier(table)}",
+        )
+    except sqlite3.Error as exc:  # pragma: no cover - defensive guard
+        logger.exception("Unable to count rows for table %s", table)
+        raise
+
+    result = cursor.fetchone()
+    return int(result[0]) if result else 0
+
+
+def _fetch_table_columns(table: str) -> tuple[TableColumn, ...]:
+    conn = db()
+    try:
+        pragma_sql = f"PRAGMA table_info({_quote_identifier(table)})"
+        rows = conn.execute(pragma_sql).fetchall()
+    finally:
+        conn.close()
+
+    if not rows:
+        abort(404)
+
+    columns: list[TableColumn] = []
+    for row in rows:
+        columns.append(
+            TableColumn(
+                name=str(row["name"]),
+                declared_type=str(row["type"] or ""),
+                notnull=bool(row["notnull"]),
+                default=str(row["dflt_value"]) if row["dflt_value"] is not None else None,
+                primary_key=bool(row["pk"]),
+            )
+        )
+
+    return tuple(columns)
+
+
+def _fetch_table_rows(
+    table: str,
+    columns: Sequence[TableColumn],
+    *,
+    limit: int,
+    offset: int,
+) -> tuple[sqlite3.Row, ...]:
+    conn = db()
+    try:
+        column_list = ", ".join(_quote_identifier(col.name) for col in columns)
+        sql = (
+            f"SELECT rowid AS __rowid__, {column_list} "
+            f"FROM {_quote_identifier(table)} ORDER BY rowid LIMIT ? OFFSET ?"
+        )
+        rows = conn.execute(sql, (limit, offset)).fetchall()
+        return tuple(rows)
+    finally:
+        conn.close()
+
+
+def _fetch_single_row(
+    table: str,
+    rowid: int,
+    columns: Sequence[TableColumn],
+) -> sqlite3.Row | None:
+    conn = db()
+    try:
+        column_list = ", ".join(_quote_identifier(col.name) for col in columns)
+        sql = (
+            f"SELECT rowid AS __rowid__, {column_list} "
+            f"FROM {_quote_identifier(table)} WHERE rowid = ?"
+        )
+        row = conn.execute(sql, (rowid,)).fetchone()
+        return row
+    finally:
+        conn.close()
+
+
+def _get_table_meta(tables: Iterable[TableMeta], name: str) -> TableMeta:
+    for table in tables:
+        if table.name == name:
+            return table
+    abort(404)
+
+
+def _build_insert_sql(table: str, columns: Sequence[str]) -> str:
+    quoted_columns = ", ".join(_quote_identifier(col) for col in columns)
+    placeholders = ", ".join("?" for _ in columns)
+    return f"INSERT INTO {_quote_identifier(table)} ({quoted_columns}) VALUES ({placeholders})"
+
+
+def _quote_identifier(identifier: str) -> str:
+    if not _IDENTIFIER_RE.match(identifier):  # pragma: no cover - defensive guard
+        raise ValueError(f"Unsafe identifier: {identifier!r}")
+    return f'"{identifier}"'
+
+
+def _normalise_value(value: str | None) -> object | None:
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped if stripped != "" else None
+
+
+def _parse_positive_int(raw_value: str | None, *, default: int) -> int:
+    try:
+        value = int(raw_value) if raw_value is not None else default
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _redirect_to_table(table: str, *, status: str, message: str | None = None) -> Response:
+    params: dict[str, str] = {"status": status}
+    if message:
+        params["message"] = message
+    return redirect(url_for("tables.browse_table", table_name=table, **params))
+
+
+def _extract_status() -> tuple[str | None, str | None]:
+    status = request.args.get("status")
+    message = request.args.get("message")
+    if status == "error" and message is None:
+        message = "An unexpected error occurred."
+    return status, message
+
+
+def _format_error(exc: sqlite3.Error) -> str:
+    return str(exc).strip() or exc.__class__.__name__
+
+
+__all__ = ["blueprint"]

--- a/dvorik/admin/templates/base.html
+++ b/dvorik/admin/templates/base.html
@@ -198,6 +198,298 @@
         color: var(--accent);
       }
 
+      .tables-layout {
+        display: flex;
+        gap: 2rem;
+        align-items: flex-start;
+      }
+
+      .tables-sidebar {
+        width: 220px;
+        background: var(--surface);
+        border-radius: 16px;
+        box-shadow: var(--shadow);
+        padding: 1.25rem 1rem;
+        position: sticky;
+        top: 1.5rem;
+        max-height: calc(100vh - 3rem);
+        overflow-y: auto;
+      }
+
+      .tables-sidebar__title {
+        margin: 0 0 0.75rem;
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--text-muted);
+      }
+
+      .tables-sidebar__list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+      }
+
+      .tables-sidebar__item a {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.5rem;
+        padding: 0.5rem 0.75rem;
+        border-radius: 12px;
+        transition: background 0.2s ease, transform 0.2s ease;
+      }
+
+      .tables-sidebar__item a:hover,
+      .tables-sidebar__item a:focus-visible {
+        background: var(--surface-muted);
+        transform: translateX(3px);
+      }
+
+      .tables-sidebar__item.is-active a {
+        background: rgba(79, 70, 229, 0.15);
+        color: var(--accent);
+        font-weight: 600;
+      }
+
+      .tables-sidebar__count {
+        font-size: 0.85rem;
+        color: var(--text-muted);
+      }
+
+      .tables-sidebar__empty {
+        color: var(--text-muted);
+        font-size: 0.9rem;
+      }
+
+      .tables-content {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 1.25rem;
+      }
+
+      .tables-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+      }
+
+      .tables-header__title {
+        margin: 0;
+        font-size: 1.5rem;
+      }
+
+      .tables-header__meta {
+        margin: 0.25rem 0 0;
+        color: var(--text-muted);
+        font-size: 0.9rem;
+      }
+
+      .tables-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.5rem;
+        padding: 0.5rem 1rem;
+        border-radius: 12px;
+        border: 1px solid transparent;
+        background: var(--accent);
+        color: #fff;
+        font-weight: 600;
+        text-decoration: none;
+        cursor: pointer;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      .tables-button:hover,
+      .tables-button:focus-visible {
+        transform: translateY(-1px);
+        box-shadow: 0 16px 30px rgba(79, 70, 229, 0.25);
+      }
+
+      .tables-button--ghost {
+        background: transparent;
+        color: var(--text-primary);
+        border-color: var(--border-soft);
+      }
+
+      .tables-button--ghost:hover,
+      .tables-button--ghost:focus-visible {
+        background: var(--surface-muted);
+        box-shadow: none;
+      }
+
+      .tables-responsive {
+        background: var(--surface);
+        border-radius: 18px;
+        box-shadow: var(--shadow);
+        overflow-x: auto;
+      }
+
+      .tables-grid {
+        width: 100%;
+        border-collapse: collapse;
+        min-width: 640px;
+      }
+
+      .tables-grid th,
+      .tables-grid td {
+        padding: 0.75rem 1rem;
+        border-bottom: 1px solid var(--border-soft);
+        text-align: left;
+        font-size: 0.95rem;
+      }
+
+      .tables-grid thead th {
+        background: rgba(79, 70, 229, 0.08);
+        font-weight: 600;
+      }
+
+      .tables-grid__actions {
+        width: 140px;
+        white-space: nowrap;
+      }
+
+      .tables-grid__actions form {
+        display: inline;
+      }
+
+      .tables-link {
+        border: none;
+        background: none;
+        color: var(--accent);
+        font-weight: 600;
+        cursor: pointer;
+        padding: 0;
+        margin-right: 0.75rem;
+      }
+
+      .tables-link--danger {
+        color: #ef4444;
+      }
+
+      .tables-empty,
+      .tables-empty-state {
+        background: var(--surface);
+        border-radius: 18px;
+        padding: 2rem;
+        box-shadow: var(--shadow);
+        color: var(--text-muted);
+        text-align: center;
+      }
+
+      .tables-empty-state h2 {
+        margin-top: 0;
+      }
+
+      .tables-pagination {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        font-size: 0.95rem;
+      }
+
+      .tables-pagination__link {
+        color: var(--accent);
+        font-weight: 600;
+      }
+
+      .tables-pagination__link.is-disabled {
+        color: var(--text-muted);
+        pointer-events: none;
+      }
+
+      .tables-flash {
+        padding: 0.75rem 1rem;
+        border-radius: 12px;
+        background: rgba(79, 70, 229, 0.1);
+        color: var(--text-primary);
+      }
+
+      .tables-flash--error {
+        background: rgba(239, 68, 68, 0.15);
+        color: #b91c1c;
+      }
+
+      .tables-form {
+        background: var(--surface);
+        border-radius: 18px;
+        box-shadow: var(--shadow);
+        padding: 2rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+        max-width: 640px;
+      }
+
+      .tables-form__group {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+      }
+
+      .tables-form__label {
+        font-weight: 600;
+        display: flex;
+        align-items: baseline;
+        gap: 0.5rem;
+      }
+
+      .tables-form__type {
+        font-size: 0.8rem;
+        color: var(--text-muted);
+        font-weight: 500;
+      }
+
+      .tables-form__input {
+        padding: 0.6rem 0.75rem;
+        border-radius: 12px;
+        border: 1px solid var(--border-soft);
+        background: var(--surface-muted);
+        font-size: 1rem;
+      }
+
+      .tables-form__input:focus-visible {
+        outline: 2px solid rgba(79, 70, 229, 0.4);
+        outline-offset: 2px;
+      }
+
+      .tables-form__input.has-error {
+        border-color: rgba(239, 68, 68, 0.6);
+        background: rgba(239, 68, 68, 0.1);
+      }
+
+      .tables-form__help {
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+
+      .tables-form__error {
+        font-size: 0.85rem;
+        color: #b91c1c;
+      }
+
+      .tables-form__actions {
+        display: flex;
+        gap: 1rem;
+      }
+
+      @media (max-width: 960px) {
+        .tables-layout {
+          flex-direction: column;
+        }
+
+        .tables-sidebar {
+          width: 100%;
+          position: static;
+          max-height: none;
+        }
+      }
+
       .menu-nav__title {
         font-weight: 600;
       }

--- a/dvorik/admin/templates/tables/form.html
+++ b/dvorik/admin/templates/tables/form.html
@@ -1,0 +1,60 @@
+{% extends "base.html" %}
+
+{% if mode == 'create' %}
+  {% set page_title = 'Create row' %}
+{% else %}
+  {% set page_title = 'Edit row' %}
+{% endif %}
+
+{% block title %}{{ page_title }} · {{ table.name }} · Dvorik{% endblock %}
+{% block header_title %}{{ page_title }}{% endblock %}
+{% block header_subtitle %}Table: {{ table.name }}{% endblock %}
+
+{% block content %}
+  <form class="tables-form" method="post">
+    {% if errors.get('__form__') %}
+      <div class="tables-flash tables-flash--error">{{ errors.get('__form__') }}</div>
+    {% endif %}
+
+    {% for column in columns %}
+      {% set value = values.get(column.name) %}
+      {% if value is none %}
+        {% set display_value = '' %}
+      {% else %}
+        {% set display_value = value %}
+      {% endif %}
+      <div class="tables-form__group">
+        <label class="tables-form__label" for="field-{{ column.name }}">
+          {{ column.name }}
+          <span class="tables-form__type">{{ column.declared_type or 'TEXT' }}</span>
+        </label>
+        <input
+          class="tables-form__input{% if errors.get(column.name) %} has-error{% endif %}"
+          type="text"
+          id="field-{{ column.name }}"
+          name="{{ column.name }}"
+          value="{{ display_value }}"
+          {% if mode == 'edit' and column.primary_key %}readonly{% endif %}
+          {% if column.notnull and column.default is none %}required{% endif %}
+          autocomplete="off"
+        >
+        <div class="tables-form__help">
+          {% if column.primary_key %}
+            Primary key{% if mode == 'create' %} (leave blank for auto value){% endif %}
+          {% endif %}
+          {% if column.default is not none %}
+            Default: {{ column.default }}
+          {% endif %}
+        </div>
+        {% if errors.get(column.name) %}
+          <div class="tables-form__error">{{ errors.get(column.name) }}</div>
+        {% endif %}
+      </div>
+    {% endfor %}
+
+    <div class="tables-form__actions">
+      <button class="tables-button" type="submit">Save</button>
+      <a class="tables-button tables-button--ghost" href="{{ url_for('tables.browse_table', table_name=table.name) }}">Cancel</a>
+    </div>
+  </form>
+{% endblock %}

--- a/dvorik/admin/templates/tables/table.html
+++ b/dvorik/admin/templates/tables/table.html
@@ -1,0 +1,97 @@
+{% extends "base.html" %}
+
+{% block title %}Tables · Dvorik{% endblock %}
+{% block header_title %}Table browser{% endblock %}
+
+{% block content %}
+  <div class="tables-layout">
+    <aside class="tables-sidebar">
+      <h2 class="tables-sidebar__title">Tables</h2>
+      <ul class="tables-sidebar__list">
+        {% for table in tables %}
+          <li class="tables-sidebar__item{% if active_table and table.name == active_table.name %} is-active{% endif %}">
+            <a href="{{ url_for('tables.browse_table', table_name=table.name) }}">
+              <span class="tables-sidebar__name">{{ table.name }}</span>
+              <span class="tables-sidebar__count" aria-label="Row count">{{ table.row_count }}</span>
+            </a>
+          </li>
+        {% else %}
+          <li class="tables-sidebar__empty">No tables available.</li>
+        {% endfor %}
+      </ul>
+    </aside>
+
+    <section class="tables-content">
+      {% set default_messages = {
+        'created': 'Row has been created.',
+        'updated': 'Row has been updated.',
+        'deleted': 'Row has been deleted.',
+        'error': 'An error occurred while processing the request.'
+      } %}
+      {% if status %}
+        {% set resolved_message = message or default_messages.get(status, status) %}
+        <div class="tables-flash tables-flash--{{ status }}">{{ resolved_message }}</div>
+      {% endif %}
+
+      {% if active_table %}
+        <header class="tables-header">
+          <div>
+            <h2 class="tables-header__title">{{ active_table.name }}</h2>
+            <p class="tables-header__meta">{{ active_table.row_count }} total rows</p>
+          </div>
+          <div class="tables-header__actions">
+            <a class="tables-button" href="{{ url_for('tables.new_row_form', table_name=active_table.name) }}">New row</a>
+          </div>
+        </header>
+
+        {% if rows %}
+          <div class="tables-responsive">
+            <table class="tables-grid">
+              <thead>
+                <tr>
+                  <th scope="col">rowid</th>
+                  {% for column in columns %}
+                    <th scope="col">{{ column.name }}</th>
+                  {% endfor %}
+                  <th scope="col" class="tables-grid__actions">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for row in rows %}
+                  <tr>
+                    <td data-label="rowid">{{ row['__rowid__'] }}</td>
+                    {% for column in columns %}
+                      {% set cell = row[column.name] %}
+                      <td data-label="{{ column.name }}">{{ cell if cell is not none else '—' }}</td>
+                    {% endfor %}
+                    <td class="tables-grid__actions">
+                      <a class="tables-link" href="{{ url_for('tables.edit_row_form', table_name=active_table.name, rowid=row['__rowid__']) }}">Edit</a>
+                      <form method="post" action="{{ url_for('tables.delete_row', table_name=active_table.name, rowid=row['__rowid__']) }}" onsubmit="return confirm('Delete this row?');">
+                        <button class="tables-link tables-link--danger" type="submit">Delete</button>
+                      </form>
+                    </td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        {% else %}
+          <p class="tables-empty">No rows found for this table.</p>
+        {% endif %}
+
+        {% if pages > 1 %}
+          <nav class="tables-pagination" aria-label="Pagination">
+            <a class="tables-pagination__link{% if not has_prev %} is-disabled{% endif %}" href="{{ url_for('tables.browse_table', table_name=active_table.name, page=prev_page) }}" aria-disabled="{{ 'true' if not has_prev else 'false' }}">Previous</a>
+            <span class="tables-pagination__status">Page {{ page }} of {{ pages }}</span>
+            <a class="tables-pagination__link{% if not has_next %} is-disabled{% endif %}" href="{{ url_for('tables.browse_table', table_name=active_table.name, page=next_page) }}" aria-disabled="{{ 'true' if not has_next else 'false' }}">Next</a>
+          </nav>
+        {% endif %}
+      {% else %}
+        <div class="tables-empty-state">
+          <h2>Select a table to browse</h2>
+          <p>Choose a table from the list to review and manage its rows.</p>
+        </div>
+      {% endif %}
+    </section>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement a CRUD-capable generic table browser blueprint backed by SQLite metadata
- add table management and form templates with matching styling for the admin interface

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcb03b7a808326bbb4c14288ee797e