### PR TITLE
Implement stock widgets, bot scenarios, and notification bridge

### DIFF
--- a/dvorik/admin/widgets/builtin.py
+++ b/dvorik/admin/widgets/builtin.py
@@ -2,13 +2,21 @@
 
 from __future__ import annotations
 
+import datetime as dt
 import logging
 import sqlite3
+from collections import defaultdict
+from contextlib import closing
 from dataclasses import dataclass
-from typing import Mapping, MutableMapping
+from html import escape
+from itertools import groupby
+from typing import Any, Iterable, Mapping, MutableMapping, Sequence
 
 from dvorik.core.plugins import register_widget
 from dvorik.db.conn import db
+from dvorik.domain.models import LowStockRecord, StockSnapshot
+from dvorik.repo.schedule_repo import SQLiteScheduleRepo
+from dvorik.repo.stock_repo import SQLiteStockRepo
 
 from .api import Widget, WidgetContext
 
@@ -35,12 +43,28 @@ class LowStockWidget(Widget):
     description = "Highlights products that are running low on inventory."
 
     def render(self, context: WidgetContext | None = None) -> str:
-        return """
-        <section class="widget widget-low-stock">
-            <header><h3>Low stock overview</h3></header>
-            <p>No stock analytics are available yet.</p>
-        </section>
-        """.strip()
+        threshold = float(_get_widget_option("threshold", 5, self.config, context))
+        limit = int(_get_widget_option("limit", 10, self.config, context))
+
+        with closing(db()) as conn:
+            records = SQLiteStockRepo(conn).low_stock(threshold=threshold, limit=limit)
+
+        rows = tuple(_render_low_stock_rows(records))
+        body = (
+            "<p>Всё в порядке, запасов достаточно.</p>"
+            if not rows
+            else _build_table(
+                headings=("Товар", "Локация", "Остаток"),
+                rows=rows,
+            )
+        )
+
+        return (
+            "<section class=\"widget widget-low-stock\">"
+            "<header><h3>Low stock overview</h3></header>"
+            f"<div class=\"widget-body\">{body}</div>"
+            "</section>"
+        )
 
 
 class ScheduleMiniWidget(Widget):
@@ -49,12 +73,50 @@ class ScheduleMiniWidget(Widget):
     description = "Shows the current duty schedule summary."
 
     def render(self, context: WidgetContext | None = None) -> str:
-        return """
-        <section class="widget widget-schedule-mini">
-            <header><h3>Schedule snapshot</h3></header>
-            <p>Scheduling data is coming soon.</p>
-        </section>
-        """.strip()
+        horizon = int(_get_widget_option("days", 7, self.config, context))
+        today = dt.date.today()
+        end_date = today + dt.timedelta(days=max(horizon - 1, 0))
+
+        with closing(db()) as conn:
+            repo = SQLiteScheduleRepo(conn)
+            assignments = repo.assignments(today.isoformat(), end_date.isoformat())
+            days = {item.date: repo.day(item.date) for item in {a.date for a in assignments}}
+
+        grouped: dict[str, list[int]] = defaultdict(list)
+        for assignment in assignments:
+            grouped[assignment.date].append(assignment.tg_id)
+
+        rows: list[tuple[str, str, str]] = []
+        for current_date in sorted(grouped.keys()):
+            day = days.get(current_date)
+            friendly_date = _format_date(current_date)
+            status = "Открыто" if (day.is_open if day else True) else "Закрыто"
+            notes = escape(day.notes) if day and day.notes else ""
+            assignees = ", ".join(str(tg_id) for tg_id in grouped[current_date]) or "—"
+            subtitle = f"<div class=\"notes\">{notes}</div>" if notes else ""
+            rows.append(
+                (
+                    f"{friendly_date}{subtitle}",
+                    status,
+                    escape(assignees),
+                )
+            )
+
+        body = (
+            "<p>В ближайшие дни дежурства не назначены.</p>"
+            if not rows
+            else _build_table(
+                headings=("Дата", "Статус", "Дежурные"),
+                rows=rows,
+            )
+        )
+
+        return (
+            "<section class=\"widget widget-schedule-mini\">"
+            "<header><h3>Schedule snapshot</h3></header>"
+            f"<div class=\"widget-body\">{body}</div>"
+            "</section>"
+        )
 
 
 class StockByLocationWidget(Widget):
@@ -63,12 +125,89 @@ class StockByLocationWidget(Widget):
     description = "Displays stock totals grouped by location."
 
     def render(self, context: WidgetContext | None = None) -> str:
