### PR TITLE
Add admin authentication guard

### DIFF
--- a/dvorik/admin/auth.py
+++ b/dvorik/admin/auth.py
@@ -1,0 +1,218 @@
+"""Authentication helpers and routes for the admin application."""
+
+from __future__ import annotations
+
+import hmac
+import logging
+import os
+from functools import wraps
+from typing import Callable, Mapping, ParamSpec, TypeVar, cast
+from urllib.parse import urlsplit
+
+from flask import (
+    Blueprint,
+    Flask,
+    Response,
+    current_app,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
+from flask.typing import ResponseReturnValue
+
+from dvorik.core.config import Config
+
+logger = logging.getLogger(__name__)
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+_SESSION_KEY = "dvorik.superadmin"
+_CONFIG_CREDENTIALS_KEY = "DVORIK_ADMIN_CREDENTIALS"
+
+_USERNAME_ENV_KEYS: tuple[str, ...] = ("DVORIK_ADMIN_USERNAME", "SUPER_ADMIN_USERNAME")
+_PASSWORD_ENV_KEYS: tuple[str, ...] = (
+    "DVORIK_ADMIN_PASSWORD",
+    "SUPER_ADMIN_PASSWORD",
+)
+_SECRET_ENV_KEYS: tuple[str, ...] = (
+    "DVORIK_ADMIN_SECRET_KEY",
+    "DVORIK_ADMIN_SECRET",
+    "FLASK_SECRET_KEY",
+    "SECRET_KEY",
+)
+
+blueprint = Blueprint("auth", __name__, url_prefix="/auth")
+
+
+def init_app(app: Flask, *, config: Config) -> None:
+    """Configure authentication for the admin application."""
+
+    credentials = {
+        "username": _resolve_username(config),
+        "password": _resolve_password(),
+    }
+
+    secret_key = _resolve_secret_key()
+
+    app.secret_key = secret_key
+    app.config[_CONFIG_CREDENTIALS_KEY] = credentials
+
+    app.register_blueprint(blueprint)
+
+
+def is_superadmin_authenticated() -> bool:
+    """Return ``True`` when the current session belongs to the superadmin."""
+
+    return bool(session.get(_SESSION_KEY))
+
+
+def ensure_superadmin() -> Response | None:
+    """Abort the request with ``403`` when no authenticated superadmin is present."""
+
+    if not is_superadmin_authenticated():
+        return _forbidden_response()
+    return None
+
+
+def require_superadmin(func: Callable[P, R]) -> Callable[P, R | ResponseReturnValue]:
+    """Decorator ensuring that the wrapped view is accessible to superadmins only."""
+
+    @wraps(func)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R | ResponseReturnValue:
+        failure = ensure_superadmin()
+        if failure is not None:
+            return failure
+        return func(*args, **kwargs)
+
+    return cast(Callable[P, R | ResponseReturnValue], wrapper)
+
+
+@blueprint.get("/login")
+def login_form() -> ResponseReturnValue:
+    """Render the authentication form."""
+
+    if is_superadmin_authenticated():
+        return redirect(_safe_next_url(request.args.get("next")) or url_for("home.index"))
+
+    context = _build_login_context()
+    return render_template("auth/login.html", **context)
+
+
+@blueprint.post("/login")
+def login_submit() -> ResponseReturnValue:
+    """Validate submitted credentials and initialise the session."""
+
+    form_username = (request.form.get("username") or "").strip()
+    form_password = request.form.get("password") or ""
+    next_url = _safe_next_url(request.form.get("next") or request.args.get("next"))
+
+    expected_username, expected_password = _expected_credentials()
+
+    if _matches(form_username, expected_username) and _matches(form_password, expected_password):
+        session[_SESSION_KEY] = expected_username
+        session.permanent = True
+        session.modified = True
+        destination = next_url or url_for("home.index")
+        logger.info("Superadmin authenticated", extra={"username": expected_username})
+        return redirect(destination)
+
+    logger.warning("Failed superadmin login attempt", extra={"username": form_username})
+
+    context = _build_login_context(
+        username=form_username,
+        error="Invalid username or password. Please try again.",
+    )
+    context["next_url"] = next_url
+    return render_template("auth/login.html", **context), 401
+
+
+@blueprint.post("/logout")
+def logout() -> ResponseReturnValue:
+    """Terminate the authenticated session and redirect to the login form."""
+
+    session.pop(_SESSION_KEY, None)
+    session.modified = True
+    next_url = _safe_next_url(request.form.get("next") or request.args.get("next"))
+    destination = next_url or url_for("auth.login")
+    return redirect(destination)
+
+
+def _build_login_context(*, username: str | None = None, error: str | None = None) -> Mapping[str, object]:
+    next_url = _safe_next_url(request.args.get("next"))
+    return {
+        "username": username or "",
+        "error": error,
+        "next_url": next_url,
+    }
+
+
+def _expected_credentials() -> tuple[str, str]:
+    config_value = current_app.config.get(_CONFIG_CREDENTIALS_KEY)
+    if not isinstance(config_value, Mapping):  # pragma: no cover - defensive guard
+        raise RuntimeError("Admin credentials are not initialised")
+    username = str(config_value.get("username") or "")
+    password = str(config_value.get("password") or "")
+    return username, password
+
+
+def _resolve_username(config: Config) -> str:
+    for key in _USERNAME_ENV_KEYS:
+        value = os.environ.get(key)
+        if value:
+            return value.strip()
+    return config.super_admin_username
+
+
+def _resolve_password() -> str:
+    for key in _PASSWORD_ENV_KEYS:
+        value = os.environ.get(key)
+        if value:
+            return value
+    raise RuntimeError(
+        "Admin password environment variable is not set. "
+        "Provide DVORIK_ADMIN_PASSWORD to enable the admin interface."
+    )
+
+
+def _resolve_secret_key() -> str:
+    for key in _SECRET_ENV_KEYS:
+        value = os.environ.get(key)
+        if value:
+            return value
+    logger.warning("Falling back to an insecure development secret key")
+    return "dev-insecure-admin-secret"
+
+
+def _safe_next_url(candidate: str | None) -> str | None:
+    if not candidate:
+        return None
+    parsed = urlsplit(candidate)
+    if parsed.scheme or parsed.netloc:
+        return None
+    if candidate.startswith("//"):
+        return None
+    return candidate
+
+
+def _matches(value: str, expected: str) -> bool:
+    if not expected:
+        return False
+    return hmac.compare_digest(value, expected)
+
+
+def _forbidden_response() -> Response:
+    login_url = url_for("auth.login", next=request.url)
+    response = render_template("auth/forbidden.html", login_url=login_url)
+    return Response(response, status=403)
+
+
+__all__ = [
+    "blueprint",
+    "ensure_superadmin",
+    "init_app",
+    "is_superadmin_authenticated",
+    "require_superadmin",
+]

--- a/dvorik/admin/blueprints/superadmin.py
+++ b/dvorik/admin/blueprints/superadmin.py
@@ -8,6 +8,7 @@ import sqlite3
 
 from flask import Blueprint, Response, has_request_context, redirect, render_template, request, url_for
 
+from dvorik.admin.auth import require_superadmin
 from dvorik.db.conn import db
 
 logger = logging.getLogger(__name__)
@@ -16,6 +17,7 @@ blueprint = Blueprint("superadmin", __name__, url_prefix="/superadmin")
 
 
 @blueprint.get("/")
+@require_superadmin
 def dashboard() -> str:
     """Render the management console overview."""
 
@@ -32,6 +34,7 @@ def dashboard() -> str:
 
 
 @blueprint.post("/widgets/save")
+@require_superadmin
 def save_widget() -> Response:
     """Create or update a widget definition."""
 
@@ -90,6 +93,7 @@ def save_widget() -> Response:
 
 
 @blueprint.post("/widgets/delete")
+@require_superadmin
 def delete_widget() -> Response:
     """Delete a widget definition."""
 
@@ -114,6 +118,7 @@ def delete_widget() -> Response:
 
 
 @blueprint.post("/widget-instances/save")
+@require_superadmin
 def save_widget_instance() -> Response:
     """Create or update a widget instance."""
 
@@ -178,6 +183,7 @@ def save_widget_instance() -> Response:
 
 
 @blueprint.post("/widget-instances/delete")
+@require_superadmin
 def delete_widget_instance() -> Response:
     """Remove a widget instance."""
 
@@ -206,6 +212,7 @@ def delete_widget_instance() -> Response:
 
 
 @blueprint.post("/menu/save")
+@require_superadmin
 def save_menu_entry() -> Response:
     """Create or update a menu entry."""
 
@@ -272,6 +279,7 @@ def save_menu_entry() -> Response:
 
 
 @blueprint.post("/menu/delete")
+@require_superadmin
 def delete_menu_entry() -> Response:
     """Remove a menu entry."""
 
@@ -296,6 +304,7 @@ def delete_menu_entry() -> Response:
 
 
 @blueprint.post("/queries/save")
+@require_superadmin
 def save_query() -> Response:
     """Create or update a stored SQL query."""
 
@@ -350,6 +359,7 @@ def save_query() -> Response:
 
 
 @blueprint.post("/queries/delete")
+@require_superadmin
 def delete_query() -> Response:
     """Delete a stored SQL query."""
 
@@ -374,6 +384,7 @@ def delete_query() -> Response:
 
 
 @blueprint.post("/jobs/save")
+@require_superadmin
 def save_job() -> Response:
     """Create or update a scheduled job."""
 
@@ -469,6 +480,7 @@ def save_job() -> Response:
 
 
 @blueprint.post("/jobs/delete")
+@require_superadmin
 def delete_job() -> Response:
     """Delete a scheduled job."""
 

--- a/dvorik/admin/blueprints/supply.py
+++ b/dvorik/admin/blueprints/supply.py
@@ -14,6 +14,7 @@ from werkzeug.datastructures import FileStorage
 from werkzeug.utils import secure_filename
 
 from dvorik.core.config import Config
+from dvorik.admin.auth import require_superadmin
 from dvorik.db.conn import db
 from dvorik.domain.models import ImportLogEntry
 from dvorik.repo.import_repo import SQLiteImportLogRepo
@@ -47,6 +48,7 @@ class PreviewContext:
 
 
 @blueprint.get("/")
+@require_superadmin
 def supply_home() -> str:
     """Render the supply management landing page."""
 
@@ -62,6 +64,7 @@ def supply_home() -> str:
 
 
 @blueprint.post("/preview")
+@require_superadmin
 def preview_import() -> str | Response:
     """Accept an uploaded file and display a preview before importing."""
 
@@ -113,6 +116,7 @@ def preview_import() -> str | Response:
 
 
 @blueprint.post("/confirm")
+@require_superadmin
 def confirm_import() -> Response:
     """Persist a processed import into the database."""
 
@@ -216,6 +220,7 @@ def confirm_import() -> Response:
 
 
 @blueprint.post("/<int:import_id>/revert")
+@require_superadmin
 def revert_import(import_id: int) -> Response:
     """Mark an import as reverted for audit purposes."""
 

--- a/dvorik/admin/server.py
+++ b/dvorik/admin/server.py
@@ -26,6 +26,10 @@ def create_app(*, config: Config | None = None) -> Flask:
     )
     app.config["DVORIK_CONFIG"] = config
 
