### PR TITLE
Add bot card rendering helpers

### DIFF
--- a/dvorik/bot/cards.py
+++ b/dvorik/bot/cards.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Sequence
+
+from dvorik.domain.models import Product, StockSnapshot
+
+from . import texts
+
+__all__ = [
+    "CardSection",
+    "Card",
+    "RenderedCard",
+    "product_card",
+]
+
+
+@dataclass(slots=True)
+class CardSection:
+    """Logical section inside a card."""
+
+    title: str | None = None
+    lines: Sequence[str] = field(default_factory=tuple)
+
+    def render(self) -> str:
+        """Render section into text block."""
+
+        content = [line for line in self.lines if line]
+        if not content:
+            return ""
+        if self.title:
+            return texts.join_non_empty(
+                (texts.bold(self.title), *content),
+                separator="\n",
+            )
+        return "\n".join(content)
+
+
+@dataclass(slots=True)
+class RenderedCard:
+    """Rendered card ready to be sent via Telegram."""
+
+    text: str
+    parse_mode: str = "HTML"
+    photo_file_id: str | None = None
+    photo_path: str | None = None
+
+    def as_message_kwargs(self) -> dict[str, object]:
+        """Return kwargs usable with ``bot.send_message`` or ``bot.send_photo``."""
+
+        payload: dict[str, object] = {"text": self.text, "parse_mode": self.parse_mode}
+        if self.photo_file_id:
+            payload["photo"] = self.photo_file_id
+        elif self.photo_path:
+            payload["photo"] = self.photo_path
+        return payload
+
+
+@dataclass(slots=True)
+class Card:
+    """High level description of a message card."""
+
+    title: str | None = None
+    sections: Sequence[CardSection] = field(default_factory=tuple)
+    footer: str | None = None
+    photo_file_id: str | None = None
+    photo_path: str | None = None
+
+    def render(self) -> RenderedCard:
+        """Render card into ``RenderedCard`` object."""
+
+        blocks = []
+        if self.title:
+            blocks.append(texts.bold(self.title))
+        blocks.extend(filter(None, (section.render() for section in self.sections)))
+        if self.footer:
+            blocks.append(self.footer)
+
+        text = "\n\n".join(blocks)
+        return RenderedCard(
+            text=text,
+            photo_file_id=self.photo_file_id,
+            photo_path=self.photo_path,
+        )
+
+
+def _build_meta_lines(product: Product) -> list[str]:
+    lines: list[str] = []
+    lines.append(texts.label_value("Артикул", texts.code(product.article)) if product.article else None)
+    lines.append(texts.label_value("Штрихкод", texts.code(product.barcode)) if product.barcode else None)
+    lines.append(texts.label_value("Локальное название", texts.escape(product.local_name)) if product.local_name else None)
+    lines.append(texts.label_value("Единица", texts.escape(product.unit)) if product.unit else None)
+    if product.price is not None:
+        price_value = texts.format_money(product.price)
+        if product.unit:
+            price_value = f"{price_value}{texts.NBSP}/{texts.NBSP}{texts.escape(product.unit)}"
+        lines.append(texts.label_value("Цена", price_value))
+    if product.vat_rate is not None:
+        vat_value = f"{texts.escape(product.vat_rate)}%"
+        lines.append(texts.label_value("Ставка НДС", vat_value))
+    if product.is_new:
+        lines.append(texts.italic("Новинка"))
+    if product.archived:
+        lines.append(texts.label_value("Статус", texts.bold("В архиве")))
+    if product.last_restock_at:
+        lines.append(
+            texts.label_value("Последнее пополнение", texts.format_datetime(product.last_restock_at))
+        )
+    if product.updated_at:
+        lines.append(texts.label_value("Обновлено", texts.format_datetime(product.updated_at)))
+    return [line for line in lines if line]
+
+
+def _build_stock_lines(product: Product, stock: Sequence[StockSnapshot] | None) -> list[str]:
+    if not stock:
+        return []
+
+    lines: list[str] = []
+    for snapshot in stock:
+        location_name = snapshot.location.title or snapshot.location.code
+        qty_text = texts.format_quantity(snapshot.qty_pack, unit=product.unit)
+        if snapshot.reserved_pack:
+            reserve = texts.format_quantity(snapshot.reserved_pack, unit=product.unit)
+            qty_text = texts.join_non_empty([qty_text, texts.italic(f"(резерв {reserve})")], separator=" ")
+        lines.append(texts.label_value(location_name, qty_text))
+    return [line for line in lines if line]
+
+
+def product_card(
+    product: Product,
+    /,
+    *,
+    stock: Sequence[StockSnapshot] | None = None,
+    show_description: bool = True,
+) -> RenderedCard:
+    """Build card representation for :class:`~dvorik.domain.models.Product`."""
+
+    sections: list[CardSection] = []
+
+    meta_lines = _build_meta_lines(product)
+    if meta_lines:
+        sections.append(CardSection(title="Характеристики", lines=meta_lines))
+
+    stock_lines = _build_stock_lines(product, stock)
+    if stock_lines:
+        sections.append(CardSection(title="Остатки", lines=stock_lines))
+
+    footer: str | None = None
+    if show_description and product.description and product.description.strip():
+        footer = texts.escape(product.description.strip())
+
+    card = Card(
+        title=product.name or "Товар",
+        sections=sections,
+        footer=footer,
+        photo_file_id=product.photo_file_id,
+        photo_path=product.photo_path,
+    )
+    return card.render()

