### PR TITLE
Implement supply management UI

### DIFF
--- a/dvorik/admin/blueprints/supply.py
+++ b/dvorik/admin/blueprints/supply.py
@@ -1,10 +1,374 @@
 from __future__ import annotations
 
-from flask import Blueprint
+import hashlib
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping
+from uuid import uuid4
+
+from flask import Blueprint, Response, current_app, redirect, render_template, request, url_for
+from werkzeug.datastructures import FileStorage
+from werkzeug.utils import secure_filename
+
+from dvorik.core.config import Config
+from dvorik.db.conn import db
+from dvorik.domain.models import ImportLogEntry
+from dvorik.repo.import_repo import SQLiteImportLogRepo
+from dvorik.services.imports import ImportBatch, ImportFacade
 
 blueprint = Blueprint("supply", __name__, url_prefix="/supply")
+
+logger = logging.getLogger(__name__)
+
+_PREVIEW_SAMPLE_ROWS = 15
+_SNAPSHOT_ROWS = 50
+
+
+@dataclass(slots=True)
+class PreviewContext:
+    """Data required to render the preview confirmation panel."""
+
+    original_name: str
+    stored_path: str
+    stored_filename: str
+    import_type: str
+    source_hash: str
+    row_count: int
+    headers: tuple[str, ...]
+    sample_rows: tuple[Mapping[str, object], ...]
+    column_mapping: Mapping[str, str]
+    supplier: str
+    invoice: str
+    delimiter: str | None
+    sheet_name: str | None
 
 
 @blueprint.get("/")
 def supply_home() -> str:
-    return "Supply placeholder"
+    """Render the supply management landing page."""
+
+    status, message = _extract_status()
+    imports = _load_recent_imports()
+    return render_template(
+        "supply.html",
+        preview=None,
+        imports=imports,
+        status=status,
+        message=message,
+    )
+
+
+@blueprint.post("/preview")
+def preview_import() -> str | Response:
+    """Accept an uploaded file and display a preview before importing."""
+
+    upload = request.files.get("file")
+    if upload is None or not upload.filename:
+        return _redirect_with_status("error", "Please choose a file to upload.")
+
+    supplier = (request.form.get("supplier") or "").strip()
+    invoice = (request.form.get("invoice") or "").strip()
+    sheet_name = (request.form.get("sheet_name") or "").strip() or None
+    delimiter = (request.form.get("delimiter") or "").strip() or None
+    requested_type = (request.form.get("import_type") or "auto").strip().lower()
+
+    config = _get_config()
+
+    try:
+        stored_path = _persist_upload(upload, config)
+        import_type = _resolve_import_type(requested_type, stored_path)
+        facade = _get_facade(config)
+        batch = _parse_batch(
+            facade,
+            import_type,
+            stored_path,
+            original_name=upload.filename,
+            delimiter=delimiter,
+            sheet_name=sheet_name,
+        )
+        preview = _build_preview_context(
+            batch,
+            stored_path=stored_path,
+            import_type=import_type,
+            supplier=supplier,
+            invoice=invoice,
+            delimiter=delimiter,
+            sheet_name=sheet_name,
+        )
+    except Exception:  # pragma: no cover - defensive logging
+        logger.exception("Failed to build import preview")
+        return _redirect_with_status("error", "Failed to analyse the uploaded file.")
+
+    imports = _load_recent_imports()
+    return render_template(
+        "supply.html",
+        preview=preview,
+        imports=imports,
+        status=None,
+        message=None,
+    )
+
+
+@blueprint.post("/confirm")
+def confirm_import() -> Response:
+    """Persist a processed import into the database."""
+
+    stored_ref = request.form.get("stored_path") or ""
+    original_name = request.form.get("original_name") or ""
+    import_type = request.form.get("import_type") or ""
+    source_hash = request.form.get("source_hash") or ""
+    supplier = (request.form.get("supplier") or "").strip()
+    invoice = (request.form.get("invoice") or "").strip()
+    delimiter = (request.form.get("delimiter") or "").strip() or None
+    sheet_name = (request.form.get("sheet_name") or "").strip() or None
+
+    if not stored_ref or not original_name or not import_type or not source_hash:
+        return _redirect_with_status("error", "Import context is incomplete. Please start over.")
+
+    config = _get_config()
+
+    try:
+        stored_path = _resolve_uploaded_path(stored_ref, config)
+    except ValueError:
+        return _redirect_with_status("error", "The referenced upload is no longer available.")
+
+    facade = _get_facade(config)
+
+    try:
+        batch = _parse_batch(
+            facade,
+            import_type,
+            stored_path,
+            original_name=original_name,
+            delimiter=delimiter,
+            sheet_name=sheet_name,
+        )
+    except Exception:  # pragma: no cover - defensive logging
+        logger.exception("Failed to re-parse uploaded file for confirmation")
+        return _redirect_with_status("error", "Could not re-read the uploaded file. Please upload again.")
+
+    if batch.source_hash != source_hash:
+        logger.warning(
+            "Source hash mismatch during confirmation (expected %s, got %s)",
+            source_hash,
+            batch.source_hash,
+        )
+        return _redirect_with_status(
+            "error",
+            "The uploaded file has changed. Please upload and preview again.",
+        )
+
+    normalised_rows = batch.normalised_rows()
+    normalised_csv = batch.to_csv()
+    normalised_hash = hashlib.sha256(normalised_csv.encode("utf-8")).hexdigest() if normalised_csv else None
+    snapshot = normalised_rows[:_SNAPSHOT_ROWS]
+
+    try:
+        facade.store_normalised(batch, filename=f"{batch.source_hash}.csv")
+    except Exception:  # pragma: no cover - defensive logging
+        logger.exception("Failed to persist normalised CSV")
+        return _redirect_with_status("error", "Could not store the normalised data.")
+
+    entry = ImportLogEntry(
+        original_name=original_name,
+        stored_path=str(stored_path),
+        import_type=import_type,
+        source_hash=source_hash,
+        normalized_csv=normalised_csv or None,
+        normalized_hash=normalised_hash,
+        supplier=supplier or None,
+        invoice=invoice or None,
+        items_count=len(normalised_rows),
+        items_json=json.dumps(snapshot, ensure_ascii=False) if snapshot else None,
+    )
+
+    conn = None
+    try:
+        conn = db()
+        repo = SQLiteImportLogRepo(conn)
+        saved_entry = repo.add(entry)
+    except Exception:  # pragma: no cover - defensive logging
+        logger.exception("Failed to persist import log entry")
+        return _redirect_with_status("error", "Failed to record the import in the log.")
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:  # pragma: no cover - best effort
+                logger.warning("Could not close database connection after import confirmation")
+
+    return redirect(
+        url_for(
+            "supply.supply_home",
+            status="imported",
+            message=f"Import #{saved_entry.id} completed successfully." if saved_entry.id else "Import completed successfully.",
+        )
+    )
+
+
+@blueprint.post("/<int:import_id>/revert")
+def revert_import(import_id: int) -> Response:
+    """Mark an import as reverted for audit purposes."""
+
+    conn = None
+    try:
+        conn = db()
+        repo = SQLiteImportLogRepo(conn)
+        entry = repo.get(import_id)
+        if entry is None:
+            return _redirect_with_status("error", "Import entry was not found.")
+        if entry.reverted_at:
+            return _redirect_with_status("error", "Import has already been reverted.")
+        repo.mark_reverted(import_id)
+    except Exception:  # pragma: no cover - defensive logging
+        logger.exception("Failed to mark import %s as reverted", import_id)
+        return _redirect_with_status("error", "Could not revert the selected import.")
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:  # pragma: no cover - best effort
+                logger.warning("Could not close database connection after revert operation")
+
+    return redirect(
+        url_for(
+            "supply.supply_home",
+            status="reverted",
+            message=f"Import #{import_id} marked as reverted.",
+        )
+    )
+
+
+def _build_preview_context(
+    batch: ImportBatch,
+    *,
+    stored_path: Path,
+    import_type: str,
+    supplier: str,
+    invoice: str,
+    delimiter: str | None,
+    sheet_name: str | None,
+) -> PreviewContext:
+    rows = batch.normalised_rows()
+    sample = tuple(rows[:_PREVIEW_SAMPLE_ROWS])
+    headers: Iterable[str]
+    if sample:
+        headers = sample[0].keys()
+    else:
+        headers = batch.columns.as_dict().keys()
+
+    config = _get_config()
+    stored_ref = _relativise_path(stored_path, config.uploads_dir)
+
+    return PreviewContext(
+        original_name=batch.original_name,
+        stored_path=stored_ref,
+        stored_filename=stored_path.name,
+        import_type=import_type,
+        source_hash=batch.source_hash,
+        row_count=len(rows),
+        headers=tuple(headers),
+        sample_rows=sample,
+        column_mapping=batch.columns.as_dict(),
+        supplier=supplier,
+        invoice=invoice,
+        delimiter=delimiter,
+        sheet_name=sheet_name,
+    )
+
+
+def _resolve_import_type(requested: str, stored_path: Path) -> str:
+    if requested in {"csv", "excel"}:
+        return requested
+
+    suffix = stored_path.suffix.lower()
+    if suffix in {".xls", ".xlsx", ".xlsm", ".xlsb"}:
+        return "excel"
+    return "csv"
+
+
+def _parse_batch(
+    facade: ImportFacade,
+    import_type: str,
+    stored_path: Path,
+    *,
+    original_name: str,
+    delimiter: str | None,
+    sheet_name: str | None,
+) -> ImportBatch:
+    if import_type == "excel":
+        return facade.from_excel(str(stored_path), original_name=original_name, sheet_name=sheet_name)
+    if import_type == "csv":
+        return facade.from_csv(str(stored_path), original_name=original_name, delimiter=delimiter)
+    raise ValueError(f"Unsupported import type: {import_type}")
+
+
+def _persist_upload(upload: FileStorage, config: Config) -> Path:
+    filename = secure_filename(upload.filename or "upload")
+    if not filename:
+        filename = "upload"
+    unique_name = f"{uuid4().hex}_{filename}"
+    target = config.uploads_dir / unique_name
+    target.parent.mkdir(parents=True, exist_ok=True)
+    upload.save(target)
+    return target
+
+
+def _resolve_uploaded_path(reference: str, config: Config) -> Path:
+    candidate = (config.uploads_dir / reference).resolve()
+    uploads_root = config.uploads_dir.resolve()
+    if uploads_root not in candidate.parents and candidate != uploads_root:
+        raise ValueError("Upload reference escapes the uploads directory")
+    if not candidate.exists():
+        raise ValueError("Uploaded file no longer exists")
+    return candidate
+
+
+def _relativise_path(path: Path, root: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(root.resolve()))
+    except ValueError:
+        return str(path.name)
+
+
+def _get_config() -> Config:
+    return current_app.config["DVORIK_CONFIG"]
+
+
+def _get_facade(config: Config) -> ImportFacade:
+    return ImportFacade(storage_dir=config.normalized_uploads_dir)
+
+
+def _load_recent_imports(limit: int = 15):
+    conn = None
+    try:
+        conn = db()
+        repo = SQLiteImportLogRepo(conn)
+        entries = list(repo.latest(limit))
+        return entries
+    except Exception:  # pragma: no cover - defensive logging
+        logger.exception("Failed to load recent import entries")
+        return []
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:  # pragma: no cover - best effort
+                logger.warning("Could not close database connection after loading imports")
+
+
+def _redirect_with_status(status: str, message: str | None = None) -> Response:
+    return redirect(url_for("supply.supply_home", status=status, message=message))
+
+
+def _extract_status() -> tuple[str | None, str | None]:
+    status = request.args.get("status")
+    message = request.args.get("message")
+    if status == "error" and not message:
+        message = "An unexpected error occurred."
+    return status, message
+
+
+__all__ = ["blueprint"]