+    from . import auth as auth_module
+
+    auth_module.init_app(app, config=config)
+
     _initialise_database()
     _register_builtin_components()
     _register_blueprints(app)

--- a/dvorik/admin/templates/auth/forbidden.html
+++ b/dvorik/admin/templates/auth/forbidden.html
@@ -1,0 +1,59 @@
+{% extends "base.html" %}
+
+{% block title %}Access denied · Dvorik Admin{% endblock %}
+{% block header_title %}Access denied{% endblock %}
+{% block header_subtitle %}
+  <p class="header-subtitle">You need to sign in as the superadmin to access this area.</p>
+{% endblock %}
+{% block header_actions %}{% endblock %}
+
+{% block base_styles %}
+  {{ super() }}
+  .auth-forbidden {
+    max-width: 520px;
+    margin: 2.5rem auto;
+    padding: 2.25rem 2rem;
+    border-radius: 20px;
+    background: var(--surface);
+    box-shadow: var(--shadow);
+    text-align: center;
+  }
+
+  .auth-forbidden h2 {
+    margin: 0 0 1rem;
+    font-size: 1.6rem;
+  }
+
+  .auth-forbidden p {
+    margin: 0 0 1.5rem;
+    color: var(--text-muted);
+  }
+
+  .auth-forbidden a {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.65rem 1.25rem;
+    border-radius: 14px;
+    background: var(--accent);
+    color: #fff;
+    font-weight: 600;
+    text-decoration: none;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .auth-forbidden a:hover,
+  .auth-forbidden a:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 16px 30px rgba(79, 70, 229, 0.25);
+  }
+{% endblock %}
+
+{% block content %}
+  <section class="auth-forbidden" aria-labelledby="auth-forbidden-title">
+    <h2 id="auth-forbidden-title">Authentication required</h2>
+    <p>You are not currently signed in. Please authenticate to continue.</p>
+    <a href="{{ login_url }}">Sign in</a>
+  </section>
+{% endblock %}