-        return """
-        <section class="widget widget-stock-by-location">
-            <header><h3>Stock by location</h3></header>
-            <p>Location statistics are not yet implemented.</p>
-        </section>
-        """.strip()
+        location_code = _get_widget_option("location", None, self.config, context)
+        limit = int(_get_widget_option("limit", 15, self.config, context))
+
+        with closing(db()) as conn:
+            repo = SQLiteStockRepo(conn)
+            snapshots = repo.stock_by_location(
+                location_code=str(location_code) if location_code else None,
+            )
+
+        limited = list(snapshots)[:limit]
+        rows = tuple(_render_location_rows(limited))
+        body = (
+            "<p>Нет данных по остаткам на выбранных локациях.</p>"
+            if not rows
+            else _build_table(
+                headings=("Локация", "Товар", "Остаток"),
+                rows=rows,
+            )
+        )
+
+        return (
+            "<section class=\"widget widget-stock-by-location\">"
+            "<header><h3>Stock by location</h3></header>"
+            f"<div class=\"widget-body\">{body}</div>"
+            "</section>"
+        )
+
+
+def _get_widget_option(
+    key: str,
+    default: object,
+    config: Mapping[str, Any],
+    context: WidgetContext | None,
+) -> object:
+    if key in config:
+        return config[key]
+    if context and key in context.config:
+        return context.config[key]
+    return default
+
+
+def _build_table(*, headings: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    head_html = "".join(f"<th>{escape(str(title))}</th>" for title in headings)
+    body_html = "".join(
+        "<tr>" + "".join(f"<td>{cell}</td>" for cell in row) + "</tr>" for row in rows
+    )
+    return f"<table><thead><tr>{head_html}</tr></thead><tbody>{body_html}</tbody></table>"
+
+
+def _render_low_stock_rows(records: Sequence[LowStockRecord]) -> Iterable[tuple[str, str, str]]:
+    for record in records:
+        product_name = escape(record.product.name or "Без названия")
+        location_name = escape(record.location.title or record.location.code)
+        qty_text = escape(_format_quantity(record.qty_pack, record.product.unit))
+        yield (product_name, location_name, qty_text)
+
+
+def _render_location_rows(snapshots: Sequence[StockSnapshot]) -> Iterable[tuple[str, str, str]]:
+    for location_code, group in groupby(
+        snapshots,
+        key=lambda snap: snap.location.code,
+    ):
+        entries = list(group)
+        location_title = entries[0].location.title or location_code
+        for snapshot in entries:
+            product = snapshot.product
+            product_name = escape(product.name or "Без названия")
+            location_label = escape(location_title)
+            qty_text = escape(_format_quantity(snapshot.qty_pack, product.unit))
+            yield (location_label, product_name, qty_text)
+
+
+def _format_quantity(value: float, unit: str | None) -> str:
+    qty = f"{value:.2f}".rstrip("0").rstrip(".")
+    return f"{qty} {unit}".strip() if unit else qty
+
+
+def _format_date(value: str) -> str:
+    try:
+        parsed = dt.date.fromisoformat(value)
+    except ValueError:
+        return escape(value)
+    return parsed.strftime("%d.%m.%Y")
 
 
 _BUILTIN_WIDGETS: tuple[_WidgetDefinition, ...] = (

--- a/dvorik/app.py
+++ b/dvorik/app.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import datetime as dt
 import logging
+import sqlite3
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Awaitable, Callable
+from typing import TYPE_CHECKING, Awaitable, Callable, Mapping, MutableMapping
 
 from dvorik.core import events
 from dvorik.core.config import Config, get_config
@@ -26,6 +27,8 @@ BotRunner = Callable[[], Awaitable[None]]
 _DAILY_TICK_JOB_KEY = "builtin.scheduler.daily_tick"
 _DAILY_TICK_EVENT = "scheduler.daily"
 _DAILY_TICK_TIME = dt.time(hour=9, minute=0)
+_NOTIFICATION_EVENT = "bot.notifications.generated"
+_NOTIFICATION_STATE: MutableMapping[str, object] = {}
 
 
 @dataclass(slots=True)
@@ -55,6 +58,7 @@ def create_system(*, config: Config | None = None) -> DvorikSystem:
     _register_admin_components()
     _register_bot_components()
     _register_scheduler_jobs()
+    _register_notifications(config)
 
     return DvorikSystem(
         config=config,
@@ -133,6 +137,46 @@ def _register_scheduler_jobs() -> None:
         _DAILY_TICK_JOB_KEY,
         _DAILY_TICK_TIME.isoformat(timespec="minutes"),
     )
+
+
+def _register_notifications(config: Config) -> None:
+    from dvorik.repo.stock_repo import SQLiteStockRepo
+    from dvorik.services.notify import (
+        notify_instant_thresholds,
+        notify_instant_to_skl,
+        send_daily_digests,
+    )
+
+    existing = _NOTIFICATION_STATE.pop("unsubscribers", None)
+    if isinstance(existing, (list, tuple)):
+        for unsubscribe in existing:
+            try:
+                if callable(unsubscribe):
+                    unsubscribe()
+            except Exception:  # pragma: no cover - logging for observability
+                logger.exception("Failed to unregister previous notification subscriber")
+
+    previous_conn = _NOTIFICATION_STATE.pop("conn", None)
+    if isinstance(previous_conn, sqlite3.Connection):
+        previous_conn.close()
+
+    conn = db()
+    repo = SQLiteStockRepo(conn)
+
+    async def _dispatch(payload: Mapping[str, object]) -> None:
+        await events.publish(_NOTIFICATION_EVENT, payload=payload)
+
+    threshold = 2.0
+    stock_limit = max(config.stock_page_size, 50)
+    unsubscribers = [
+        notify_instant_thresholds(repo, _dispatch, threshold=threshold, limit=stock_limit),
+        notify_instant_to_skl(_dispatch),
+        send_daily_digests(repo, _dispatch, threshold=threshold, limit=stock_limit * 4),
+    ]
+
+    _NOTIFICATION_STATE["conn"] = conn
+    _NOTIFICATION_STATE["unsubscribers"] = unsubscribers
+    logger.debug("Notification subscribers registered (%d handlers)", len(unsubscribers))
 
 
 __all__ = ["create_system", "DvorikSystem"]

--- a/dvorik/bot/keyboards.py
+++ b/dvorik/bot/keyboards.py
@@ -14,46 +14,81 @@ __all__ = [
 ]
 
 
-def _coming_soon_keyboard(namespace: str) -> InlineKeyboardMarkup:
-    """Return a shared keyboard notifying users about pending features."""
+def core_entry_keyboard() -> InlineKeyboardMarkup:
+    """Keyboard for the ``/start`` command."""
 
     return InlineKeyboardMarkup(
         inline_keyboard=[
             [
                 InlineKeyboardButton(
-                    text="Узнать статус",
-                    callback_data=build(namespace, "status"),
-                )
-            ],
-            [
-                InlineKeyboardButton(
-                    text="Оставить отзыв",
-                    callback_data=build(namespace, "feedback"),
+                    text="Команды",
+                    callback_data=build("builtin.core", "help"),
                 )
             ],
         ]
     )
 
 
-def core_entry_keyboard() -> InlineKeyboardMarkup:
-    """Keyboard for the ``/start`` command."""
-
-    return _coming_soon_keyboard("builtin.core")
-
-
 def admin_entry_keyboard() -> InlineKeyboardMarkup:
     """Keyboard for the ``/admin`` command."""
 
-    return _coming_soon_keyboard("builtin.admin")
+    namespace = "builtin.admin"
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(
+                    text="Активные задачи",
+                    callback_data=build(namespace, "jobs"),
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="Заявки на доступ",
+                    callback_data=build(namespace, "requests"),
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="Обновить",
+                    callback_data=build(namespace, "refresh"),
+                )
+            ],
+        ]
+    )
 
 
 def stock_entry_keyboard() -> InlineKeyboardMarkup:
     """Keyboard for the ``/stock`` command."""
 