--- a/dvorik/admin/templates/supply.html
+++ b/dvorik/admin/templates/supply.html
@@ -1,0 +1,406 @@
+{% extends "base.html" %}
+
+{% block title %}Supply · Dvorik{% endblock %}
+{% block header_title %}Supply management{% endblock %}
+
+{% block base_styles %}
+  {{ super() }}
+  <style>
+    .supply-layout {
+      display: grid;
+      gap: 2rem;
+    }
+
+    .supply-card {
+      background: var(--surface);
+      border-radius: 18px;
+      padding: 1.75rem;
+      box-shadow: var(--shadow);
+      display: grid;
+      gap: 1.25rem;
+    }
+
+    .supply-card__title {
+      margin: 0;
+      font-size: 1.4rem;
+      font-weight: 600;
+    }
+
+    .supply-flash {
+      border-radius: 14px;
+      padding: 1rem 1.25rem;
+      font-weight: 500;
+    }
+
+    .supply-flash--imported {
+      background: rgba(16, 185, 129, 0.1);
+      color: #047857;
+    }
+
+    .supply-flash--reverted {
+      background: rgba(59, 130, 246, 0.1);
+      color: #1d4ed8;
+    }
+
+    .supply-flash--error {
+      background: rgba(248, 113, 113, 0.12);
+      color: #b91c1c;
+    }
+
+    .supply-form {
+      display: grid;
+      gap: 1rem;
+    }
+
+    .supply-form__row {
+      display: grid;
+      gap: 1rem;
+    }
+
+    @media (min-width: 720px) {
+      .supply-form__row {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    .supply-field {
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+    }
+
+    .supply-label {
+      font-weight: 600;
+      font-size: 0.95rem;
+    }
+
+    .supply-input,
+    .supply-select,
+    .supply-text {
+      border-radius: 12px;
+      border: 1px solid var(--border-soft);
+      padding: 0.65rem 0.75rem;
+      font-size: 0.95rem;
+      background: var(--surface-muted);
+      color: inherit;
+    }
+
+    .supply-actions {
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+    }
+
+    .supply-button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.4rem;
+      border-radius: 12px;
+      border: none;
+      padding: 0.7rem 1.1rem;
+      font-weight: 600;
+      font-size: 0.95rem;
+      cursor: pointer;
+      transition: transform 0.15s ease, box-shadow 0.15s ease;
+      text-decoration: none;
+    }
+
+    .supply-button--primary {
+      background: var(--accent);
+      color: #fff;
+      box-shadow: 0 12px 24px rgba(79, 70, 229, 0.3);
+    }
+
+    .supply-button--primary:hover,
+    .supply-button--primary:focus-visible {
+      transform: translateY(-1px);
+      box-shadow: 0 16px 30px rgba(79, 70, 229, 0.35);
+    }
+
+    .supply-button--ghost {
+      background: transparent;
+      color: var(--text-muted);
+      border: 1px solid var(--border-soft);
+    }
+
+    .supply-preview__meta {
+      display: grid;
+      gap: 0.5rem;
+      font-size: 0.95rem;
+      color: var(--text-muted);
+    }
+
+    .supply-preview__grid {
+      overflow-x: auto;
+      border-radius: 12px;
+      border: 1px solid var(--border-soft);
+    }
+
+    .supply-table {
+      width: 100%;
+      border-collapse: collapse;
+      min-width: 480px;
+    }
+
+    .supply-table th,
+    .supply-table td {
+      padding: 0.6rem 0.75rem;
+      border-bottom: 1px solid var(--border-soft);
+      text-align: left;
+      font-size: 0.9rem;
+    }
+
+    .supply-table thead {
+      background: rgba(79, 70, 229, 0.08);
+    }
+
+    .supply-table tbody tr:last-child td {
+      border-bottom: none;
+    }
+
+    .supply-mapping {
+      display: grid;
+      gap: 0.4rem;
+      font-size: 0.9rem;
+      background: var(--surface-muted);
+      border-radius: 12px;
+      padding: 0.85rem 1rem;
+    }
+
+    .supply-history__table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    .supply-history__table th,
+    .supply-history__table td {
+      padding: 0.6rem 0.75rem;
+      border-bottom: 1px solid var(--border-soft);
+      text-align: left;
+      font-size: 0.9rem;
+      vertical-align: top;
+    }
+
+    .supply-history__table tbody tr:last-child td {
+      border-bottom: none;
+    }
+
+    .supply-tag {
+      display: inline-flex;
+      align-items: center;
+      border-radius: 999px;
+      padding: 0.2rem 0.65rem;
+      font-size: 0.8rem;
+      font-weight: 600;
+      background: rgba(79, 70, 229, 0.12);
+      color: var(--accent);
+    }
+
+    .supply-tag--muted {
+      background: rgba(99, 102, 241, 0.08);
+      color: var(--text-muted);
+    }
+
+    .supply-empty {
+      margin: 0;
+      color: var(--text-muted);
+      font-size: 0.95rem;
+    }
+
+    .supply-revert-form {
+      display: inline;
+    }
+
+    .supply-revert-button {
+      border: none;
+      background: transparent;
+      color: #b91c1c;
+      font-weight: 600;
+      cursor: pointer;
+      padding: 0;
+    }
+
+    .supply-revert-button:hover,
+    .supply-revert-button:focus-visible {
+      text-decoration: underline;
+    }
+  </style>
+{% endblock %}
+
+{% block content %}
+  <div class="supply-layout">
+    {% set default_messages = {
+      'imported': 'Import completed successfully.',
+      'reverted': 'Import marked as reverted.',
+      'error': 'An error occurred while processing the request.'
+    } %}
+    {% if status %}
+      {% set resolved_message = message or default_messages.get(status, status) %}
+      <div class="supply-flash supply-flash--{{ status }}">{{ resolved_message }}</div>
+    {% endif %}
+
+    <section class="supply-card">
+      <h2 class="supply-card__title">Upload supply file</h2>
+      <form class="supply-form" method="post" action="{{ url_for('supply.preview_import') }}" enctype="multipart/form-data">
+        <div class="supply-field">
+          <label class="supply-label" for="supply-file">File</label>
+          <input class="supply-input" type="file" id="supply-file" name="file" required>
+        </div>
+
+        <div class="supply-form__row">
+          <div class="supply-field">
+            <label class="supply-label" for="supply-type">Import type</label>
+            <select class="supply-select" id="supply-type" name="import_type">
+              <option value="auto" {% if not preview %}selected{% endif %}>Detect automatically</option>
+              <option value="csv" {% if preview and preview.import_type == 'csv' %}selected{% endif %}>CSV</option>
+              <option value="excel" {% if preview and preview.import_type == 'excel' %}selected{% endif %}>Excel</option>
+            </select>
+          </div>
+          <div class="supply-field">
+            <label class="supply-label" for="supply-sheet">Excel sheet name</label>
+            <input class="supply-input" type="text" id="supply-sheet" name="sheet_name" placeholder="Leave empty for the first sheet" value="{{ preview.sheet_name if preview else '' }}">
+          </div>
+        </div>
+
+        <div class="supply-form__row">
+          <div class="supply-field">
+            <label class="supply-label" for="supply-delimiter">CSV delimiter</label>
+            <input class="supply-input" type="text" id="supply-delimiter" name="delimiter" maxlength="1" placeholder="Auto" value="{{ preview.delimiter if preview and preview.delimiter else '' }}">
+          </div>
+          <div class="supply-field">
+            <label class="supply-label" for="supply-supplier">Supplier</label>
+            <input class="supply-input" type="text" id="supply-supplier" name="supplier" value="{{ preview.supplier if preview else '' }}" placeholder="Optional">
+          </div>
+        </div>
+
+        <div class="supply-field">
+          <label class="supply-label" for="supply-invoice">Invoice / reference</label>
+          <input class="supply-input" type="text" id="supply-invoice" name="invoice" value="{{ preview.invoice if preview else '' }}" placeholder="Optional">
+        </div>
+
+        <div class="supply-actions">
+          <button class="supply-button supply-button--primary" type="submit">Preview import</button>
+        </div>
+      </form>
+    </section>
+
+    {% if preview %}
+      <section class="supply-card">
+        <h2 class="supply-card__title">Preview</h2>
+        <div class="supply-preview__meta">
+          <span><strong>File:</strong> {{ preview.original_name }}</span>
+          <span><strong>Detected type:</strong> {{ preview.import_type|capitalize }}</span>
+          <span><strong>Total rows:</strong> {{ preview.row_count }}</span>
+          <span><strong>Stored path:</strong> {{ preview.stored_filename }}</span>
+        </div>
+
+        <div>
+          <h3 class="supply-label">Detected column mapping</h3>
+          <div class="supply-mapping">
+            {% for canonical, source in preview.column_mapping.items() %}
+              <div><strong>{{ canonical }}</strong> ← {{ source }}</div>
+            {% else %}
+              <div>No automatic mappings detected.</div>
+            {% endfor %}
+          </div>
+        </div>
+
+        {% if preview.sample_rows %}
+          <div>
+            <h3 class="supply-label">Sample rows</h3>
+            <div class="supply-preview__grid">
+              <table class="supply-table">
+                <thead>
+                  <tr>
+                    {% for header in preview.headers %}
+                      <th scope="col">{{ header }}</th>
+                    {% endfor %}
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for row in preview.sample_rows %}
+                    <tr>
+                      {% for header in preview.headers %}
+                        {% set value = row.get(header) %}
+                        <td>{{ value if value is not none else '—' }}</td>
+                      {% endfor %}
+                    </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        {% else %}
+          <p class="supply-empty">No data rows detected in the uploaded file.</p>
+        {% endif %}
+
+        <form class="supply-actions" method="post" action="{{ url_for('supply.confirm_import') }}">
+          <input type="hidden" name="stored_path" value="{{ preview.stored_path }}">
+          <input type="hidden" name="original_name" value="{{ preview.original_name }}">
+          <input type="hidden" name="import_type" value="{{ preview.import_type }}">
+          <input type="hidden" name="source_hash" value="{{ preview.source_hash }}">
+          <input type="hidden" name="supplier" value="{{ preview.supplier }}">
+          <input type="hidden" name="invoice" value="{{ preview.invoice }}">
+          <input type="hidden" name="delimiter" value="{{ preview.delimiter if preview.delimiter else '' }}">
+          <input type="hidden" name="sheet_name" value="{{ preview.sheet_name if preview.sheet_name else '' }}">
+          <button class="supply-button supply-button--primary" type="submit">Confirm import</button>
+          <a class="supply-button supply-button--ghost" href="{{ url_for('supply.supply_home') }}">Cancel</a>
+        </form>
+      </section>
+    {% endif %}
+
+    <section class="supply-card">
+      <h2 class="supply-card__title">Recent imports</h2>
+      {% if imports %}
+        <div class="supply-preview__grid">
+          <table class="supply-history__table">
+            <thead>
+              <tr>
+                <th scope="col">ID</th>
+                <th scope="col">File</th>
+                <th scope="col">Supplier</th>
+                <th scope="col">Items</th>
+                <th scope="col">Imported at</th>
+                <th scope="col">Status</th>
+                <th scope="col">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for entry in imports %}
+                <tr>
+                  <td>#{{ entry.id }}</td>
+                  <td>
+                    <div>{{ entry.original_name }}</div>
+                    <div class="supply-tag supply-tag--muted">{{ entry.import_type|upper }}</div>
+                  </td>
+                  <td>{{ entry.supplier or '—' }}</td>
+                  <td>{{ entry.items_count }}</td>
+                  <td>{{ entry.created_at or '—' }}</td>
+                  <td>
+                    {% if entry.reverted_at %}
+                      <span class="supply-tag supply-tag--muted">Reverted</span>
+                    {% else %}
+                      <span class="supply-tag">Active</span>
+                    {% endif %}
+                  </td>
+                  <td>
+                    {% if entry.reverted_at %}
+                      <span class="supply-empty">—</span>
+                    {% else %}
+                      <form class="supply-revert-form" method="post" action="{{ url_for('supply.revert_import', import_id=entry.id) }}" onsubmit="return confirm('Revert this import?');">
+                        <button class="supply-revert-button" type="submit">Revert</button>
+                      </form>
+                    {% endif %}
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% else %}
+        <p class="supply-empty">No imports have been recorded yet.</p>
+      {% endif %}
+    </section>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a supply blueprint that handles preview, confirmation, and revert flows for imports
- create a supply management template with upload form, preview panel, and import history table

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcb1a825b48326bc4dc74b1dbbe49f