### PR TITLE
Synchronise menu registry with database menu catalogue

### DIFF
--- a/dvorik/admin/blueprints/menus.py
+++ b/dvorik/admin/blueprints/menus.py
@@ -5,17 +5,11 @@ from dataclasses import dataclass
 import logging
 from typing import Iterable, Mapping
 
-from __future__ import annotations
-
-from collections import defaultdict
-from dataclasses import dataclass
-import logging
-from typing import Iterable, Mapping
-
 from flask import Blueprint
 import sqlite3
 
 from dvorik.db.conn import db
+from dvorik.services.menu_catalog import get_fallback_menu
 
 logger = logging.getLogger(__name__)
 
@@ -47,11 +41,15 @@ class _MenuNode:
     parent_id: int | None
 
 
-_FALLBACK_MENU: tuple[MenuEntry, ...] = (
-    MenuEntry(slug="dashboard", title="Dashboard", url="/"),
-    MenuEntry(slug="supply", title="Supply", url="/supply"),
-    MenuEntry(slug="tables", title="Tables", url="/tables"),
-    MenuEntry(slug="superadmin", title="Superadmin", url="/superadmin"),
+_FALLBACK_MENU: tuple[MenuEntry, ...] = tuple(
+    MenuEntry(
+        slug=definition.slug,
+        title=definition.title,
+        url=definition.url,
+        icon=definition.icon,
+        target=definition.target,
+    )
+    for definition in get_fallback_menu()
 )
 
 

--- a/dvorik/admin/server.py
+++ b/dvorik/admin/server.py
@@ -9,6 +9,7 @@ from flask import Blueprint, Flask
 from dvorik.core.config import Config, get_config
 from dvorik.core.plugins import load_plugins
 from dvorik.db import init_db
+from dvorik.services.menu_catalog import sync_menu_catalog
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +33,7 @@ def create_app(*, config: Config | None = None) -> Flask:
 
     _initialise_database()
     _register_builtin_components()
+    _synchronise_menu_catalog()
     _register_blueprints(app)
 
     @app.get("/health")
@@ -68,6 +70,14 @@ def _register_builtin_components() -> None:
         register_builtin_widgets()
     except Exception:  # pragma: no cover - defensive, logged
         logger.exception("Failed to register admin widgets")
+        raise
+
+
+def _synchronise_menu_catalog() -> None:
+    try:
+        sync_menu_catalog()
+    except Exception:  # pragma: no cover - defensive, logged
+        logger.exception("Failed to synchronise menu catalogue")
         raise
 
 

--- a/dvorik/app.py
+++ b/dvorik/app.py
@@ -13,6 +13,7 @@ from dvorik.core.plugins import load_plugins
 from dvorik.core.registry import JobRegistry
 from dvorik.core.scheduler import register_daily
 from dvorik.db import init_db
+from dvorik.services.menu_catalog import sync_menu_catalog
 
 if TYPE_CHECKING:  # pragma: no cover - imported only for type checkers
     from flask import Flask
@@ -55,6 +56,7 @@ def create_system(*, config: Config | None = None) -> DvorikSystem:
     _register_admin_components()
     _register_bot_components()
     _register_scheduler_jobs()
+    _sync_menu_entries()
 
     return DvorikSystem(
         config=config,
@@ -133,6 +135,16 @@ def _register_scheduler_jobs() -> None:
         _DAILY_TICK_JOB_KEY,
         _DAILY_TICK_TIME.isoformat(timespec="minutes"),
     )
+
+
+def _sync_menu_entries() -> None:
+    try:
+        synced = sync_menu_catalog()
+    except Exception:  # pragma: no cover - defensive guard
+        logger.exception("Failed to synchronise menu catalogue")
+        raise
+
+    logger.debug("Synchronised %d menu entries into ui_menu", len(synced))
 
 
 __all__ = ["create_system", "DvorikSystem"]

--- a/dvorik/plugins/example/__init__.py
+++ b/dvorik/plugins/example/__init__.py
@@ -134,35 +134,6 @@ def _ensure_widget_catalogued() -> None:
         conn.close()
 
 
-def _ensure_menu_entry() -> None:
-    conn = db()
-    try:
-        with conn:
-            conn.execute(
-                """
-                INSERT INTO ui_menu(slug, title, url, icon, parent_id, position, target, visible)
-                VALUES (?, ?, ?, ?, NULL, ?, NULL, 1)
-                ON CONFLICT(slug) DO UPDATE SET
-                    title = excluded.title,
-                    url = excluded.url,
-                    icon = excluded.icon,
-                    position = excluded.position,
-                    visible = excluded.visible
-                """,
-                (
-                    _MENU_ENTRY.slug,
-                    _MENU_ENTRY.title,
-                    _MENU_ENTRY.url,
-                    _MENU_ENTRY.icon,
-                    _MENU_ENTRY.position,
-                ),
-            )
-    except sqlite3.Error:  # pragma: no cover - logged for visibility
-        logger.exception("Failed to persist example plugin menu entry")
-    finally:
-        conn.close()
-
-
 def _register_components() -> None:
     register_plugin(
         "example",
@@ -176,6 +147,7 @@ def _register_components() -> None:
             "title": _MENU_ENTRY.title,
             "url": _MENU_ENTRY.url,
             "icon": _MENU_ENTRY.icon,
+            "position": _MENU_ENTRY.position,
         },
         replace=True,
     )
