### PR TITLE
Import database factory for notifications

### DIFF
--- a/dvorik/app.py
+++ b/dvorik/app.py
@@ -13,7 +13,7 @@ from dvorik.core.config import Config, get_config
 from dvorik.core.plugins import load_plugins
 from dvorik.core.registry import JobRegistry
 from dvorik.core.scheduler import register_daily
-from dvorik.db import init_db
+from dvorik.db import db, init_db
 
 if TYPE_CHECKING:  # pragma: no cover - imported only for type checkers
     from flask import Flask


### PR DESCRIPTION
## Summary
- extend the dvorik.app module to import the database factory alongside init_db so notification setup can create connections

## Testing
- python -m dvorik.admin *(fails: missing DVORIK_ADMIN_PASSWORD environment variable)*
- python -m dvorik.bot *(fails: network access to api.telegram.org is unavailable in CI)*

------
https://chatgpt.com/codex/tasks/task_e_68dce32cf6308326953c7e7b603b93af