### PR TITLE
Update requirements and runner scripts for new architecture

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,14 @@
 aiogram==3.7.0
-pandas==2.2.2
+Flask==3.0.3
+Pillow==10.4.0
 openpyxl==3.1.5
+pandas==2.2.2
 xlrd==2.0.1
 xlrd2==1.3.4
-Pillow==10.4.0
-Flask==3.0.3
+
+# Optional developer tooling (install with `pip install -r requirements.txt`)
+black==24.8.0
+mypy==1.10.0
+pytest==8.3.2
+pytest-asyncio==0.23.8
+ruff==0.5.7

--- a/run_admin.command
+++ b/run_admin.command
@@ -85,6 +85,13 @@ python -m pip install -r requirements.txt
 export PYTHONUNBUFFERED=1
 export PYTHONPATH="$SCRIPT_DIR:${PYTHONPATH:-}"
 
+# Проверка наличия новой архитектуры
+if [ ! -d "$SCRIPT_DIR/dvorik" ]; then
+  echo "Каталог $SCRIPT_DIR/dvorik не найден — проверьте структуру проекта." >&2
+  ls -la "$SCRIPT_DIR" >&2
+  exit 1
+fi
+
 # Настройки хоста/порта админки: слушаем на всех интерфейсах, если не задано явно
 export ADMIN_HOST="${ADMIN_HOST:-0.0.0.0}"
 export ADMIN_PORT="${ADMIN_PORT:-8000}"
@@ -119,4 +126,18 @@ if [ -n "${LAN_IP}" ] && [ "${LAN_IP}" != "127.0.0.1" ]; then
 fi
 echo "Слушаю на ${ADMIN_HOST}:${ADMIN_PORT} (если фаерволл открыт)"
 
-python -m admin_ui
+python - <<'PY'
+import os
+
+from dvorik.app import create_system
+
+
+def main() -> None:
+    system = create_system()
+    host = os.environ.get("ADMIN_HOST", "0.0.0.0")
+    system.run_admin(host=host)
+
+
+if __name__ == "__main__":
+    main()
+PY

--- a/run_bot.command
+++ b/run_bot.command
@@ -92,11 +92,11 @@ python -m ensurepip --upgrade || true
 python -m pip install --upgrade pip
 python -m pip install -r requirements.txt
 
-# 6) Запуск бота (через модуль app.main)
+# 6) Запуск бота (новая архитектура dvorik)
 
-# Проверим, что есть пакет app
-if [ ! -d "$SCRIPT_DIR/app" ]; then
-  echo "Каталог $SCRIPT_DIR/app не найден — проверьте структуру проекта." >&2
+# Проверим, что пакет dvorik доступен
+if [ ! -d "$SCRIPT_DIR/dvorik" ]; then
+  echo "Каталог $SCRIPT_DIR/dvorik не найден — проверьте структуру проекта." >&2
   ls -la "$SCRIPT_DIR" >&2
   exit 1
 fi
@@ -123,7 +123,7 @@ PY
 fi
 
 START_TS=$(date +%s)
-python -m app.main
+python -m dvorik.bot
 CODE=$?
 END_TS=$(date +%s)
 DUR=$((END_TS-START_TS))


### PR DESCRIPTION
## Summary
- expand `requirements.txt` with developer tooling alongside existing runtime packages
- point `run_admin.command` and `run_bot.command` at the new `dvorik` entry points with safety checks for the rebuilt stack

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcca38feb08326a8edd4ea0625a8a6