### PR TITLE
Add audit log browsing to superadmin console

### DIFF
--- a/dvorik/admin/blueprints/superadmin.py
+++ b/dvorik/admin/blueprints/superadmin.py
@@ -29,6 +29,7 @@ def dashboard() -> str:
         menu_entries=data["menu_entries"],
         queries=data["queries"],
         jobs=data["jobs"],
+        audit_entries=data["audit_entries"],
         schedule_types=("daily", "cron"),
     )
 
@@ -567,6 +568,26 @@ def _fetch_dashboard_data() -> dict[str, list[sqlite3.Row]]:
                 """
             ).fetchall()
         )
+
+        audit_entries = [
+            {
+                "id": row["id"],
+                "created_at": row["created_at"],
+                "actor_username": row["actor_username"],
+                "action": row["action"],
+                "entity": row["entity"],
+                "entity_id": row["entity_id"],
+                "payload": _deserialize_payload(row["payload_json"]),
+            }
+            for row in conn.execute(
+                """
+                SELECT id, created_at, actor_username, action, entity, entity_id, payload_json
+                FROM audit_log
+                ORDER BY datetime(created_at) DESC, id DESC
+                LIMIT 100
+                """
+            ).fetchall()
+        ]
     finally:
         conn.close()
 
@@ -576,6 +597,7 @@ def _fetch_dashboard_data() -> dict[str, list[sqlite3.Row]]:
         "menu_entries": menu_entries,
         "queries": queries,
         "jobs": jobs,
+        "audit_entries": audit_entries,
     }
 
 
@@ -641,6 +663,19 @@ def _log_audit(conn: sqlite3.Connection, action: str, entity: str, entity_id: in
             json.dumps(record, ensure_ascii=False),
         ),
     )
+
+
+def _deserialize_payload(payload_json: str | None) -> dict[str, Any] | None:
+    if not payload_json:
+        return None
+    try:
+        data = json.loads(payload_json)
+    except json.JSONDecodeError:
+        logger.warning("Failed to decode audit payload JSON: %s", payload_json)
+        return None
+    if isinstance(data, dict):
+        return data
+    return {"value": data}
 
 
 def _format_error(exc: Exception) -> str:

--- a/dvorik/admin/templates/superadmin/dashboard.html
+++ b/dvorik/admin/templates/superadmin/dashboard.html
@@ -130,6 +130,41 @@
     gap: 0.75rem;
   }
 
+  .audit-log-wrapper {
+    overflow-x: auto;
+  }
+
+  .audit-log-table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 720px;
+  }
+
+  .audit-log-table th,
+  .audit-log-table td {
+    text-align: left;
+    padding: 0.75rem 0.85rem;
+    border-bottom: 1px solid var(--border-soft);
+    vertical-align: top;
+  }
+
+  .audit-log-table tbody tr:nth-child(even) {
+    background: rgba(79, 70, 229, 0.05);
+  }
+
+  .audit-log-meta {
+    color: var(--text-muted);
+    font-size: 0.85rem;
+  }
+
+  .audit-log-table td pre {
+    margin: 0;
+    font-family: var(--font-mono, "SFMono-Regular", Menlo, Consolas, monospace);
+    font-size: 0.85rem;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
   .button {
     display: inline-flex;
     align-items: center;
@@ -664,6 +699,56 @@
           </div>
         </form>
       </details>
+    </section>
+
+    <section id="audit-log" class="superadmin-section">
+      <header>
+        <h2>Audit log</h2>
+        <p>Review recent configuration changes performed via this console.</p>
+      </header>
+
+      {% if audit_entries %}
+        <div class="audit-log-wrapper">
+          <table class="audit-log-table">
+            <thead>
+              <tr>
+                <th scope="col">Timestamp</th>
+                <th scope="col">Actor</th>
+                <th scope="col">Action</th>
+                <th scope="col">Entity</th>
+                <th scope="col">Payload</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for entry in audit_entries %}
+                <tr>
+                  <td>
+                    <div>{{ entry.created_at or '—' }}</div>
+                    <div class="audit-log-meta">#{{ entry.id }}</div>
+                  </td>
+                  <td>{{ entry.actor_username or '—' }}</td>
+                  <td>{{ entry.action }}</td>
+                  <td>
+                    <div>{{ entry.entity or '—' }}</div>
+                    {% if entry.entity_id %}
+                      <div class="audit-log-meta">ID: {{ entry.entity_id }}</div>
+                    {% endif %}
+                  </td>
+                  <td>
+                    {% if entry.payload %}
+                      <pre>{{ entry.payload | tojson(indent=2) }}</pre>
+                    {% else %}
+                      —
+                    {% endif %}
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% else %}
+        <p class="empty-state">No audit events recorded yet.</p>
+      {% endif %}
     </section>
   </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- fetch recent audit entries when rendering the superadmin dashboard
- expose the audit history in the console with a formatted table for payload details

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcc55acfc483269153957d11c7e784