--- a/dvorik/admin/templates/auth/login.html
+++ b/dvorik/admin/templates/auth/login.html
@@ -1,0 +1,113 @@
+{% extends "base.html" %}
+
+{% block title %}Sign in · Dvorik Admin{% endblock %}
+{% block header_title %}Sign in{% endblock %}
+{% block header_subtitle %}
+  <p class="header-subtitle">Access to supply operations and the superadmin console is restricted.</p>
+{% endblock %}
+{% block header_actions %}{% endblock %}
+
+{% block base_styles %}
+  {{ super() }}
+  .auth-card {
+    max-width: 420px;
+    margin: 2rem auto;
+    padding: 2.25rem 2rem;
+    border-radius: 20px;
+    background: var(--surface);
+    box-shadow: var(--shadow);
+  }
+
+  .auth-card h2 {
+    margin: 0 0 1.25rem;
+    font-size: 1.5rem;
+  }
+
+  .auth-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .auth-field label {
+    font-weight: 600;
+    color: var(--text-muted);
+  }
+
+  .auth-field input {
+    padding: 0.7rem 0.85rem;
+    border-radius: 12px;
+    border: 1px solid var(--border-soft);
+    background: var(--surface-muted);
+    font: inherit;
+  }
+
+  .auth-submit {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    border-radius: 14px;
+    border: none;
+    font-weight: 600;
+    background: var(--accent);
+    color: #fff;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .auth-submit:hover,
+  .auth-submit:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 16px 30px rgba(79, 70, 229, 0.25);
+  }
+
+  .auth-error {
+    margin-bottom: 1rem;
+    padding: 0.75rem 1rem;
+    border-radius: 12px;
+    background: rgba(239, 68, 68, 0.15);
+    color: #991b1b;
+    font-weight: 600;
+  }
+
+  .auth-hint {
+    margin-top: 1rem;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+  }
+{% endblock %}
+
+{% block content %}
+  <section class="auth-card" aria-labelledby="auth-card-title">
+    <h2 id="auth-card-title">Authenticate as Superadmin</h2>
+    {% if error %}
+      <div class="auth-error" role="alert">{{ error }}</div>
+    {% endif %}
+    <form method="post" action="{{ url_for('auth.login') }}">
+      <input type="hidden" name="next" value="{{ next_url or '' }}">
+      <div class="auth-field">
+        <label for="auth-username">Username</label>
+        <input
+          id="auth-username"
+          name="username"
+          type="text"
+          value="{{ username }}"
+          autocomplete="username"
+          required
+        >
+      </div>
+      <div class="auth-field">
+        <label for="auth-password">Password</label>
+        <input
+          id="auth-password"
+          name="password"
+          type="password"
+          autocomplete="current-password"
+          required
+        >
+      </div>
+      <button type="submit" class="auth-submit">Sign in</button>
+    </form>
+    <p class="auth-hint">Use the credentials configured via environment variables.</p>
+  </section>
+{% endblock %}

