### PR TITLE
Add widget catalog synchronizer service

### DIFF
--- a/dvorik/admin/widgets/builtin.py
+++ b/dvorik/admin/widgets/builtin.py
@@ -2,31 +2,15 @@
 
 from __future__ import annotations
 
-import logging
-import sqlite3
-from dataclasses import dataclass
-from typing import Mapping, MutableMapping
+from typing import Iterable
 
 from dvorik.core.plugins import register_widget
-from dvorik.db.conn import db
+from dvorik.services.widget_catalog import (
+    register_default_widget_layout,
+    sync_widget_catalog,
+)
 
 from .api import Widget, WidgetContext
-
-logger = logging.getLogger(__name__)
-
-
-@dataclass(frozen=True, slots=True)
-class _WidgetDefinition:
-    module: str
-    name: str
-    title: str
-    widget: type[Widget]
-    description: str | None = None
-    config_schema: str | None = None
-
-    @property
-    def key(self) -> str:
-        return f"{self.module}.{self.name}"
 
 
 class LowStockWidget(Widget):
@@ -69,104 +53,29 @@ class StockByLocationWidget(Widget):
             <p>Location statistics are not yet implemented.</p>
         </section>
         """.strip()
-
-
-_BUILTIN_WIDGETS: tuple[_WidgetDefinition, ...] = (
-    _WidgetDefinition(
-        module="builtin",
-        name="low_stock",
-        title=LowStockWidget.title,
-        widget=LowStockWidget,
-        description=LowStockWidget.description,
-    ),
-    _WidgetDefinition(
-        module="builtin",
-        name="schedule_mini",
-        title=ScheduleMiniWidget.title,
-        widget=ScheduleMiniWidget,
-        description=ScheduleMiniWidget.description,
-    ),
-    _WidgetDefinition(
-        module="builtin",
-        name="stock_by_location",
-        title=StockByLocationWidget.title,
-        widget=StockByLocationWidget,
-        description=StockByLocationWidget.description,
-    ),
+_BUILTIN_WIDGETS: tuple[type[Widget], ...] = (
+    LowStockWidget,
+    ScheduleMiniWidget,
+    StockByLocationWidget,
 )
 
-_DEFAULT_HOME_ORDER: tuple[str, ...] = tuple(defn.key for defn in _BUILTIN_WIDGETS)
+
+def _widget_key(widget: type[Widget]) -> str:
+    slug = getattr(widget, "slug", widget.__name__)
+    return f"builtin.{slug}"
+
+
+def _builtin_widget_keys() -> Iterable[str]:
+    for widget in _BUILTIN_WIDGETS:
+        yield _widget_key(widget)
 
 
 def register_builtin_widgets() -> None:
-    for definition in _BUILTIN_WIDGETS:
-        register_widget(definition.key, definition.widget, replace=True)
+    for widget in _BUILTIN_WIDGETS:
+        register_widget(_widget_key(widget), widget, replace=True)
 
-    conn = db()
-    try:
-        widget_ids = _sync_catalog(conn)
-        _seed_home_instances(conn, widget_ids)
-    finally:
-        conn.close()
-
-
-def _sync_catalog(conn: sqlite3.Connection) -> Mapping[str, int]:
-    ids: MutableMapping[str, int] = {}
-
-    with conn:
-        for definition in _BUILTIN_WIDGETS:
-            conn.execute(
-                """
-                INSERT INTO ui_widget(module, name, title, description, entrypoint, config_schema)
-                VALUES (?, ?, ?, ?, ?, ?)
-                ON CONFLICT(module, name) DO UPDATE SET
-                    title = excluded.title,
-                    description = excluded.description,
-                    entrypoint = excluded.entrypoint,
-                    config_schema = excluded.config_schema
-                """,
-                (
-                    definition.module,
-                    definition.name,
-                    definition.title,
-                    definition.description,
-                    definition.widget.entrypoint(),
-                    definition.config_schema,
-                ),
-            )
-
-        for definition in _BUILTIN_WIDGETS:
-            row = conn.execute(
-                "SELECT id FROM ui_widget WHERE module = ? AND name = ?",
-                (definition.module, definition.name),
-            ).fetchone()
-            if row is None:
-                raise RuntimeError(f"Failed to persist widget {definition.key}")
-            ids[definition.key] = int(row["id"] if isinstance(row, sqlite3.Row) else row[0])
-
-    return ids
-
-
-def _seed_home_instances(conn: sqlite3.Connection, widget_ids: Mapping[str, int]) -> None:
-    cursor = conn.execute("SELECT COUNT(*) FROM ui_widget_instance")
-    row = cursor.fetchone()
-    existing = int(row[0]) if row is not None else 0
-    if existing:
-        return
-
-    with conn:
-        for position, key in enumerate(_DEFAULT_HOME_ORDER):
-            widget_id = widget_ids.get(key)
-            if widget_id is None:
-                logger.warning("Widget %s missing from catalog; skipping seed", key)
-                continue
-            conn.execute(
-                """
-                INSERT INTO ui_widget_instance(widget_id, zone, position, enabled)
-                VALUES (?, ?, ?, 1)
-                """,
-                (widget_id, "home.main", position),
-            )
+    register_default_widget_layout("home.main", tuple(_builtin_widget_keys()), replace=True)
+    sync_widget_catalog()
 
 
 __all__ = [

--- a/dvorik/core/plugins.py
+++ b/dvorik/core/plugins.py
@@ -113,6 +113,11 @@ def load_plugins(dir: str = "dvorik/plugins") -> Sequence[PluginDescriptor]:
             register_plugin(module.__name__.rsplit(".", 1)[-1], module=module)
 
     logger.info("Loaded %d plugins from %s", len(loaded_modules), package_name)
+
+    # Ensure widgets registered by plugins are persisted and default placements exist.
+    from dvorik.services.widget_catalog import sync_widget_catalog
+
+    sync_widget_catalog()
     return get_plugins()
 
 

--- a/dvorik/plugins/example/__init__.py
+++ b/dvorik/plugins/example/__init__.py
@@ -18,6 +18,7 @@ from dvorik.core.plugins import (
     register_widget,
 )
 from dvorik.db.conn import db
+from dvorik.services.widget_catalog import register_default_widget_layout
 
 logger = logging.getLogger(__name__)
 
@@ -76,64 +77,6 @@ _MENU_ENTRY = _MenuDefinition(
 )
 
 
-def _ensure_widget_catalogued() -> None:
-    conn = db()
-    try:
-        with conn:
-            conn.execute(
-                """
-                INSERT INTO ui_widget(module, name, title, description, entrypoint, config_schema)
-                VALUES (?, ?, ?, ?, ?, NULL)
-                ON CONFLICT(module, name) DO UPDATE SET
-                    title = excluded.title,
-                    description = excluded.description,
-                    entrypoint = excluded.entrypoint,
-                    config_schema = excluded.config_schema
-                """,
-                (
-                    "example",
-                    TopSkusWidget.slug,
-                    TopSkusWidget.title,
-                    TopSkusWidget.description,
-                    TopSkusWidget.entrypoint(),
-                ),
-            )
-
-            row = conn.execute(
-                "SELECT id FROM ui_widget WHERE module = ? AND name = ?",
-                ("example", TopSkusWidget.slug),
-            ).fetchone()
-            if row is None:
-                return
-
-            widget_id = int(row["id"] if isinstance(row, sqlite3.Row) else row[0])
-
-            instance_row = conn.execute(
-                """
-                SELECT id FROM ui_widget_instance
-                WHERE widget_id = ? AND zone = ?
-                """,
-                (widget_id, "home.main"),
-            ).fetchone()
-            if instance_row is None:
-                position_row = conn.execute(
-                    "SELECT COALESCE(MAX(position), -1) FROM ui_widget_instance WHERE zone = ?",
-                    ("home.main",),
-                ).fetchone()
-                position = int(position_row[0]) + 1 if position_row else 0
-                conn.execute(
-                    """
-                    INSERT INTO ui_widget_instance(widget_id, zone, position, enabled)
-                    VALUES (?, ?, ?, 1)
-                    """,
-                    (widget_id, "home.main", position),
-                )
-    except sqlite3.Error:  # pragma: no cover - logged for visibility
-        logger.exception("Failed to ensure example widget catalogue entry")
-    finally:
-        conn.close()
-
-
 def _ensure_menu_entry() -> None:
     conn = db()
     try:
@@ -183,7 +126,7 @@ def _register_components() -> None:
 
 
 _register_components()
-_ensure_widget_catalogued()
+register_default_widget_layout("home.main", ("example.top_skus",))
 _ensure_menu_entry()
 
 

--- a/dvorik/services/__init__.py
+++ b/dvorik/services/__init__.py
@@ -1,5 +1,5 @@
 """Service layer helpers tying domain and infrastructure together."""
 
-from . import notify, schedule, stock
+from . import notify, schedule, stock, widget_catalog
 
-__all__ = ["notify", "schedule", "stock"]
+__all__ = ["notify", "schedule", "stock", "widget_catalog"]

--- a/dvorik/services/widget_catalog.py
+++ b/dvorik/services/widget_catalog.py
@@ -1,0 +1,203 @@
+"""Helpers for synchronising the widget catalogue with the database."""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from collections import defaultdict
+from typing import Iterable, Mapping, MutableMapping, Sequence
+
+from dvorik.admin.widgets.api import Widget
+from dvorik.core.registry import WidgetRegistry
+from dvorik.db.conn import db
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_LAYOUTS: MutableMapping[str, list[str]] = defaultdict(list)
+_WIDGET_ID_CACHE: MutableMapping[str, int] = {}
+
+
+def register_default_widget_layout(
+    zone: str, widgets: Sequence[str] | str, *, replace: bool = False
+) -> None:
+    """Declare widgets that should exist in ``zone`` by default.
+
+    Parameters
+    ----------
+    zone:
+        Dashboard zone identifier (e.g. ``"home.main"``).
+    widgets:
+        Sequence of widget registry keys. A single key may also be supplied.
+    replace:
+        When ``True`` the stored layout for ``zone`` is replaced entirely.
+    """
+
+    if isinstance(widgets, str):
+        widget_keys = [widgets]
+    else:
+        widget_keys = list(widgets)
+
+    if not widget_keys:
+        return
+
+    if replace or zone not in _DEFAULT_LAYOUTS:
+        _DEFAULT_LAYOUTS[zone] = []
+
+    layout = _DEFAULT_LAYOUTS[zone]
+    if replace:
+        layout.clear()
+
+    for key in widget_keys:
+        if key and key not in layout:
+            layout.append(key)
+
+
+def sync_widget_catalog(
+    *, connection: sqlite3.Connection | None = None
+) -> Mapping[str, int]:
+    """Persist registered widgets and ensure default instances exist."""
+
+    close_connection = False
+    conn = connection
+    if conn is None:
+        conn = db()
+        close_connection = True
+
+    try:
+        widgets = list(WidgetRegistry.items())
+        catalog = _persist_widgets(conn, widgets)
+        _ensure_default_instances(conn, catalog)
+        _WIDGET_ID_CACHE.clear()
+        _WIDGET_ID_CACHE.update(catalog)
+        return dict(catalog)
+    finally:
+        if close_connection and conn is not None:
+            conn.close()
+
+
+def get_widget_catalog_ids() -> Mapping[str, int]:
+    """Return a snapshot of the most recent key→ID mapping."""
+
+    return dict(_WIDGET_ID_CACHE)
+
+
+def _persist_widgets(
+    conn: sqlite3.Connection, entries: Iterable[tuple[str, object]]
+) -> dict[str, int]:
+    ids: dict[str, int] = {}
+
+    with conn:
+        for key, candidate in entries:
+            widget_cls = _coerce_widget_class(candidate, key)
+            if widget_cls is None:
+                continue
+
+            module_name, widget_name = _split_widget_key(key, widget_cls)
+            title = getattr(widget_cls, "title", widget_name)
+            description = getattr(widget_cls, "description", None)
+            config_schema = getattr(widget_cls, "config_schema", None)
+
+            conn.execute(
+                """
+                INSERT INTO ui_widget(module, name, title, description, entrypoint, config_schema)
+                VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(module, name) DO UPDATE SET
+                    title = excluded.title,
+                    description = excluded.description,
+                    entrypoint = excluded.entrypoint,
+                    config_schema = excluded.config_schema
+                """,
+                (
+                    module_name,
+                    widget_name,
+                    title,
+                    description,
+                    widget_cls.entrypoint(),
+                    config_schema,
+                ),
+            )
+
+        for key, candidate in entries:
+            widget_cls = _coerce_widget_class(candidate, key)
+            if widget_cls is None:
+                continue
+
+            module_name, widget_name = _split_widget_key(key, widget_cls)
+            row = conn.execute(
+                "SELECT id FROM ui_widget WHERE module = ? AND name = ?",
+                (module_name, widget_name),
+            ).fetchone()
+            if row is None:
+                logger.warning("Widget %s was not persisted in ui_widget", key)
+                continue
+            widget_id = int(row["id"] if isinstance(row, sqlite3.Row) else row[0])
+            ids[key] = widget_id
+
+    return ids
+
+
+def _ensure_default_instances(
+    conn: sqlite3.Connection, widget_ids: Mapping[str, int]
+) -> None:
+    if not _DEFAULT_LAYOUTS:
+        return
+
+    with conn:
+        for zone, widget_keys in _DEFAULT_LAYOUTS.items():
+            existing_ids = {
+                int(row["widget_id"] if isinstance(row, sqlite3.Row) else row[0])
+                for row in conn.execute(
+                    "SELECT widget_id FROM ui_widget_instance WHERE zone = ?",
+                    (zone,),
+                ).fetchall()
+            }
+
+            position_row = conn.execute(
+                "SELECT COALESCE(MAX(position), -1) FROM ui_widget_instance WHERE zone = ?",
+                (zone,),
+            ).fetchone()
+            position = int(position_row[0]) if position_row else -1
+
+            for key in widget_keys:
+                widget_id = widget_ids.get(key)
+                if widget_id is None:
+                    logger.debug("Skipping default placement for unknown widget %s", key)
+                    continue
+                if widget_id in existing_ids:
+                    continue
+
+                position += 1
+                conn.execute(
+                    """
+                    INSERT INTO ui_widget_instance(widget_id, zone, position, enabled)
+                    VALUES (?, ?, ?, 1)
+                    """,
+                    (widget_id, zone, position),
+                )
+                existing_ids.add(widget_id)
+
+
+def _coerce_widget_class(candidate: object, key: str) -> type[Widget] | None:
+    if isinstance(candidate, type) and issubclass(candidate, Widget):
+        return candidate
+
+    logger.debug(
+        "Widget registry entry %s is not a Widget subclass; skipping persistence", key
+    )
+    return None
+
+
+def _split_widget_key(key: str, widget_cls: type[Widget]) -> tuple[str, str]:
+    module_name, _, widget_name = key.partition(".")
+    if not module_name or not widget_name:
+        module_name = widget_cls.__module__
+        widget_name = getattr(widget_cls, "slug", widget_cls.__name__)
+    return module_name, widget_name
+
+
+__all__ = [
+    "get_widget_catalog_ids",
+    "register_default_widget_layout",
+    "sync_widget_catalog",
+]
+


### PR DESCRIPTION
## Summary
- add a widget catalog synchronisation service that persists registry entries and seeds default instances
- update builtin widget registration and plugin loader to call the shared synchroniser
- rely on the shared synchroniser from the example plugin instead of hand-written SQL

## Testing
- pytest tests/test_registry.py

------
https://chatgpt.com/codex/tasks/task_e_68dcdbaba5308326ac0600311e620e31