### PR TITLE
Add scheduler catalog sync for DB-backed jobs

### DIFF
--- a/dvorik/admin/blueprints/superadmin.py
+++ b/dvorik/admin/blueprints/superadmin.py
@@ -10,6 +10,7 @@ from flask import Blueprint, Response, has_request_context, redirect, render_tem
 
 from dvorik.admin.auth import require_superadmin
 from dvorik.db.conn import db
+from dvorik.services.scheduler_catalog import sync_jobs as sync_scheduler_jobs
 
 logger = logging.getLogger(__name__)
 
@@ -422,6 +423,7 @@ def save_job() -> Response:
     }
 
     conn = db()
+    needs_sync = False
     try:
         with conn:
             if job_id is not None:
@@ -448,6 +450,7 @@ def save_job() -> Response:
                 if cursor.rowcount == 0:
                     return _redirect_to_dashboard("jobs", status="error", error="Scheduled job was not found.")
                 _log_audit(conn, "update", "scheduled_job", job_id, payload)
+                needs_sync = True
             else:
                 cursor = conn.execute(
                     """
@@ -471,11 +474,18 @@ def save_job() -> Response:
                 )
                 new_id = int(cursor.lastrowid)
                 _log_audit(conn, "create", "scheduled_job", new_id, payload)
+                needs_sync = True
     except sqlite3.Error as exc:  # pragma: no cover - defensive programming
         logger.exception("Failed to save scheduled job")
         return _redirect_to_dashboard("jobs", status="error", error=_format_error(exc))
     finally:
         conn.close()
+
+    if needs_sync:
+        try:
+            sync_scheduler_jobs()
+        except Exception:  # pragma: no cover - defensive guard
+            logger.exception("Failed to refresh scheduler after saving job")
 
     return _redirect_to_dashboard("jobs", status="saved")
 
@@ -490,17 +500,25 @@ def delete_job() -> Response:
         return _redirect_to_dashboard("jobs", status="error", error="Job id is required for deletion.")
 
     conn = db()
+    needs_sync = False
     try:
         with conn:
             cursor = conn.execute("DELETE FROM scheduled_job WHERE id = ?", (job_id,))
             if cursor.rowcount == 0:
                 return _redirect_to_dashboard("jobs", status="error", error="Scheduled job was not found.")
             _log_audit(conn, "delete", "scheduled_job", job_id, {"deleted": True})
+            needs_sync = True
     except sqlite3.Error as exc:  # pragma: no cover - defensive programming
         logger.exception("Failed to delete scheduled job")
         return _redirect_to_dashboard("jobs", status="error", error=_format_error(exc))
     finally:
         conn.close()
+
+    if needs_sync:
+        try:
+            sync_scheduler_jobs()
+        except Exception:  # pragma: no cover - defensive guard
+            logger.exception("Failed to refresh scheduler after deleting job")
 
     return _redirect_to_dashboard("jobs", status="deleted")
 

--- a/dvorik/app.py
+++ b/dvorik/app.py
@@ -13,6 +13,7 @@ from dvorik.core.plugins import load_plugins
 from dvorik.core.registry import JobRegistry
 from dvorik.core.scheduler import register_daily
 from dvorik.db import init_db
+from dvorik.services.scheduler_catalog import sync_jobs as sync_scheduler_jobs
 
 if TYPE_CHECKING:  # pragma: no cover - imported only for type checkers
     from flask import Flask
@@ -45,6 +46,7 @@ def create_system(*, config: Config | None = None) -> DvorikSystem:
 
     logger.debug("Initialising Dvorik system")
     init_db()
+    sync_scheduler_jobs()
 
     plugins = load_plugins()
     if plugins:

--- a/dvorik/core/scheduler.py
+++ b/dvorik/core/scheduler.py
@@ -164,6 +164,9 @@ class ScheduledJob:
     callback: Callback
     schedule: Schedule
     next_run: _dt.datetime | None = None
+    enabled: bool = True
+    metadata: dict[str, object] = dataclasses.field(default_factory=dict)
+    state_updater: Callable[[_dt.datetime | None, _dt.datetime | None], None] | None = None
 
     def compute_next_run(self, *, reference: _dt.datetime | None = None) -> None:
         reference = reference or _dt.datetime.now(_dt.timezone.utc)
@@ -174,15 +177,35 @@ _jobs: Dict[str, ScheduledJob] = {}
 
 
 def register_daily(
-    name: str, callback: Callback, at: _dt.time | str, *, tzinfo: _dt.tzinfo | None = None
+    name: str,
+    callback: Callback,
+    at: _dt.time | str,
+    *,
+    tzinfo: _dt.tzinfo | None = None,
+    enabled: bool = True,
+    metadata: Optional[Dict[str, object]] = None,
+    state_updater: Callable[[_dt.datetime | None, _dt.datetime | None], None] | None = None,
+    next_run_at: _dt.datetime | None = None,
 ) -> ScheduledJob:
     """Register a new job executed once per day at the specified time."""
 
     if isinstance(at, str):
         at = _dt.time.fromisoformat(at)
     schedule = DailySchedule(at=at, tzinfo=tzinfo)
-    job = ScheduledJob(name=name, callback=callback, schedule=schedule)
-    job.compute_next_run()
+    job = ScheduledJob(
+        name=name,
+        callback=callback,
+        schedule=schedule,
+        enabled=enabled,
+        metadata=dict(metadata or {}),
+        state_updater=state_updater,
+    )
+    if next_run_at is not None:
+        job.next_run = next_run_at
+    elif job.enabled:
+        job.compute_next_run()
+    else:
+        job.next_run = None
     _jobs[name] = job
     logger.debug("Registered daily job %s -> %s", name, job.next_run)
     return job
@@ -194,15 +217,37 @@ def register_cron(
     expression: str,
     *,
     tzinfo: _dt.tzinfo | None = None,
+    enabled: bool = True,
+    metadata: Optional[Dict[str, object]] = None,
+    state_updater: Callable[[_dt.datetime | None, _dt.datetime | None], None] | None = None,
+    next_run_at: _dt.datetime | None = None,
 ) -> ScheduledJob:
     """Register a cron-style job with minute precision."""
 
     schedule = CronSchedule.from_expression(expression, tzinfo=tzinfo)
-    job = ScheduledJob(name=name, callback=callback, schedule=schedule)
-    job.compute_next_run()
+    job = ScheduledJob(
+        name=name,
+        callback=callback,
+        schedule=schedule,
+        enabled=enabled,
+        metadata=dict(metadata or {}),
+        state_updater=state_updater,
+    )
+    if next_run_at is not None:
+        job.next_run = next_run_at
+    elif job.enabled:
+        job.compute_next_run()
+    else:
+        job.next_run = None
     _jobs[name] = job
     logger.debug("Registered cron job %s -> %s (%s)", name, job.next_run, expression)
     return job
+
+
+def unregister(name: str) -> None:
+    """Remove a job from the scheduler registry (no-op if absent)."""
+
+    _jobs.pop(name, None)
 
 
 async def _execute_job(job: ScheduledJob) -> None:
@@ -212,6 +257,15 @@ async def _execute_job(job: ScheduledJob) -> None:
             await result
     except Exception:  # noqa: BLE001 - we want to guard the scheduler loop
         logger.exception("Scheduled job %s raised an exception", job.name)
+
+
+def _invoke_state_updater(job: ScheduledJob, last_run: _dt.datetime | None) -> None:
+    if job.state_updater is None:
+        return
+    try:
+        job.state_updater(last_run, job.next_run)
+    except Exception:  # pragma: no cover - persistence must not break scheduler
+        logger.exception("Failed to persist scheduler state", extra={"job": job.name})
 
 
 async def run_forever(loop: asyncio.AbstractEventLoop | None = None) -> None:
@@ -224,21 +278,24 @@ async def run_forever(loop: asyncio.AbstractEventLoop | None = None) -> None:
     try:
         while True:
             jobs = list(_jobs.values())
+            active_jobs = [job for job in jobs if job.enabled and job.next_run is not None]
 
-            if not jobs:
+            if not active_jobs:
                 await asyncio.sleep(1)
                 continue
 
             now = _dt.datetime.now(_dt.timezone.utc)
-            due_jobs = [job for job in jobs if job.next_run and job.next_run <= now]
+            due_jobs = [job for job in active_jobs if job.next_run and job.next_run <= now]
 
             if due_jobs:
                 for job in due_jobs:
                     await _execute_job(job)
-                    job.compute_next_run(reference=now)
+                    last_run = _dt.datetime.now(_dt.timezone.utc)
+                    job.compute_next_run(reference=last_run)
+                    _invoke_state_updater(job, last_run)
                 continue
 
-            next_run = min(job.next_run for job in jobs if job.next_run is not None)
+            next_run = min(job.next_run for job in active_jobs if job.next_run is not None)
             sleep_for = max((next_run - now).total_seconds(), 0.1)
             await asyncio.sleep(min(sleep_for, 60))
     except asyncio.CancelledError:  # pragma: no cover - forwarded cancellation

--- a/dvorik/services/__init__.py
+++ b/dvorik/services/__init__.py
@@ -1,5 +1,5 @@
 """Service layer helpers tying domain and infrastructure together."""
 
-from . import notify, schedule, stock
+from . import notify, schedule, scheduler_catalog, stock
 
-__all__ = ["notify", "schedule", "stock"]
+__all__ = ["notify", "schedule", "scheduler_catalog", "stock"]

--- a/dvorik/services/scheduler_catalog.py
+++ b/dvorik/services/scheduler_catalog.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import datetime as dt
+import importlib
+import json
+import logging
+import sqlite3
+from collections.abc import Callable, Iterable, Mapping
+from typing import Dict
+
+from dvorik.core.registry import JobRegistry
+from dvorik.core.scheduler import (
+    ScheduledJob,
+    register_cron,
+    register_daily,
+    unregister,
+)
+from dvorik.db.conn import db
+
+logger = logging.getLogger(__name__)
+
+_REGISTRY_PREFIX = "db.scheduled_job."
+
+
+def _format_datetime(value: dt.datetime | None) -> str | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=dt.timezone.utc)
+    return value.astimezone(dt.timezone.utc).isoformat(timespec="seconds")
+
+
+def _parse_datetime(raw: str | None) -> dt.datetime | None:
+    if not raw:
+        return None
+    try:
+        parsed = dt.datetime.fromisoformat(raw)
+    except ValueError:
+        logger.warning("Invalid datetime stored for scheduled job", extra={"value": raw})
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def _load_callback(module_name: str, attribute: str) -> Callable[..., object]:
+    module = importlib.import_module(module_name)
+    try:
+        callback = getattr(module, attribute)
+    except AttributeError as exc:
+        raise AttributeError(f"Scheduled task '{module_name}.{attribute}' not found") from exc
+    if not callable(callback):
+        raise TypeError(f"Scheduled task '{module_name}.{attribute}' is not callable")
+    return callback
+
+
+def _make_state_updater(job_id: int) -> Callable[[dt.datetime | None, dt.datetime | None], None]:
+    def _updater(last_run: dt.datetime | None, next_run: dt.datetime | None) -> None:
+        conn = db()
+        try:
+            with conn:
+                conn.execute(
+                    """
+                    UPDATE scheduled_job
+                    SET last_run_at = ?, next_run_at = ?
+                    WHERE id = ?
+                    """,
+                    (_format_datetime(last_run), _format_datetime(next_run), job_id),
+                )
+        except sqlite3.Error:
+            logger.exception("Failed to persist scheduler state", extra={"job_id": job_id})
+        finally:
+            conn.close()
+
+    return _updater
+
+
+def _decode_config(config_json: str | None) -> Mapping[str, object] | None:
+    if not config_json:
+        return None
+    try:
+        data = json.loads(config_json)
+    except json.JSONDecodeError:
+        logger.warning("Failed to decode job configuration JSON", extra={"config": config_json})
+        return None
+    if not isinstance(data, Mapping):
+        return None
+    return data
+
+
+def _registry_keys(prefix: str) -> Iterable[str]:
+    return tuple(key for key in JobRegistry.keys() if key.startswith(prefix))
+
+
+def _cleanup_previous_entries(prefix: str) -> None:
+    for key in _registry_keys(prefix):
+        try:
+            job = JobRegistry.get(key)
+        except KeyError:
+            JobRegistry.unregister(key)
+            continue
+        unregister(job.name)
+        JobRegistry.unregister(key)
+
+
+def sync_jobs(conn: sqlite3.Connection | None = None) -> Dict[str, ScheduledJob]:
+    """Synchronise DB-backed scheduled jobs with the in-memory scheduler."""
+
+    _cleanup_previous_entries(_REGISTRY_PREFIX)
+
+    owns_connection = conn is None
+    connection = conn if conn is not None else db()
+    try:
+        try:
+            rows = connection.execute(
+                """
+                SELECT id, name, schedule_type, schedule_expression,
+                       next_run_at, last_run_at, task_module, task_name,
+                       config_json, enabled
+                FROM scheduled_job
+                ORDER BY name ASC
+                """
+            ).fetchall()
+        except sqlite3.Error:
+            logger.exception("Failed to load scheduled jobs from database")
+            return {}
+
+        registered: Dict[str, ScheduledJob] = {}
+        for row in rows:
+            name = str(row["name"])
+            schedule_type = str(row["schedule_type"])
+            schedule_expression = row["schedule_expression"]
+            task_module = str(row["task_module"])
+            task_name = str(row["task_name"])
+            enabled = bool(row["enabled"])
+            next_run = _parse_datetime(row["next_run_at"])
+
+            try:
+                callback = _load_callback(task_module, task_name)
+            except (ImportError, AttributeError, TypeError):
+                logger.exception(
+                    "Failed to resolve scheduled job callback",
+                    extra={"module": task_module, "name": task_name},
+                )
+                continue
+
+            state_updater = _make_state_updater(int(row["id"]))
+            metadata: Dict[str, object] = {
+                "id": int(row["id"]),
+                "config": _decode_config(row["config_json"]),
+                "config_json": row["config_json"],
+                "last_run_at": row["last_run_at"],
+            }
+
+            try:
+                if schedule_type == "daily":
+                    if not schedule_expression:
+                        raise ValueError("Daily schedule requires time expression")
+                    job = register_daily(
+                        name,
+                        callback,
+                        schedule_expression,
+                        enabled=enabled,
+                        metadata=metadata,
+                        state_updater=state_updater,
+                        next_run_at=next_run,
+                    )
+                elif schedule_type == "cron":
+                    if not schedule_expression:
+                        raise ValueError("Cron schedule requires expression")
+                    job = register_cron(
+                        name,
+                        callback,
+                        schedule_expression,
+                        enabled=enabled,
+                        metadata=metadata,
+                        state_updater=state_updater,
+                        next_run_at=next_run,
+                    )
+                else:
+                    raise ValueError(f"Unsupported schedule type: {schedule_type}")
+            except Exception:
+                logger.exception(
+                    "Failed to register scheduled job",
+                    extra={"name": name, "type": schedule_type, "expression": schedule_expression},
+                )
+                continue
+
+            registry_key = f"{_REGISTRY_PREFIX}{name}"
+            JobRegistry.register(registry_key, job, replace=True)
+            registered[name] = job
+
+        if registered:
+            logger.info("Synchronized %d scheduled job(s) from catalog", len(registered))
+        else:
+            logger.info("No scheduled jobs to synchronize")
+        return registered
+    finally:
+        if owns_connection:
+            connection.close()
+
+
+__all__ = ["sync_jobs"]
+


### PR DESCRIPTION
## Summary
- add a scheduler catalog service that loads scheduled_job rows, resolves task callables, and registers them with the scheduler while updating the JobRegistry
- extend the scheduler to handle enabled flags, persist state back to the database, and allow unregistering jobs for resyncs
- trigger catalog sync on startup and after superadmin job CRUD actions so in-memory schedules reflect database changes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcd987ed6c8326869c93aa4c832eb7