### PR TITLE
Add missing plugin import for superadmin dashboard

### DIFF
--- a/dvorik/admin/blueprints/superadmin.py
+++ b/dvorik/admin/blueprints/superadmin.py
@@ -10,7 +10,7 @@ from flask import Blueprint, Response, has_request_context, redirect, render_tem
 
 from dvorik.admin.auth import require_superadmin
 from dvorik.admin.widgets.validation import WidgetConfigError, validate_widget_config
-
+from dvorik.core.plugins import get_plugins
 from dvorik.db.conn import db
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- import the plugin registry in the superadmin blueprint so plugin data loads correctly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dce3302bc48326a8609a9e49725e5f