-    return _coming_soon_keyboard("builtin.stock")
+    namespace = "builtin.stock"
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(
+                    text="Низкие остатки",
+                    callback_data=build(namespace, "low"),
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="Справка",
+                    callback_data=build(namespace, "help"),
+                )
+            ],
+        ]
+    )
 
 
 def supply_entry_keyboard() -> InlineKeyboardMarkup:
     """Keyboard for the ``/supply`` command."""
 
-    return _coming_soon_keyboard("builtin.supply")
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(
+                    text="Уведомить о поставке",
+                    callback_data=build("builtin.supply", "announce"),
+                )
+            ],
+        ]
+    )

--- a/dvorik/bot/main.py
+++ b/dvorik/bot/main.py
@@ -16,6 +16,7 @@ from dvorik.core.plugins import load_plugins
 from dvorik.core.registry import BotRouterRegistry
 from dvorik.core.scheduler import run_forever
 from dvorik.db import init_db
+from dvorik.bot import notifications as bot_notifications
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +38,7 @@ async def run_bot(*, config: Config | None = None) -> None:
     )
     dispatcher = Dispatcher()
     _attach_registered_routers(dispatcher)
+    notification_unsubscribe = bot_notifications.setup_notification_bridge(bot, config)
 
     loop = asyncio.get_running_loop()
     scheduler_task = loop.create_task(run_forever(loop))
@@ -48,6 +50,7 @@ async def run_bot(*, config: Config | None = None) -> None:
         scheduler_task.cancel()
         with suppress(asyncio.CancelledError):
             await scheduler_task
+        notification_unsubscribe()
         await bot.session.close()
         logger.info("Bot shutdown complete")
 