--- a/dvorik/bot/texts.py
+++ b/dvorik/bot/texts.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import html
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
+from typing import Iterable
+
+__all__ = [
+    "NBSP",
+    "escape",
+    "bold",
+    "italic",
+    "underline",
+    "code",
+    "pre",
+    "join_non_empty",
+    "bullet_list",
+    "label_value",
+    "format_money",
+    "format_quantity",
+    "format_bool",
+    "format_datetime",
+]
+
+NBSP = "\u00a0"
+
+
+def escape(text: object | None) -> str:
+    """Return HTML-escaped representation of *text* for Telegram messages."""
+
+    if text is None:
+        return ""
+    return html.escape(str(text), quote=False)
+
+
+def bold(text: object | None) -> str:
+    """Wrap *text* with ``<b>`` tags after escaping it."""
+
+    return f"<b>{escape(text)}</b>"
+
+
+def italic(text: object | None) -> str:
+    """Wrap *text* with ``<i>`` tags after escaping it."""
+
+    return f"<i>{escape(text)}</i>"
+
+
+def underline(text: object | None) -> str:
+    """Wrap *text* with ``<u>`` tags after escaping it."""
+
+    return f"<u>{escape(text)}</u>"
+
+
+def code(text: object | None) -> str:
+    """Wrap *text* with ``<code>`` tags after escaping it."""
+
+    return f"<code>{escape(text)}</code>"
+
+
+def pre(text: object | None) -> str:
+    """Wrap *text* with ``<pre>`` tags after escaping it."""
+
+    return f"<pre>{escape(text)}</pre>"
+
+
+def join_non_empty(parts: Iterable[str | None], *, separator: str = "\n") -> str:
+    """Join non-empty *parts* using *separator*."""
+
+    return separator.join(part for part in parts if part)
+
+
+def bullet_list(items: Iterable[str | None], *, bullet: str = "•") -> str:
+    """Return ``\n``-joined bullet list preserving existing markup."""
+
+    escaped_bullet = escape(bullet) if bullet else ""
+    lines = []
+    for item in items:
+        if not item:
+            continue
+        if escaped_bullet:
+            lines.append(f"{escaped_bullet}{NBSP}{item}")
+        else:
+            lines.append(item)
+    return "\n".join(lines)
+
+
+def label_value(label: str, value: str | None) -> str | None:
+    """Return ``"<b>Label:</b> value"`` style string when *value* is provided."""
+
+    if not value:
+        return None
+    label_part = bold(f"{label}:")
+    return f"{label_part}{NBSP}{value}"
+
+
+def _to_decimal(value: float | int | Decimal) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError) as exc:  # pragma: no cover - defensive
+        raise ValueError("value cannot be converted to Decimal") from exc
+
+
+def _format_decimal(value: Decimal, *, precision: int) -> str:
+    quantizer = Decimal("1").scaleb(-precision)
+    quantized = value.quantize(quantizer) if precision >= 0 else value
+    if precision > 0:
+        formatted = f"{quantized:,.{precision}f}"
+        if "." in formatted:
+            formatted = formatted.rstrip("0").rstrip(".")
+    elif precision == 0:
+        formatted = f"{quantized:,.0f}"
+    else:  # pragma: no cover - precision < 0 is not expected currently
+        formatted = f"{quantized}"
+    return formatted.replace(",", NBSP)
+
+
+def format_money(
+    amount: float | int | Decimal | None,
+    *,
+    currency: str = "₽",
+    precision: int = 2,
+    none_text: str = "—",
+) -> str:
+    """Format monetary *amount* with currency sign suitable for HTML output."""
+
+    if amount is None:
+        return escape(none_text)
+
+    value = _to_decimal(amount)
+    formatted = _format_decimal(value, precision=precision)
+    currency_part = escape(currency)
+    return join_non_empty([escape(formatted), currency_part], separator=NBSP)
+
+
+def format_quantity(
+    value: float | int | Decimal | None,
+    *,
+    unit: str | None = None,
+    precision: int = 2,
+    none_text: str = "—",
+) -> str:
+    """Format numeric quantity optionally appending *unit* label."""
+
+    if value is None:
+        return escape(none_text)
+
+    decimal_value = _to_decimal(value)
+    formatted = _format_decimal(decimal_value, precision=precision)
+    unit_part = escape(unit) if unit else ""
+    return join_non_empty([escape(formatted), unit_part], separator=NBSP)
+
+
+def format_bool(
+    value: bool | None,
+    *,
+    true_text: str = "Да",
+    false_text: str = "Нет",
+    none_text: str = "—",
+) -> str:
+    """Return human-readable representation for boolean flags."""
+
+    if value is None:
+        return escape(none_text)
+    return escape(true_text if value else false_text)
+
+
+def format_datetime(
+    value: datetime | date | str | None,
+    *,
+    datetime_format: str = "%d.%m.%Y %H:%M",
+    date_format: str = "%d.%m.%Y",
+    none_text: str = "—",
+) -> str:
+    """Format ``datetime``/``date`` objects or plain strings for display."""
+
+    if value is None:
+        return escape(none_text)
+    if isinstance(value, datetime):
+        return escape(value.strftime(datetime_format))
+    if isinstance(value, date):
+        return escape(value.strftime(date_format))
+    return escape(value)


### PR DESCRIPTION
## Summary
- add reusable card primitives for bot messages including a product card builder
- provide text formatting utilities for HTML-based Telegram output

## Testing
- python -m py_compile dvorik/bot/cards.py dvorik/bot/texts.py

------
https://chatgpt.com/codex/tasks/task_e_68dcbbca407883269f868fc6efca4ffd