### PR TITLE
Reuse notification DB connection

### DIFF
--- a/dvorik/app.py
+++ b/dvorik/app.py
@@ -156,11 +156,14 @@ def _register_notifications(config: Config) -> None:
             except Exception:  # pragma: no cover - logging for observability
                 logger.exception("Failed to unregister previous notification subscriber")
 
-    previous_conn = _NOTIFICATION_STATE.pop("conn", None)
-    if isinstance(previous_conn, sqlite3.Connection):
-        previous_conn.close()
-
-    conn = db()
+    conn = _NOTIFICATION_STATE.get("conn")
+    if isinstance(conn, sqlite3.Connection):
+        try:
+            conn.execute("PRAGMA user_version")
+        except sqlite3.ProgrammingError:
+            conn = db()
+    else:
+        conn = db()
     repo = SQLiteStockRepo(conn)
 
     async def _dispatch(payload: Mapping[str, object]) -> None:


### PR DESCRIPTION
## Summary
- keep the notification registration routine on the shared SQLite connection by reusing the cached handle when available and recreating it only when invalid

## Testing
- DVORIK_ADMIN_PASSWORD=test python -m dvorik.admin *(fails: ModuleNotFoundError: No module named 'jsonschema')*
- python -m dvorik.bot *(fails: aiogram.exceptions.TelegramNetworkError: HTTP Client says - ClientConnectorError: Cannot connect to host api.telegram.org:443)*

------
https://chatgpt.com/codex/tasks/task_e_68dd4a3b4bd0832680b3fb6a2d9c727d