--- a/dvorik/admin/templates/base.html
+++ b/dvorik/admin/templates/base.html
@@ -533,6 +533,51 @@
         display: none;
       }
 
+      .auth-status {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.75rem;
+        background: var(--surface);
+        padding: 0.5rem 0.75rem 0.5rem 0.85rem;
+        border-radius: 999px;
+        box-shadow: var(--shadow);
+      }
+
+      .auth-status__label {
+        font-size: 0.9rem;
+        color: var(--text-muted);
+      }
+
+      .auth-logout-form {
+        margin: 0;
+      }
+
+      .auth-button {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.45rem 1rem;
+        border-radius: 999px;
+        border: 1px solid transparent;
+        background: var(--accent);
+        color: #fff;
+        font-weight: 600;
+        cursor: pointer;
+        text-decoration: none;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      .auth-button--logout {
+        background: rgba(239, 68, 68, 0.12);
+        color: #b91c1c;
+      }
+
+      .auth-button:hover,
+      .auth-button:focus-visible {
+        transform: translateY(-1px);
+        box-shadow: 0 16px 30px rgba(79, 70, 229, 0.25);
+      }
+
       .branding h1 {
         margin: 0;
         font-size: 1.75rem;
@@ -669,7 +714,22 @@
           </div>
         </div>
         <div class="header-right">
-          {%- block header_actions %}{% endblock -%}
+          {%- block header_actions %}
+            {% set next_url = request.full_path if request.query_string else request.path %}
+            <div class="auth-status">
+              {% if session.get('dvorik.superadmin') %}
+                <span class="auth-status__label">
+                  Signed in as {{ session.get('dvorik.superadmin') }}
+                </span>
+                <form method="post" action="{{ url_for('auth.logout') }}" class="auth-logout-form">
+                  <input type="hidden" name="next" value="{{ next_url }}">
+                  <button type="submit" class="auth-button auth-button--logout">Sign out</button>
+                </form>
+              {% else %}
+                <a class="auth-button" href="{{ url_for('auth.login', next=next_url) }}">Sign in</a>
+              {% endif %}
+            </div>
+          {%- endblock -%}
         </div>
       </header>
       <main class="app-main">


### PR DESCRIPTION
## Summary
- add a session-based admin authentication module with login/logout routes
- protect the superadmin and supply blueprints with the new `require_superadmin` decorator
- surface sign-in/out controls and dedicated auth templates in the admin UI

## Testing
- DVORIK_ADMIN_PASSWORD=test-pass DVORIK_ADMIN_SECRET_KEY=test-secret pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcc2ddb5788326a1fa241e86ea168f