@@ -184,7 +156,6 @@ def _register_components() -> None:
 
 _register_components()
 _ensure_widget_catalogued()
-_ensure_menu_entry()
 
 
 __all__ = [

--- a/dvorik/services/__init__.py
+++ b/dvorik/services/__init__.py
@@ -1,5 +1,5 @@
 """Service layer helpers tying domain and infrastructure together."""
 
-from . import notify, schedule, stock
+from . import menu_catalog, notify, schedule, stock
 
-__all__ = ["notify", "schedule", "stock"]
+__all__ = ["menu_catalog", "notify", "schedule", "stock"]

--- a/dvorik/services/menu_catalog.py
+++ b/dvorik/services/menu_catalog.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import logging
+import sqlite3
+from dataclasses import asdict, dataclass, is_dataclass
+from typing import Mapping, MutableMapping
+
+from dvorik.core.registry import MenuRegistry
+from dvorik.db.conn import db
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class MenuDefinition:
+    """Declarative description of a menu item for catalogue seeding."""
+
+    key: str
+    slug: str
+    title: str
+    url: str | None = None
+    icon: str | None = None
+    position: int = 0
+    target: str | None = None
+    visible: bool = True
+    parent_slug: str | None = None
+
+    def to_payload(self) -> Mapping[str, object]:
+        """Return a mapping suitable for :class:`MenuRegistry`."""
+
+        return {
+            "slug": self.slug,
+            "title": self.title,
+            "url": self.url,
+            "icon": self.icon,
+            "position": self.position,
+            "target": self.target,
+            "visible": self.visible,
+            "parent_slug": self.parent_slug,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class _CatalogEntry:
+    key: str
+    slug: str
+    title: str
+    url: str | None
+    icon: str | None
+    position: int
+    target: str | None
+    visible: bool
+    parent_slug: str | None
+
+
+_FALLBACK_MENU: tuple[MenuDefinition, ...] = (
+    MenuDefinition(
+        key="builtin.menu.dashboard",
+        slug="dashboard",
+        title="Dashboard",
+        url="/",
+        position=10,
+    ),
+    MenuDefinition(
+        key="builtin.menu.supply",
+        slug="supply",
+        title="Supply",
+        url="/supply",
+        position=20,
+    ),
+    MenuDefinition(
+        key="builtin.menu.tables",
+        slug="tables",
+        title="Tables",
+        url="/tables",
+        position=30,
+    ),
+    MenuDefinition(
+        key="builtin.menu.superadmin",
+        slug="superadmin",
+        title="Superadmin",
+        url="/superadmin",
+        position=40,
+    ),
+)
+
+
+def get_fallback_menu() -> tuple[MenuDefinition, ...]:
+    """Return fallback menu definitions used when the DB catalogue is empty."""
+
+    return _FALLBACK_MENU
+
+
+def ensure_fallback_menu_registered() -> None:
+    """Ensure fallback menu definitions are present in :class:`MenuRegistry`."""
+
+    for definition in _FALLBACK_MENU:
+        MenuRegistry.ensure(definition.key, definition.to_payload())
+
+
+def sync_menu_catalog(connection: sqlite3.Connection | None = None) -> Mapping[str, int]:
+    """Persist registered menu entries into ``ui_menu``.
+
+    Parameters
+    ----------
+    connection:
+        Optional SQLite connection.  When ``None`` the default application
+        connection is used.
+
+    Returns
+    -------
+    Mapping[str, int]
+        Mapping of menu ``slug`` to the corresponding database ``id``.
+    """
+
+    ensure_fallback_menu_registered()
+
+    snapshot = tuple(MenuRegistry.items())
+    if not snapshot:
+        return {}
+
+    entries = tuple(filter(None, (_normalise_entry(key, value) for key, value in snapshot)))
+    if not entries:
+        return {}
+
+    owns_connection = connection is None
+    conn = connection if connection is not None else db()
+    ids: MutableMapping[str, int] = {}
+
+    try:
+        with conn:
+            for entry in entries:
+                conn.execute(
+                    """
+                    INSERT INTO ui_menu(slug, title, url, icon, parent_id, position, target, visible)
+                    VALUES (?, ?, ?, ?, NULL, ?, ?, ?)
+                    ON CONFLICT(slug) DO UPDATE SET
+                        title = excluded.title,
+                        url = excluded.url,
+                        icon = excluded.icon,
+                        position = excluded.position,
+                        target = excluded.target,
+                        visible = excluded.visible
+                    """,
+                    (
+                        entry.slug,
+                        entry.title,
+                        entry.url,
+                        entry.icon,
+                        entry.position,
+                        entry.target,
+                        1 if entry.visible else 0,
+                    ),
+                )
+
+            for entry in entries:
+                row = conn.execute("SELECT id FROM ui_menu WHERE slug = ?", (entry.slug,)).fetchone()
+                if row is None:
+                    logger.warning("Menu entry '%s' was not persisted", entry.slug)
+                    continue
+                ids[entry.slug] = int(row["id"] if isinstance(row, sqlite3.Row) else row[0])
+
+            for entry in entries:
+                desired_parent_slug = entry.parent_slug
+                parent_id = ids.get(desired_parent_slug) if desired_parent_slug else None
+                conn.execute(
+                    "UPDATE ui_menu SET parent_id = ? WHERE slug = ?",
+                    (parent_id, entry.slug),
+                )
+    finally:
+        if owns_connection:
+            conn.close()
+
+    return dict(ids)
+
+
+def _normalise_entry(key: str, value: object) -> _CatalogEntry | None:
+    mapping = _to_mapping(value)
+    if mapping is None:
+        logger.warning("Menu registry entry '%s' must be a mapping or dataclass", key)
+        return None
+
+    slug_raw = mapping.get("slug")
+    title_raw = mapping.get("title")
+    if not slug_raw or not title_raw:
+        logger.warning("Menu registry entry '%s' is missing slug/title", key)
+        return None
+
+    slug = str(slug_raw).strip()
+    title = str(title_raw).strip()
+    if not slug or not title:
+        logger.warning("Menu registry entry '%s' has empty slug/title", key)
+        return None
+
+    url_value = mapping.get("url")
+    url = str(url_value).strip() if isinstance(url_value, str) else url_value if url_value is None else str(url_value)
+
+    icon_value = mapping.get("icon")
+    icon = str(icon_value).strip() if isinstance(icon_value, str) and icon_value.strip() else None
+
+    target_value = mapping.get("target")
+    target = str(target_value).strip() if isinstance(target_value, str) and target_value.strip() else None
+
+    position_value = mapping.get("position", 0)
+    try:
+        position = int(position_value)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Menu registry entry '%s' provides invalid position %r; defaulting to 0",
+            key,
+            position_value,
+        )
+        position = 0
+
+    visible = bool(mapping.get("visible", True))
+
+    parent_slug_value = mapping.get("parent_slug") or mapping.get("parent")
+    parent_slug = None
+    if isinstance(parent_slug_value, str):
+        parent_slug = parent_slug_value.strip() or None
+    elif parent_slug_value is not None:
+        parent_slug = str(parent_slug_value)
+
+    return _CatalogEntry(
+        key=key,
+        slug=slug,
+        title=title,
+        url=url,
+        icon=icon,
+        position=position,
+        target=target,
+        visible=visible,
+        parent_slug=parent_slug,
+    )
+
+
+def _to_mapping(value: object) -> Mapping[str, object] | None:
+    if isinstance(value, Mapping):
+        return value
+    if is_dataclass(value):
+        return asdict(value)
+    return None
+
+
+__all__ = [
+    "MenuDefinition",
+    "ensure_fallback_menu_registered",
+    "get_fallback_menu",
+    "sync_menu_catalog",
+]

--- a/tests/test_menu_catalog.py
+++ b/tests/test_menu_catalog.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+
+import pytest
+
+from dvorik.core.registry import MenuRegistry
+from dvorik.services.menu_catalog import get_fallback_menu, sync_menu_catalog
+
+
+@pytest.fixture()
+def conn():
+    connection = sqlite3.connect(":memory:")
+    connection.row_factory = sqlite3.Row
+    connection.executescript(
+        """
+        CREATE TABLE ui_menu(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            slug TEXT NOT NULL UNIQUE,
+            title TEXT NOT NULL,
+            url TEXT,
+            icon TEXT,
+            parent_id INTEGER,
+            position INTEGER NOT NULL DEFAULT 0,
+            target TEXT,
+            visible INTEGER NOT NULL DEFAULT 1
+        );
+        """
+    )
+    yield connection
+    connection.close()
+
+
+@pytest.fixture(autouse=True)
+def reset_menu_registry():
+    MenuRegistry.clear()
+    yield
+    MenuRegistry.clear()
+
+
+def test_sync_menu_catalog_seeds_fallback_entries(conn):
+    result = sync_menu_catalog(connection=conn)
+
+    rows = conn.execute(
+        "SELECT slug, title, position FROM ui_menu ORDER BY position ASC, slug ASC"
+    ).fetchall()
+    fallback = get_fallback_menu()
+
+    assert [row["slug"] for row in rows] == [definition.slug for definition in fallback]
+    assert [row["title"] for row in rows] == [definition.title for definition in fallback]
+    assert [row["position"] for row in rows] == [definition.position for definition in fallback]
+    assert set(result) == {definition.slug for definition in fallback}
+
+
+def test_sync_menu_catalog_persists_dataclass_entries(conn):
+    @dataclass(slots=True)
+    class PluginMenu:
+        slug: str
+        title: str
+        url: str | None = None
+        icon: str | None = None
+        position: int = 55
+
+    MenuRegistry.register("plugin.menu.custom", PluginMenu(slug="custom", title="Custom", url="/custom"))
+
+    sync_menu_catalog(connection=conn)
+
+    row = conn.execute("SELECT slug, url, position FROM ui_menu WHERE slug = ?", ("custom",)).fetchone()
+    assert row["slug"] == "custom"
+    assert row["url"] == "/custom"
+    assert row["position"] == 55
+
+    fallback_slugs = {definition.slug for definition in get_fallback_menu()}
+    rows = conn.execute("SELECT slug FROM ui_menu").fetchall()
+    assert fallback_slugs.union({"custom"}) == {row["slug"] for row in rows}


### PR DESCRIPTION
## Summary
- add a menu catalogue synchroniser that seeds fallback entries and upserts MenuRegistry items into ui_menu
- trigger synchronisation during system and admin start-up and simplify the example plugin
- cover the synchroniser with regression tests and reuse fallback definitions in the menu blueprint

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcdbacdf1c8326bd541597ba41191d