--- a/dvorik/bot/notifications.py
+++ b/dvorik/bot/notifications.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from contextlib import closing
+from html import escape
+from typing import Callable, Mapping, Sequence
+
+from aiogram import Bot
+
+from dvorik.core import events
+from dvorik.core.config import Config
+from dvorik.db.conn import db
+from dvorik.domain.models import LowStockRecord, Product
+from dvorik.repo.product_repo import SQLiteProductRepo
+
+logger = logging.getLogger(__name__)
+
+_NOTIFICATION_EVENT = "bot.notifications.generated"
+
+__all__ = ["setup_notification_bridge"]
+
+
+def setup_notification_bridge(bot: Bot, config: Config) -> Callable[[], None]:
+    """Subscribe to notification events and relay them to Telegram."""
+
+    async def _listener(*, payload: Mapping[str, object]) -> None:
+        await _dispatch_notification(bot, config, payload)
+
+    events.subscribe(_NOTIFICATION_EVENT, _listener)
+    logger.debug("Notification bridge subscribed to '%s'", _NOTIFICATION_EVENT)
+
+    def _unsubscribe() -> None:
+        events.unsubscribe(_NOTIFICATION_EVENT, _listener)
+        logger.debug("Notification bridge unsubscribed from '%s'", _NOTIFICATION_EVENT)
+
+    return _unsubscribe
+
+
+async def _dispatch_notification(bot: Bot, config: Config, payload: Mapping[str, object]) -> None:
+    recipients = _resolve_recipients(config)
+    if not recipients:
+        logger.debug("No recipients configured for notification payload: %s", payload)
+        return
+
+    notification_type = payload.get("type")
+    text: str | None = None
+
+    if notification_type == "threshold":
+        record = payload.get("record")
+        if isinstance(record, LowStockRecord):
+            text = _format_threshold_notification(record, float(payload.get("threshold", 0)))
+    elif notification_type == "to_skl":
+        text = await _format_transfer_notification(payload)
+    elif notification_type == "daily_digest":
+        records = payload.get("records")
+        if isinstance(records, Sequence):
+            text = _format_digest_notification(tuple(r for r in records if isinstance(r, LowStockRecord)))
+    else:
+        logger.debug("Unsupported notification payload: %s", payload)
+        return
+
+    if not text:
+        logger.debug("Notification payload produced no message: %s", payload)
+        return
+
+    for chat_id in recipients:
+        try:
+            await bot.send_message(chat_id, text)
+        except Exception:  # pragma: no cover - network failures logged
+            logger.exception("Failed to send notification to %s", chat_id)
+
+
+def _resolve_recipients(config: Config) -> Sequence[int]:
+    if config.super_admin_id is None:
+        return ()
+    return (config.super_admin_id,)
+
+
+def _format_threshold_notification(record: LowStockRecord, threshold: float) -> str:
+    product_name = escape(record.product.name or "Без названия")
+    location_name = escape(record.location.title or record.location.code)
+    qty_text = _format_quantity(record.qty_pack, record.product.unit)
+    return (
+        "<b>Низкий остаток</b>\n"
+        f"{product_name} — {qty_text}\n"
+        f"Локация: {location_name}\n"
+        f"Порог: {threshold:.0f}"
+    )
+
+
+async def _format_transfer_notification(payload: Mapping[str, object]) -> str | None:
+    product_id = payload.get("product_id")
+    if not isinstance(product_id, int):
+        return None
+
+    qty = float(payload.get("qty") or 0)
+    from_code = payload.get("from_location")
+    to_code = payload.get("to_location")
+
+    product_display, unit, from_title, to_title = await asyncio.to_thread(
+        _lookup_transfer_context,
+        product_id,
+        from_code,
+        to_code,
+    )
+
+    qty_text = _format_quantity(qty, unit)
+    return (
+        "<b>Движение на склад</b>\n"
+        f"{product_display} — +{qty_text}\n"
+        f"Из {escape(from_title)} → {escape(to_title)}"
+    )
+
+
+def _format_digest_notification(records: Sequence[LowStockRecord]) -> str | None:
+    if not records:
+        return None
+
+    lines = ["<b>Сводка по остаткам</b>"]
+    for record in records[:20]:
+        product_name = escape(record.product.name or "Без названия")
+        location = escape(record.location.title or record.location.code)
+        qty_text = _format_quantity(record.qty_pack, record.product.unit)
+        lines.append(f"• {product_name} — {qty_text} ({location})")
+    return "\n".join(lines)
+
+
+def _lookup_transfer_context(
+    product_id: int,
+    from_code: object,
+    to_code: object,
+) -> tuple[str, str | None, str, str]:
+    with closing(db()) as conn:
+        repo = SQLiteProductRepo(conn)
+        product = repo.get(product_id)
+        product_display = _describe_product(product_id, product)
+        unit = product.unit if product else None
+        from_title = _lookup_location_title(conn, from_code)
+        to_title = _lookup_location_title(conn, to_code)
+    return product_display, unit, from_title, to_title
+
+
+def _describe_product(product_id: int, product: Product | None) -> str:
+    if product is None:
+        return escape(f"Товар #{product_id}")
+    name = product.name or product.local_name or f"Товар #{product_id}"
+    article = product.article or product.barcode
+    if article:
+        return f"{escape(name)} ({escape(article)})"
+    return escape(name)
+
+
+def _lookup_location_title(conn, code: object) -> str:
+    if not code:
+        return "не указано"
+    try:
+        row = conn.execute(
+            "SELECT title FROM location WHERE code = ?",
+            (str(code),),
+        ).fetchone()
+    except Exception:  # pragma: no cover - defensive logging
+        logger.exception("Failed to look up location title for %s", code)
+        return str(code)
+    if row and row["title"]:
+        return str(row["title"])
+    return str(code)
+
+
+def _format_quantity(value: float, unit: str | None) -> str:
+    qty = f"{value:.2f}".rstrip("0").rstrip(".")
+    if unit:
+        return f"{qty} {escape(unit)}"
+    return qty

