### PR TITLE
Add namespaced callback helpers and keyboards for bot routers

### DIFF
--- a/dvorik/bot/callbacks.py
+++ b/dvorik/bot/callbacks.py
@@ -1,0 +1,147 @@
+"""Utilities for building and parsing namespaced callback payloads."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping
+
+__all__ = ["CallbackPayload", "build", "parse"]
+
+_SEGMENT_SEPARATOR = ":"
+_FIELD_SEPARATOR = "&"
+_ASSIGNMENT_SEPARATOR = "="
+
+
+@dataclass(frozen=True, slots=True)
+class CallbackPayload:
+    """Structured representation of callback data.
+
+    Attributes
+    ----------
+    namespace:
+        Unique namespace used to avoid collisions between different routers or
+        plugins.
+    action:
+        Action identifier within the namespace.
+    params:
+        Optional parameters encoded in the payload.
+    """
+
+    namespace: str
+    action: str
+    params: Dict[str, str]
+
+
+def build(
+    namespace: str,
+    action: str,
+    /,
+    *,
+    params: Mapping[str, Any] | None = None,
+    **extra: Any,
+) -> str:
+    """Return callback data string with namespacing applied.
+
+    Parameters
+    ----------
+    namespace:
+        High-level grouping for callbacks. Typically matches router or plugin
+        identifier.
+    action:
+        Specific action to be performed when the callback is received.
+    params / extra:
+        Additional key/value pairs encoded into the payload. ``None`` values are
+        omitted.
+    """
+
+    _validate_segment(namespace, "namespace")
+    _validate_segment(action, "action")
+
+    combined: Dict[str, str] = {}
+    if params:
+        combined.update(_normalise_params(params))
+    if extra:
+        extra_params = _normalise_params(extra)
+        overlap = combined.keys() & extra_params.keys()
+        if overlap:
+            joined = ", ".join(sorted(overlap))
+            raise ValueError(f"duplicate callback params for keys: {joined}")
+        combined.update(extra_params)
+
+    pieces = [namespace, action]
+    if combined:
+        encoded = _FIELD_SEPARATOR.join(
+            f"{key}{_ASSIGNMENT_SEPARATOR}{value}" for key, value in sorted(combined.items())
+        )
+        pieces.append(encoded)
+
+    return _SEGMENT_SEPARATOR.join(pieces)
+
+
+def parse(data: str, /, *, expected_namespace: str | None = None) -> CallbackPayload:
+    """Parse callback data into a structured payload.
+
+    Parameters
+    ----------
+    data:
+        Raw callback payload received from Telegram.
+    expected_namespace:
+        When provided, ``ValueError`` is raised if the payload belongs to a
+        different namespace.
+    """
+
+    if not data:
+        raise ValueError("callback data is empty")
+
+    parts = data.split(_SEGMENT_SEPARATOR, 2)
+    if len(parts) < 2:
+        raise ValueError("callback data must include namespace and action")
+
+    namespace, action = parts[0], parts[1]
+    if expected_namespace is not None and namespace != expected_namespace:
+        raise ValueError("callback namespace mismatch")
+
+    params_segment = parts[2] if len(parts) == 3 else ""
+    params: Dict[str, str] = {}
+    if params_segment:
+        for chunk in params_segment.split(_FIELD_SEPARATOR):
+            if not chunk:
+                continue
+            if _ASSIGNMENT_SEPARATOR in chunk:
+                key, value = chunk.split(_ASSIGNMENT_SEPARATOR, 1)
+            else:
+                key, value = chunk, ""
+            if not key:
+                raise ValueError("callback data contains empty parameter name")
+            params[key] = value
+
+    return CallbackPayload(namespace=namespace, action=action, params=params)
+
+
+def _validate_segment(value: str, label: str) -> None:
+    if not value:
+        raise ValueError(f"callback {label} must not be empty")
+    if any(separator in value for separator in (_SEGMENT_SEPARATOR, _FIELD_SEPARATOR, _ASSIGNMENT_SEPARATOR)):
+        raise ValueError(
+            f"callback {label} must not contain '{_SEGMENT_SEPARATOR}', '{_FIELD_SEPARATOR}' or '{_ASSIGNMENT_SEPARATOR}'"
+        )
+
+
+def _normalise_params(params: Mapping[str, Any]) -> Dict[str, str]:
+    normalised: Dict[str, str] = {}
+    for key, raw_value in params.items():
+        if raw_value is None:
+            continue
+        key_str = str(key)
+        _validate_segment(key_str, "parameter name")
+        value_str = str(raw_value)
+        _ensure_value_safe(value_str)
+        normalised[key_str] = value_str
+    return normalised
+
+
+def _ensure_value_safe(value: str) -> None:
+    if any(separator in value for separator in (_SEGMENT_SEPARATOR, _FIELD_SEPARATOR, _ASSIGNMENT_SEPARATOR)):
+        raise ValueError(
+            "callback parameter values must not contain reserved separators ':' '&' '='"
+        )

--- a/dvorik/bot/keyboards.py
+++ b/dvorik/bot/keyboards.py
@@ -1,0 +1,59 @@
+"""Inline keyboard factories for the Telegram bot."""
+
+from __future__ import annotations
+
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+
+from .callbacks import build
+
+__all__ = [
+    "core_entry_keyboard",
+    "admin_entry_keyboard",
+    "stock_entry_keyboard",
+    "supply_entry_keyboard",
+]
+
+
+def _coming_soon_keyboard(namespace: str) -> InlineKeyboardMarkup:
+    """Return a shared keyboard notifying users about pending features."""
+
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(
+                    text="Узнать статус",
+                    callback_data=build(namespace, "status"),
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="Оставить отзыв",
+                    callback_data=build(namespace, "feedback"),
+                )
+            ],
+        ]
+    )
+
+
+def core_entry_keyboard() -> InlineKeyboardMarkup:
+    """Keyboard for the ``/start`` command."""
+
+    return _coming_soon_keyboard("builtin.core")
+
+
+def admin_entry_keyboard() -> InlineKeyboardMarkup:
+    """Keyboard for the ``/admin`` command."""
+
+    return _coming_soon_keyboard("builtin.admin")
+
+
+def stock_entry_keyboard() -> InlineKeyboardMarkup:
+    """Keyboard for the ``/stock`` command."""
+
+    return _coming_soon_keyboard("builtin.stock")
+
+
+def supply_entry_keyboard() -> InlineKeyboardMarkup:
+    """Keyboard for the ``/supply`` command."""
+
+    return _coming_soon_keyboard("builtin.supply")

--- a/dvorik/bot/routers/admin.py
+++ b/dvorik/bot/routers/admin.py
@@ -1,11 +1,10 @@
-"""Administrative tooling routers bundled with the bot."""
-
 from __future__ import annotations
 
 from aiogram import Router
 from aiogram.filters import Command
-from aiogram.types import Message
+from aiogram.types import CallbackQuery, Message
 
+from dvorik.bot import callbacks, keyboards
 from dvorik.core.registry import BotRouterRegistry
 
 __all__ = ["router", "register"]
@@ -19,7 +18,32 @@ async def handle_admin_entry(message: Message) -> None:
 
     await message.answer(
         "Админ-команды скоро переедут сюда. Пока что раздел находится в разработке.",
+        reply_markup=keyboards.admin_entry_keyboard(),
     )
+
+
+@router.callback_query()
+async def handle_admin_callbacks(query: CallbackQuery) -> None:
+    """React to callbacks associated with the admin namespace."""
+
+    if not query.data:
+        return
+
+    try:
+        payload = callbacks.parse(query.data, expected_namespace="builtin.admin")
+    except ValueError:
+        return
+
+    if payload.action == "status":
+        await query.answer("Мы готовим обновлённую админку, скоро поделимся деталями.")
+    elif payload.action == "feedback":
+        await query.answer("Спасибо!", show_alert=False)
+        if query.message:
+            await query.message.answer(
+                "Напишите свои пожелания в чат администраторов, чтобы мы учли их при релизе."
+            )
+    else:
+        await query.answer("Эта кнопка пока неактивна.")
 
 
 def register() -> None:

--- a/dvorik/bot/routers/core.py
+++ b/dvorik/bot/routers/core.py
@@ -1,11 +1,10 @@
-"""Core command handlers available to every operator."""
-
 from __future__ import annotations
 
 from aiogram import Router
 from aiogram.filters import CommandStart
-from aiogram.types import Message
+from aiogram.types import CallbackQuery, Message
 
+from dvorik.bot import callbacks, keyboards
 from dvorik.core.registry import BotRouterRegistry
 
 __all__ = ["router", "register"]
@@ -19,7 +18,32 @@ async def handle_start(message: Message) -> None:
 
     await message.answer(
         "Привет! Я бот новой архитектуры Dvorik. Функционал скоро появится.",
+        reply_markup=keyboards.core_entry_keyboard(),
     )
+
+
+@router.callback_query()
+async def handle_core_callbacks(query: CallbackQuery) -> None:
+    """Process callbacks from the core namespace."""
+
+    if not query.data:
+        return
+
+    try:
+        payload = callbacks.parse(query.data, expected_namespace="builtin.core")
+    except ValueError:
+        return
+
+    if payload.action == "status":
+        await query.answer("Мы активно переносим функциональность в новую версию.")
+    elif payload.action == "feedback":
+        await query.answer("Будем рады обратной связи!", show_alert=False)
+        if query.message:
+            await query.message.answer(
+                "Напишите нам в служебный чат или через поддержку, чтобы поделиться предложениями."
+            )
+    else:
+        await query.answer("Действие пока не поддерживается.")
 
 
 def register() -> None:

--- a/dvorik/bot/routers/stock.py
+++ b/dvorik/bot/routers/stock.py
@@ -1,11 +1,10 @@
-"""Routers dedicated to stock management flows."""
-
 from __future__ import annotations
 
 from aiogram import Router
 from aiogram.filters import Command
-from aiogram.types import Message
+from aiogram.types import CallbackQuery, Message
 
+from dvorik.bot import callbacks, keyboards
 from dvorik.core.registry import BotRouterRegistry
 
 __all__ = ["router", "register"]
@@ -19,7 +18,32 @@ async def handle_stock_entry(message: Message) -> None:
 
     await message.answer(
         "Задачи по остаткам ещё переносятся в новую версию. Следите за обновлениями!",
+        reply_markup=keyboards.stock_entry_keyboard(),
     )
+
+
+@router.callback_query()
+async def handle_stock_callbacks(query: CallbackQuery) -> None:
+    """Handle callbacks scoped to stock actions."""
+
+    if not query.data:
+        return
+
+    try:
+        payload = callbacks.parse(query.data, expected_namespace="builtin.stock")
+    except ValueError:
+        return
+
+    if payload.action == "status":
+        await query.answer("Модуль остатков в работе, планируем запуск после тестов.")
+    elif payload.action == "feedback":
+        await query.answer("Принято!", show_alert=False)
+        if query.message:
+            await query.message.answer(
+                "Сообщите, какие сценарии по остаткам важнее всего, чтобы мы приоритизировали их."
+            )
+    else:
+        await query.answer("Пока без действий.")
 
 
 def register() -> None:

--- a/dvorik/bot/routers/supply.py
+++ b/dvorik/bot/routers/supply.py
@@ -1,11 +1,10 @@
-"""Routers focused on supply import and tracking."""
-
 from __future__ import annotations
 
 from aiogram import Router
 from aiogram.filters import Command
-from aiogram.types import Message
+from aiogram.types import CallbackQuery, Message
 
+from dvorik.bot import callbacks, keyboards
 from dvorik.core.registry import BotRouterRegistry
 
 __all__ = ["router", "register"]
@@ -19,7 +18,32 @@ async def handle_supply_entry(message: Message) -> None:
 
     await message.answer(
         "Импорт поставок пока в процессе миграции. Эта команда заработает позже.",
+        reply_markup=keyboards.supply_entry_keyboard(),
     )
+
+
+@router.callback_query()
+async def handle_supply_callbacks(query: CallbackQuery) -> None:
+    """Handle callbacks linked to supply features."""
+
+    if not query.data:
+        return
+
+    try:
+        payload = callbacks.parse(query.data, expected_namespace="builtin.supply")
+    except ValueError:
+        return
+
+    if payload.action == "status":
+        await query.answer("Импорт поставок появится после переноса сервисов импорта.")
+    elif payload.action == "feedback":
+        await query.answer("Записали!")
+        if query.message:
+            await query.message.answer(
+                "Сообщите, какие форматы поставок важны, чтобы мы учли это при запуске."
+            )
+    else:
+        await query.answer("Эта функция скоро появится.")
 
 
 def register() -> None:


### PR DESCRIPTION
## Summary
- add utilities to build and parse namespaced callback payloads for the bot
- provide reusable inline keyboards that generate callbacks under router namespaces
- update built-in routers to use the keyboards and handle callbacks safely

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcbab8a6688326af836ed1737f49c8