### PR TITLE
Integrate import completion events

### DIFF
--- a/dvorik/admin/blueprints/supply.py
+++ b/dvorik/admin/blueprints/supply.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import logging
@@ -16,7 +17,7 @@ from dvorik.core.config import Config
 from dvorik.db.conn import db
 from dvorik.domain.models import ImportLogEntry
 from dvorik.repo.import_repo import SQLiteImportLogRepo
-from dvorik.services.imports import ImportBatch, ImportFacade
+from dvorik.services.imports import ImportBatch, ImportFacade, log_completed_import
 
 blueprint = Blueprint("supply", __name__, url_prefix="/supply")
 
@@ -188,7 +189,13 @@ def confirm_import() -> Response:
     try:
         conn = db()
         repo = SQLiteImportLogRepo(conn)
-        saved_entry = repo.add(entry)
+        saved_entry = asyncio.run(
+            log_completed_import(
+                repo,
+                entry,
+                metadata={"stored_path": entry.stored_path},
+            )
+        )
     except Exception:  # pragma: no cover - defensive logging
         logger.exception("Failed to persist import log entry")
         return _redirect_with_status("error", "Failed to record the import in the log.")

--- a/dvorik/services/imports/__init__.py
+++ b/dvorik/services/imports/__init__.py
@@ -5,11 +5,24 @@ import hashlib
 import io
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable, List, Mapping, Sequence
+from typing import Any, Dict, Iterable, List, Mapping, Sequence
+
+from dvorik.core import events
+from dvorik.domain.models import ImportLogEntry
+from dvorik.domain.ports import ImportLogRepo
 
 from .strategies import ColumnMapping, detect_columns, parse_csv, parse_sheet
 
-__all__ = ["ImportBatch", "ImportFacade", "NormalisedRow", "normalise_rows"]
+__all__ = [
+    "ImportBatch",
+    "ImportFacade",
+    "NormalisedRow",
+    "log_completed_import",
+    "normalise_rows",
+]
+
+
+_IMPORT_COMPLETED_EVENT = "import.completed"
 
 
 NormalisedRow = Mapping[str, Any]
@@ -105,6 +118,52 @@ class ImportFacade:
             for row in normalised:
                 writer.writerow({key: row.get(key) for key in headers})
         return target_path
