### PR TITLE
Add composition root and module entry points

### DIFF
--- a/dvorik/__init__.py
+++ b/dvorik/__init__.py
@@ -1,3 +1,5 @@
 """New modular implementation of the Dvorik project."""
 
-__all__ = ["__doc__"]
+from .app import DvorikSystem, create_system
+
+__all__ = ["create_system", "DvorikSystem"]

--- a/dvorik/admin/__main__.py
+++ b/dvorik/admin/__main__.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+"""Module entry point exposing ``python -m dvorik.admin``."""
+
+from dvorik.app import create_system
+
+
+def main() -> None:
+    system = create_system()
+    system.run_admin()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution entry point
+    main()

--- a/dvorik/app.py
+++ b/dvorik/app.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+"""Composition root wiring shared infrastructure for the Dvorik project."""
+
+import datetime as dt
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Awaitable, Callable
+
+from dvorik.core import events
+from dvorik.core.config import Config, get_config
+from dvorik.core.plugins import load_plugins
+from dvorik.core.registry import JobRegistry
+from dvorik.core.scheduler import register_daily
+from dvorik.db import init_db
+
+if TYPE_CHECKING:  # pragma: no cover - imported only for type checkers
+    from flask import Flask
+
+logger = logging.getLogger(__name__)
+
+AdminAppFactory = Callable[[], "Flask"]
+AdminRunner = Callable[..., None]
+BotRunner = Callable[[], Awaitable[None]]
+
+_DAILY_TICK_JOB_KEY = "builtin.scheduler.daily_tick"
+_DAILY_TICK_EVENT = "scheduler.daily"
+_DAILY_TICK_TIME = dt.time(hour=9, minute=0)
+
+
+@dataclass(slots=True)
+class DvorikSystem:
+    """Container exposing factories for the admin UI and Telegram bot."""
+
+    config: Config
+    create_admin_app: AdminAppFactory
+    run_admin: AdminRunner
+    run_bot: BotRunner
+
+
+def create_system(*, config: Config | None = None) -> DvorikSystem:
+    """Initialise shared services and return runnable application factories."""
+
+    config = config or get_config()
+
+    logger.debug("Initialising Dvorik system")
+    init_db()
+
+    plugins = load_plugins()
+    if plugins:
+        logger.info("Loaded %d plugin(s)", len(plugins))
+    else:
+        logger.info("No plugins discovered")
+
+    _register_admin_components()
+    _register_bot_components()
+    _register_scheduler_jobs()
+
+    return DvorikSystem(
+        config=config,
+        create_admin_app=_create_admin_app_factory(config),
+        run_admin=_create_admin_runner(config),
+        run_bot=_create_bot_runner(config),
+    )
+
+
+def _create_admin_app_factory(config: Config) -> AdminAppFactory:
+    from dvorik.admin.server import create_app
+
+    def factory() -> "Flask":
+        return create_app(config=config)
+
+    return factory
+
+
+def _create_admin_runner(config: Config) -> AdminRunner:
+    factory = _create_admin_app_factory(config)
+
+    def runner(*, host: str = "0.0.0.0", port: int | None = None, debug: bool = True) -> None:
+        app = factory()
+        final_port = port if port is not None else config.admin_port
+        logger.info("Starting admin server on %s:%s", host, final_port)
+        app.run(host=host, port=final_port, debug=debug)
+
+    return runner
+
+
+def _create_bot_runner(config: Config) -> BotRunner:
+    from dvorik.bot.main import run_bot
+
+    async def runner() -> None:
+        await run_bot(config=config)
+
+    return runner
+
+
+def _register_admin_components() -> None:
+    try:
+        from dvorik.admin.widgets import register_builtin_widgets
+    except Exception:  # pragma: no cover - defensive guard
+        logger.exception("Failed to import admin widgets for registration")
+        raise
+
+    try:
+        register_builtin_widgets()
+    except Exception:  # pragma: no cover - defensive guard
+        logger.exception("Failed to register built-in admin widgets")
+        raise
+
+
+def _register_bot_components() -> None:
+    try:
+        from dvorik.bot.routers import register_builtin_routers
+    except Exception:  # pragma: no cover - defensive guard
+        logger.exception("Failed to import bot routers for registration")
+        raise
+
+    try:
+        register_builtin_routers()
+    except Exception:  # pragma: no cover - defensive guard
+        logger.exception("Failed to register built-in bot routers")
+        raise
+
+
+def _register_scheduler_jobs() -> None:
+    async def _emit_daily_tick() -> None:
+        await events.publish(_DAILY_TICK_EVENT)
+
+    job = register_daily(_DAILY_TICK_JOB_KEY, _emit_daily_tick, at=_DAILY_TICK_TIME)
+    JobRegistry.register(_DAILY_TICK_JOB_KEY, job, replace=True)
+    logger.debug(
+        "Registered daily scheduler job '%s' at %s",
+        _DAILY_TICK_JOB_KEY,
+        _DAILY_TICK_TIME.isoformat(timespec="minutes"),
+    )
+
+
+__all__ = ["create_system", "DvorikSystem"]
+

--- a/dvorik/bot/__main__.py
+++ b/dvorik/bot/__main__.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+"""Module entry point exposing ``python -m dvorik.bot``."""
+
+import asyncio
+
+from dvorik.app import create_system
+
+
+def main() -> None:
+    system = create_system()
+    asyncio.run(system.run_bot())
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution entry point
+    main()


### PR DESCRIPTION
## Summary
- add `dvorik.app.create_system` to bootstrap the database, plugins, and built-in components while returning factories for the admin UI and bot
- expose the composition root via the package `__init__` and provide Python module entry points for `python -m dvorik.admin` and `python -m dvorik.bot`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcc6c4a2008326af6bbcb1a7b72142