### PR TITLE
Add built-in bot routers for new architecture

### DIFF
--- a/dvorik/bot/routers/__init__.py
+++ b/dvorik/bot/routers/__init__.py
@@ -1,0 +1,45 @@
+"""Built-in routers bundled with the core Dvorik bot package."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from importlib import import_module
+from types import ModuleType
+
+from dvorik.core.registry import BotRouterRegistry
+
+__all__ = ["register_builtin_routers"]
+
+
+def _iter_router_modules() -> Iterable[ModuleType]:
+    """Yield router modules that are part of the built-in bundle."""
+
+    module_names = (
+        ".core",
+        ".admin",
+        ".stock",
+        ".supply",
+    )
+
+    for suffix in module_names:
+        yield import_module(suffix, package=__name__)
+
+
+def _call_if_callable(obj: object, name: str) -> None:
+    """Invoke ``name`` attribute on ``obj`` when it is callable."""
+
+    attribute = getattr(obj, name, None)
+    if callable(attribute):
+        attribute()
+
+
+def register_builtin_routers() -> None:
+    """Register core routers in the :class:`BotRouterRegistry`."""
+
+    for module in _iter_router_modules():
+        _call_if_callable(module, "register")
+
+    # Eagerly touch the registry to surface missing routers early.
+    for key in ("builtin.core", "builtin.admin", "builtin.stock", "builtin.supply"):
+        if key not in BotRouterRegistry:
+            raise RuntimeError(f"Router '{key}' was not registered")

--- a/dvorik/bot/routers/admin.py
+++ b/dvorik/bot/routers/admin.py
@@ -1,0 +1,28 @@
+"""Administrative tooling routers bundled with the bot."""
+
+from __future__ import annotations
+
+from aiogram import Router
+from aiogram.filters import Command
+from aiogram.types import Message
+
+from dvorik.core.registry import BotRouterRegistry
+
+__all__ = ["router", "register"]
+
+router = Router(name="builtin_admin")
+
+
+@router.message(Command("admin"))
+async def handle_admin_entry(message: Message) -> None:
+    """Placeholder handler advertising upcoming admin features."""
+
+    await message.answer(
+        "Админ-команды скоро переедут сюда. Пока что раздел находится в разработке.",
+    )
+
+
+def register() -> None:
+    """Register the admin router in the registry."""
+
+    BotRouterRegistry.ensure("builtin.admin", lambda: router)

--- a/dvorik/bot/routers/core.py
+++ b/dvorik/bot/routers/core.py
@@ -1,0 +1,28 @@
+"""Core command handlers available to every operator."""
+
+from __future__ import annotations
+
+from aiogram import Router
+from aiogram.filters import CommandStart
+from aiogram.types import Message
+
+from dvorik.core.registry import BotRouterRegistry
+
+__all__ = ["router", "register"]
+
+router = Router(name="builtin_core")
+
+
+@router.message(CommandStart())
+async def handle_start(message: Message) -> None:
+    """Respond to the ``/start`` command with a generic greeting."""
+
+    await message.answer(
+        "Привет! Я бот новой архитектуры Dvorik. Функционал скоро появится.",
+    )
+
+
+def register() -> None:
+    """Register the core router in the registry."""
+
+    BotRouterRegistry.ensure("builtin.core", lambda: router)

--- a/dvorik/bot/routers/stock.py
+++ b/dvorik/bot/routers/stock.py
@@ -1,0 +1,28 @@
+"""Routers dedicated to stock management flows."""
+
+from __future__ import annotations
+
+from aiogram import Router
+from aiogram.filters import Command
+from aiogram.types import Message
+
+from dvorik.core.registry import BotRouterRegistry
+
+__all__ = ["router", "register"]
+
+router = Router(name="builtin_stock")
+
+
+@router.message(Command("stock"))
+async def handle_stock_entry(message: Message) -> None:
+    """Placeholder entrypoint for upcoming stock operations."""
+
+    await message.answer(
+        "Задачи по остаткам ещё переносятся в новую версию. Следите за обновлениями!",
+    )
+
+
+def register() -> None:
+    """Register the stock router in the registry."""
+
+    BotRouterRegistry.ensure("builtin.stock", lambda: router)

--- a/dvorik/bot/routers/supply.py
+++ b/dvorik/bot/routers/supply.py
@@ -1,0 +1,28 @@
+"""Routers focused on supply import and tracking."""
+
+from __future__ import annotations
+
+from aiogram import Router
+from aiogram.filters import Command
+from aiogram.types import Message
+
+from dvorik.core.registry import BotRouterRegistry
+
+__all__ = ["router", "register"]
+
+router = Router(name="builtin_supply")
+
+
+@router.message(Command("supply"))
+async def handle_supply_entry(message: Message) -> None:
+    """Placeholder entrypoint announcing upcoming supply workflows."""
+
+    await message.answer(
+        "Импорт поставок пока в процессе миграции. Эта команда заработает позже.",
+    )
+
+
+def register() -> None:
+    """Register the supply router in the registry."""
+
+    BotRouterRegistry.ensure("builtin.supply", lambda: router)


### PR DESCRIPTION
## Summary
- add a routers package for the bot with core, admin, stock, and supply modules
- register the built-in routers through the BotRouterRegistry so they attach during startup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcb9f788cc83269654b299143ed7fb