+
+
+async def log_completed_import(
+    repo: ImportLogRepo,
+    entry: ImportLogEntry,
+    *,
+    metadata: Mapping[str, Any] | None = None,
+) -> ImportLogEntry:
+    """Persist ``entry`` and publish an ``import.completed`` event.
+
+    Parameters
+    ----------
+    repo:
+        Repository responsible for storing the import log entry.
+    entry:
+        Dataclass describing the processed import.
+    metadata:
+        Optional additional values to merge into the published event payload.
+
+    Returns
+    -------
+    ImportLogEntry
+        The stored representation returned by the repository.
+    """
+
+    saved_entry = repo.add(entry)
+
+    payload: Dict[str, Any] = {
+        "entry": saved_entry,
+        "import_id": saved_entry.id,
+        "original_name": saved_entry.original_name,
+        "import_type": saved_entry.import_type,
+        "source_hash": saved_entry.source_hash,
+        "items_count": saved_entry.items_count,
+    }
+    if saved_entry.supplier:
+        payload["supplier"] = saved_entry.supplier
+    if saved_entry.invoice:
+        payload["invoice"] = saved_entry.invoice
+    if saved_entry.normalized_hash:
+        payload["normalized_hash"] = saved_entry.normalized_hash
+    if metadata:
+        payload.update(metadata)
+
+    await events.publish(_IMPORT_COMPLETED_EVENT, **payload)
+    return saved_entry
 
 
 def normalise_rows(

--- a/tests/rebuild/test_service_events.py
+++ b/tests/rebuild/test_service_events.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from dvorik.core import events
+from dvorik.db.migrations import init_db
+from dvorik.domain.models import ImportLogEntry, Location, LowStockRecord, Product
+from dvorik.services import notify
+from dvorik.services import stock as stock_service
+from dvorik.services.imports import log_completed_import
+
+
+@pytest.fixture(autouse=True)
+def clear_event_bus():
+    events._clear_subscribers()
+    yield
+    events._clear_subscribers()
+
+
+def _make_connection() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:", detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES)
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+    return conn
+
+
+def test_stock_adjustment_triggers_threshold_notification():
+    conn = _make_connection()
+    with conn:
+        conn.execute("INSERT INTO product(id, name) VALUES (1, 'Widget')")
+        conn.execute(
+            "INSERT INTO location(code, kind, title) VALUES ('LOC-1', 'SHOP', 'Main Shop')"
+        )
+
+    product = Product(id=1, name="Widget")
+    location = Location(code="LOC-1", kind="SHOP", title="Main Shop")
+    record = LowStockRecord(product=product, location=location, qty_pack=0.5, threshold=1.0)
+
+    class StubStockRepo:
+        def __init__(self) -> None:
+            self.requests: list[tuple[float, int]] = []
+
+        def low_stock(self, *, threshold: float | None = None, limit: int = 20):
+            self.requests.append((float(threshold or 0), limit))
+            return (record,)
+
+    notifications: list[dict[str, object]] = []
+
+    async def callback(payload):
+        notifications.append(dict(payload))
+
+    repo = StubStockRepo()
+    unsubscribe = notify.notify_instant_thresholds(repo, callback, threshold=1.0, limit=5)
+
+    asyncio.run(stock_service.set_location_qty(conn, 1, "LOC-1", 0.5))
+
+    try:
+        assert notifications, "Expected notification to be emitted"
+        message = notifications[0]
+        assert message["type"] == "threshold"
+        assert message["product_id"] == 1
+        assert message["location_code"] == "LOC-1"
+        assert pytest.approx(message["qty_after"], rel=1e-9) == 0.5
+        assert message["record"] == record
+        assert repo.requests == [(1.0, 5)]
+    finally:
+        unsubscribe()
+
+
+def test_log_completed_import_publishes_event():
+    entry = ImportLogEntry(
+        original_name="latest.xlsx",
+        stored_path="/tmp/latest.xlsx",
+        import_type="excel",
+        source_hash="abc123",
+        items_count=7,
+    )
+    stored_entry = replace(
+        entry,
+        id=42,
+        normalized_hash="def456",
+        supplier="ACME",
+        invoice="INV-7",
+    )
+
+    class StubImportRepo:
+        def __init__(self) -> None:
+            self.entries: list[ImportLogEntry] = []
+
+        def add(self, log_entry: ImportLogEntry) -> ImportLogEntry:
+            self.entries.append(log_entry)
+            return stored_entry
+
+    received: list[dict[str, object]] = []
+
+    async def handler(**payload):
+        received.append(payload)
+
+    events.subscribe("import.completed", handler)
+
+    repo = StubImportRepo()
+    result = asyncio.run(log_completed_import(repo, entry, metadata={"extra": "value"}))
+
+    assert result is stored_entry
+    assert repo.entries == [entry]
+    assert received, "Import completion event was not published"
+    payload = received[0]
+    assert payload["entry"] is stored_entry
+    assert payload["import_id"] == 42
+    assert payload["original_name"] == "latest.xlsx"
+    assert payload["items_count"] == 7
+    assert payload["supplier"] == "ACME"
+    assert payload["invoice"] == "INV-7"
+    assert payload["normalized_hash"] == "def456"
+    assert payload["extra"] == "value"
+


### PR DESCRIPTION
## Summary
- add an async helper that stores import log entries and publishes an `import.completed` event
- use the helper from the supply confirmation flow so imports emit events with metadata
- cover stock and import event integration with new service-level tests

## Testing
- pytest tests/rebuild/test_service_events.py

------
https://chatgpt.com/codex/tasks/task_e_68dcbd24e8b883269c4caccea6747dd3