--- a/dvorik/bot/routers/admin.py
+++ b/dvorik/bot/routers/admin.py
@@ -1,25 +1,37 @@
 from __future__ import annotations
 
+import asyncio
+import datetime as dt
+import sqlite3
+from contextlib import closing
+from html import escape
+from typing import Sequence
+
 from aiogram import Router
+from aiogram.exceptions import TelegramBadRequest
 from aiogram.filters import Command
 from aiogram.types import CallbackQuery, Message
 
 from dvorik.bot import callbacks, keyboards
-from dvorik.core.registry import BotRouterRegistry
+from dvorik.core.registry import BotRouterRegistry, JobRegistry
+from dvorik.db.conn import db
+from dvorik.domain.models import ScheduleTransferRequest
+from dvorik.repo.schedule_repo import SQLiteScheduleRepo
 
 __all__ = ["router", "register"]
 
 router = Router(name="builtin_admin")
 
+_REGISTRATION_LIMIT = 5
+_TRANSFER_LIMIT = 5
+
 
 @router.message(Command("admin"))
 async def handle_admin_entry(message: Message) -> None:
-    """Placeholder handler advertising upcoming admin features."""
+    """Send admin overview containing job and request summaries."""
 
-    await message.answer(
-        "Админ-команды скоро переедут сюда. Пока что раздел находится в разработке.",
-        reply_markup=keyboards.admin_entry_keyboard(),
-    )
+    overview = await asyncio.to_thread(_build_admin_overview)
+    await message.answer(overview, reply_markup=keyboards.admin_entry_keyboard())
 
 
 @router.callback_query()
@@ -34,19 +46,146 @@ async def handle_admin_callbacks(query: CallbackQuery) -> None:
     except ValueError:
         return
 
-    if payload.action == "status":
-        await query.answer("Мы готовим обновлённую админку, скоро поделимся деталями.")
-    elif payload.action == "feedback":
-        await query.answer("Спасибо!", show_alert=False)
+    if payload.action == "jobs":
+        await query.answer("Задачи обновлены", show_alert=False)
+        summary = await asyncio.to_thread(_format_jobs_section)
         if query.message:
-            await query.message.answer(
-                "Напишите свои пожелания в чат администраторов, чтобы мы учли их при релизе."
-            )
+            await query.message.answer(summary)
+    elif payload.action == "requests":
+        await query.answer("Заявки загружены", show_alert=False)
+        details = await asyncio.to_thread(_build_requests_overview)
+        if query.message:
+            await query.message.answer(details)
+    elif payload.action == "refresh":
+        await query.answer("Обновляю сводку", show_alert=False)
+        overview = await asyncio.to_thread(_build_admin_overview)
+        if query.message:
+            try:
+                await query.message.edit_text(
+                    overview,
+                    reply_markup=keyboards.admin_entry_keyboard(),
+                )
+            except TelegramBadRequest:
+                await query.message.answer(
+                    overview,
+                    reply_markup=keyboards.admin_entry_keyboard(),
+                )
     else:
-        await query.answer("Эта кнопка пока неактивна.")
+        await query.answer("Команда пока не поддерживается.")
 
 
 def register() -> None:
     """Register the admin router in the registry."""
 
     BotRouterRegistry.ensure("builtin.admin", lambda: router)
+
+
+def _build_admin_overview() -> str:
+    sections = (
+        _format_jobs_section(),
+        _format_registration_section(limit=_REGISTRATION_LIMIT),
+        _format_transfer_section(limit=_TRANSFER_LIMIT),
+    )
+    return "\n\n".join(filter(None, sections))
+
+
+def _build_requests_overview() -> str:
+    sections = (
+        _format_registration_section(limit=10),
+        _format_transfer_section(limit=10),
+    )
+    return "\n\n".join(filter(None, sections))
+
+
+def _format_jobs_section() -> str:
+    entries = sorted(JobRegistry.items())
+    if not entries:
+        return "<b>Фоновые задачи</b>\nНет зарегистрированных задач."
+
+    lines = ["<b>Фоновые задачи</b>"]
+    for key, job in entries:
+        next_run = _format_next_run(getattr(job, "next_run", None))
+        lines.append(f"• {escape(key)} — следующее исполнение: {next_run}")
+    return "\n".join(lines)
+
+
+def _format_registration_section(*, limit: int) -> str:
+    rows = _load_registration_requests(limit=limit)
+    if not rows:
+        return "<b>Заявки на доступ</b>\nАктивных заявок нет."
+
+    lines = ["<b>Заявки на доступ</b>"]
+    for row in rows:
+        lines.append(f"• {_format_registration_row(row)}")
+    return "\n".join(lines)
+
+
+def _format_transfer_section(*, limit: int) -> str:
+    requests = _load_transfer_requests(limit=limit)
+    if not requests:
+        return "<b>Запросы на обмен сменами</b>\nНет активных запросов."
+
+    lines = ["<b>Запросы на обмен сменами</b>"]
+    for request in requests:
+        lines.append(f"• {_format_transfer_request(request)}")
+    return "\n".join(lines)
+
+
+def _load_registration_requests(*, limit: int) -> Sequence[sqlite3.Row]:
+    with closing(db()) as conn:
+        cursor = conn.execute(
+            """
+            SELECT id, tg_id, username, first_name, last_name,
+                   requested_role, status, created_at
+            FROM registration_request
+            WHERE status = 'pending'
+            ORDER BY created_at ASC
+            LIMIT :limit
+            """,
+            {"limit": limit},
+        )
+        return cursor.fetchall()
+
+
+def _load_transfer_requests(*, limit: int) -> Sequence[ScheduleTransferRequest]:
+    with closing(db()) as conn:
+        repo = SQLiteScheduleRepo(conn)
+        requests = repo.transfer_requests(status="pending")
+        return tuple(requests[:limit])
+
+
+def _format_registration_row(row: sqlite3.Row) -> str:
+    username = f"@{row['username']}" if row["username"] else "—"
+    full_name = " ".join(part for part in (row["first_name"], row["last_name"]) if part).strip() or "—"
+    created = _format_timestamp(row["created_at"])
+    role = escape(str(row["requested_role"]))
+    tg_id = row["tg_id"]
+    identity = escape(f"{tg_id}" if tg_id else f"id={row['id']}")
+    return f"{identity} — {escape(username)} ({escape(full_name)}), роль {role}, подана {created}"
+
+
+def _format_transfer_request(request: ScheduleTransferRequest) -> str:
+    created = _format_timestamp(request.created_at)
+    expires = _format_timestamp(request.expires_at)
+    return (
+        f"{escape(request.date)} — {escape(str(request.from_tg_id))} → {escape(str(request.to_tg_id))}, "
+        f"создано {created}, действует до {expires}"
+    )
+
+
+def _format_timestamp(value: str | None) -> str:
+    if not value:
+        return "неизвестно"
+    try:
+        dt_value = dt.datetime.fromisoformat(value)
+    except ValueError:
+        return escape(value)
+    local = dt_value.astimezone(dt.datetime.now().astimezone().tzinfo)
+    return local.strftime("%d.%m %H:%M")
+
+
+def _format_next_run(next_run: dt.datetime | None) -> str:
+    if not next_run:
+        return "не запланировано"
+    local = next_run.astimezone(dt.datetime.now().astimezone().tzinfo)
+    return local.strftime("%d.%m %H:%M")

--- a/dvorik/bot/routers/stock.py
+++ b/dvorik/bot/routers/stock.py
@@ -1,23 +1,43 @@
 from __future__ import annotations
 
+import asyncio
+import sqlite3
+from contextlib import closing
+from html import escape
+from typing import Sequence
+
 from aiogram import Router
 from aiogram.filters import Command
 from aiogram.types import CallbackQuery, Message
 
 from dvorik.bot import callbacks, keyboards
+from dvorik.bot.cards import RenderedCard, product_card
 from dvorik.core.registry import BotRouterRegistry
+from dvorik.db.conn import db
+from dvorik.domain.models import LowStockRecord, Product, StockSnapshot
+from dvorik.repo.product_repo import SQLiteProductRepo
+from dvorik.repo.stock_repo import SQLiteStockRepo
 
 __all__ = ["router", "register"]
 
 router = Router(name="builtin_stock")
 
+_SEARCH_LIMIT = 5
+_LOW_STOCK_LIMIT = 8
+_LOW_STOCK_THRESHOLD = 2.0
+
 
 @router.message(Command("stock"))
 async def handle_stock_entry(message: Message) -> None:
-    """Placeholder entrypoint for upcoming stock operations."""
+    """Entry point for stock lookups and shortcuts."""
+
+    query = _extract_query(message)
+    if query:
+        await _handle_stock_search(message, query)
+        return
 
     await message.answer(
-        "Задачи по остаткам ещё переносятся в новую версию. Следите за обновлениями!",
+        "Введите запрос, например <code>/stock кофе</code> или артикул товара.",
         reply_markup=keyboards.stock_entry_keyboard(),
     )
 
@@ -34,19 +54,154 @@ async def handle_stock_callbacks(query: CallbackQuery) -> None:
     except ValueError:
         return
 
-    if payload.action == "status":
-        await query.answer("Модуль остатков в работе, планируем запуск после тестов.")
-    elif payload.action == "feedback":
-        await query.answer("Принято!", show_alert=False)
+    if payload.action == "low":
+        await query.answer("Собираю данные…", show_alert=False)
+        summary = await _load_low_stock_summary()
+        if query.message:
+            await query.message.answer(summary)
+    elif payload.action == "help":
+        await query.answer("Инструкция отправлена", show_alert=False)
         if query.message:
             await query.message.answer(
-                "Сообщите, какие сценарии по остаткам важнее всего, чтобы мы приоритизировали их."
+                "Используйте <code>/stock &lt;поиск&gt;</code> для выдачи карточек товаров.\n"
+                "Поддерживаются артикулы, штрихкоды и поиск по названию.",
             )
     else:
-        await query.answer("Пока без действий.")
+        await query.answer("Команда пока не поддерживается.")
 
 
 def register() -> None:
     """Register the stock router in the registry."""
 
     BotRouterRegistry.ensure("builtin.stock", lambda: router)
+
+
+def _extract_query(message: Message) -> str | None:
+    text = message.text or ""
+    parts = text.split(maxsplit=1)
+    if len(parts) < 2:
+        return None
+    query = parts[1].strip()
+    return query or None
+
+
+async def _handle_stock_search(message: Message, query: str) -> None:
+    safe_query = escape(query)
+    await message.answer(f"Поиск по запросу <b>{safe_query}</b>…")
+
+    cards = await asyncio.to_thread(_search_stock_cards, query, _SEARCH_LIMIT)
+    if not cards:
+        await message.answer("Совпадений не найдено.")
+        return
+
+    for card in cards:
+        await _send_card(message, card)
+
+
+async def _send_card(message: Message, card: RenderedCard) -> None:
+    payload = card.as_message_kwargs()
+    text = str(payload.get("text", ""))
+    parse_mode = str(payload.get("parse_mode", "HTML"))
+    photo = payload.get("photo")
+
+    if photo:
+        await message.answer_photo(photo=photo, caption=text, parse_mode=parse_mode)
+    else:
+        await message.answer(text=text, parse_mode=parse_mode)
+
+
+def _search_stock_cards(query: str, limit: int) -> Sequence[RenderedCard]:
+    with closing(db()) as conn:
+        product_repo = SQLiteProductRepo(conn)
+        stock_repo = SQLiteStockRepo(conn)
+
+        products = list(product_repo.search_fts(query, limit=limit))
+        if not products:
+            fallback = _fallback_product_lookup(product_repo, conn, query)
+            if fallback is not None:
+                products = [fallback]
+
+        product_ids = [product.id for product in products if product.id is not None]
+        stock_snapshots = stock_repo.stock_by_location(product_ids=product_ids)
+        stock_map = _group_stock_by_product(stock_snapshots)
+
+        cards: list[RenderedCard] = []
+        for product in products:
+            if product.id is None:
+                continue
+            snapshots = stock_map.get(product.id, ())
+            cards.append(product_card(product, stock=snapshots))
+        return cards
+
+
+def _fallback_product_lookup(
+    repo: SQLiteProductRepo,
+    conn: sqlite3.Connection,
+    query: str,
+) -> Product | None:
+    query = query.strip()
+    if not query:
+        return None
+
+    if query.isdigit():
+        product = repo.get(int(query))
+        if product is not None:
+            return product
+
+    row = conn.execute(
+        """
+        SELECT id FROM product
+        WHERE article = :query OR barcode = :query
+        ORDER BY id ASC
+        LIMIT 1
+        """,
+        {"query": query},
+    ).fetchone()
+    if row is None:
+        return None
+    return repo.get(int(row["id"]))
+
+
+def _group_stock_by_product(snapshots: Sequence[StockSnapshot]) -> dict[int, list[StockSnapshot]]:
+    grouped: dict[int, list[StockSnapshot]] = {}
+    for snapshot in snapshots:
+        product_id = snapshot.product.id
+        if product_id is None:
+            continue
+        grouped.setdefault(product_id, []).append(snapshot)
+    return grouped
+
+
+async def _load_low_stock_summary() -> str:
+    records = await asyncio.to_thread(
+        _load_low_stock_records,
+        _LOW_STOCK_THRESHOLD,
+        _LOW_STOCK_LIMIT,
+    )
+    if not records:
+        return "<b>Низкие остатки</b>\nПо текущему порогу всё в порядке."
+
+    lines = ["<b>Низкие остатки</b>"]
+    for record in records:
+        lines.append(_format_low_stock_record(record))
+    return "\n".join(lines)
+
+
+def _load_low_stock_records(threshold: float, limit: int) -> Sequence[LowStockRecord]:
+    with closing(db()) as conn:
+        repo = SQLiteStockRepo(conn)
+        return repo.low_stock(threshold=threshold, limit=limit)
+
+
+def _format_low_stock_record(record: LowStockRecord) -> str:
+    product_name = escape(record.product.name or "Без названия")
+    location_name = escape(record.location.title or record.location.code)
+    qty_text = _format_quantity(record.qty_pack, record.product.unit)
+    return f"• {product_name} — {qty_text} ({location_name})"
+
+
+def _format_quantity(value: float, unit: str | None) -> str:
+    qty = f"{value:.2f}".rstrip("0").rstrip(".")
+    if unit:
+        return f"{qty} {escape(unit)}"
+    return qty

--- a/dvorik/bot/routers/supply.py
+++ b/dvorik/bot/routers/supply.py
@@ -42,6 +42,12 @@ async def handle_supply_callbacks(query: CallbackQuery) -> None:
             await query.message.answer(
                 "Сообщите, какие форматы поставок важны, чтобы мы учли это при запуске."
             )
+    elif payload.action == "announce":
+        await query.answer("Принято", show_alert=False)
+        if query.message:
+            await query.message.answer(
+                "Отправьте детали поставки в рабочий чат — пока принимаем уведомления вручную."
+            )
     else:
         await query.answer("Эта функция скоро появится.")
 

--- a/dvorik/domain/ports.py
+++ b/dvorik/domain/ports.py
@@ -41,8 +41,13 @@ class StockRepo(Protocol):
     def get_item(self, product_id: int, location_code: str) -> StockItem | None:
         """Return stock information for a product at a location."""
 
-    def stock_by_location(self, location_code: str | None = None) -> Sequence[StockSnapshot]:
-        """Return stock grouped by location, optionally filtered by code."""
+    def stock_by_location(
+        self,
+        location_code: str | None = None,
+        *,
+        product_ids: Sequence[int] | None = None,
+    ) -> Sequence[StockSnapshot]:
+        """Return stock grouped by location with optional filters."""
 
     def low_stock(self, *, threshold: float | None = None, limit: int = 20) -> Sequence[LowStockRecord]:
         """Return stock entries considered below the provided threshold."""

--- a/dvorik/repo/stock_repo.py
+++ b/dvorik/repo/stock_repo.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from typing import Sequence
 
@@ -52,7 +53,12 @@ class SQLiteStockRepo(StockRepo):
             updated_at=row["updated_at"],
         )
 
-    def stock_by_location(self, location_code: str | None = None) -> Sequence[StockSnapshot]:
+    def stock_by_location(
+        self,
+        location_code: str | None = None,
+        *,
+        product_ids: Sequence[int] | None = None,
+    ) -> Sequence[StockSnapshot]:
         sql = get_query(
             self._conn,
             "repo.stock.by_location",
@@ -87,10 +93,23 @@ class SQLiteStockRepo(StockRepo):
             JOIN product AS p ON p.id = s.product_id
             JOIN location AS l ON l.code = s.location_code
             WHERE (:location_code IS NULL OR l.code = :location_code)
+              AND (
+                    :product_ids_json IS NULL
+                    OR p.id IN (
+                        SELECT value FROM json_each(:product_ids_json)
+                    )
+                )
             ORDER BY l.code, p.name COLLATE NOCASE
             """,
         )
-        cursor = self._conn.execute(sql, {"location_code": location_code})
+        product_ids_json = json.dumps(list(product_ids)) if product_ids else None
+        cursor = self._conn.execute(
+            sql,
+            {
+                "location_code": location_code,
+                "product_ids_json": product_ids_json,
+            },
+        )
         rows = cursor.fetchall()
         return [_row_to_snapshot(row) for row in rows]
 


### PR DESCRIPTION
## Summary
- render the default admin widgets with stock and schedule data sourced from the repositories
- replace the stock and admin bot routers with real search, status summaries, and updated keyboards
- register stock notifications and daily digests, adding a bot bridge to deliver events to Telegram

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcd7b1dbe08326ae903545471c6de7