### PR TITLE
Add role-based filtering to admin menu

### DIFF
--- a/dvorik/admin/blueprints/menus.py
+++ b/dvorik/admin/blueprints/menus.py
@@ -3,18 +3,12 @@ from __future__ import annotations
 from collections import defaultdict
 from dataclasses import dataclass
 import logging
-from typing import Iterable, Mapping
-
-from __future__ import annotations
-
-from collections import defaultdict
-from dataclasses import dataclass
-import logging
-from typing import Iterable, Mapping
-
-from flask import Blueprint
 import sqlite3
+from typing import Iterable, Mapping
 
+from flask import Blueprint, has_request_context, session
+
+from dvorik.admin.auth import is_superadmin_authenticated
 from dvorik.db.conn import db
 
 logger = logging.getLogger(__name__)
@@ -55,6 +49,9 @@ _FALLBACK_MENU: tuple[MenuEntry, ...] = (
 )
 
 
+_ROLE_SESSION_KEY = "dvorik.role"
+
+
 @blueprint.app_context_processor
 def inject_menu() -> Mapping[str, object]:
     """Provide navigation menu entries to all templates."""
@@ -80,6 +77,7 @@ def _load_menu_entries() -> tuple[tuple[MenuEntry, ...], bool]:
 
 
 def _fetch_rows() -> list[sqlite3.Row]:
+    role = _resolve_user_role()
     conn = db()
     try:
         cursor = conn.execute(
@@ -92,11 +90,20 @@ def _fetch_rows() -> list[sqlite3.Row]:
                 icon,
                 parent_id,
                 position,
-                target
+                target,
+                required_role
             FROM ui_menu
-            WHERE visible = 1
+            WHERE
+                visible = 1
+                AND (
+                    required_role IS NULL
+                    OR TRIM(required_role) = ''
+                    {role_filter}
+                )
             ORDER BY COALESCE(parent_id, 0) ASC, position ASC, title ASC, id ASC
             """
+            .format(role_filter="" if role is None else "OR required_role = ? COLLATE NOCASE"),
+            (() if role is None else (role,)),
         )
         return list(cursor.fetchall())
     except sqlite3.Error:
@@ -173,6 +180,24 @@ def _build_tree(rows: Iterable[sqlite3.Row]) -> tuple[MenuEntry, ...]:
                 entries.append(build_entry(node_id))
 
     return tuple(entries)
+
+
+def _resolve_user_role() -> str | None:
+    """Return the role associated with the current session, if any."""
+
+    if not has_request_context():
+        return None
+
+    raw_role = session.get(_ROLE_SESSION_KEY)
+    if isinstance(raw_role, str):
+        role = raw_role.strip()
+        if role:
+            return role.lower()
+
+    if is_superadmin_authenticated():
+        return "superadmin"
+
+    return None
 
 
 __all__ = ["blueprint", "MenuEntry"]

--- a/dvorik/admin/blueprints/superadmin.py
+++ b/dvorik/admin/blueprints/superadmin.py
@@ -266,6 +266,9 @@ def save_menu_entry() -> Response:
 
     parent_id = _parse_int(request.form.get("parent_id"))
     visible = 1 if request.form.get("visible") else 0
+    required_role = _clean_text(request.form.get("required_role"))
+    if required_role is not None:
+        required_role = required_role.lower()
 
     payload = {
         "slug": slug,
@@ -276,6 +279,7 @@ def save_menu_entry() -> Response:
         "position": position,
         "parent_id": parent_id,
         "visible": bool(visible),
+        "required_role": required_role,
     }
 
     conn = db()
@@ -285,10 +289,21 @@ def save_menu_entry() -> Response:
                 cursor = conn.execute(
                     """
                     UPDATE ui_menu
-                    SET slug = ?, title = ?, url = ?, icon = ?, parent_id = ?, position = ?, target = ?, visible = ?
+                    SET slug = ?, title = ?, url = ?, icon = ?, parent_id = ?, position = ?, target = ?, visible = ?, required_role = ?
                     WHERE id = ?
                     """,
-                    (slug, title, url_value, icon, parent_id, position, target, visible, entry_id),
+                    (
+                        slug,
+                        title,
+                        url_value,
+                        icon,
+                        parent_id,
+                        position,
+                        target,
+                        visible,
+                        required_role,
+                        entry_id,
+                    ),
                 )
                 if cursor.rowcount == 0:
                     return _redirect_to_dashboard("menu", status="error", error="Menu entry was not found.")
@@ -296,10 +311,20 @@ def save_menu_entry() -> Response:
             else:
                 cursor = conn.execute(
                     """
-                    INSERT INTO ui_menu(slug, title, url, icon, parent_id, position, target, visible)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    INSERT INTO ui_menu(slug, title, url, icon, parent_id, position, target, visible, required_role)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
-                    (slug, title, url_value, icon, parent_id, position, target, visible),
+                    (
+                        slug,
+                        title,
+                        url_value,
+                        icon,
+                        parent_id,
+                        position,
+                        target,
+                        visible,
+                        required_role,
+                    ),
                 )
                 new_id = int(cursor.lastrowid)
                 _log_audit(conn, "create", "ui_menu", new_id, payload)
@@ -574,7 +599,7 @@ def _fetch_dashboard_data() -> dict[str, list[sqlite3.Row]]:
         menu_entries = list(
             conn.execute(
                 """
-                SELECT id, slug, title, url, icon, parent_id, position, target, visible
+                SELECT id, slug, title, url, icon, parent_id, position, target, visible, required_role
                 FROM ui_menu
                 ORDER BY COALESCE(parent_id, 0) ASC, position ASC, id ASC
                 """

--- a/dvorik/admin/templates/superadmin/dashboard.html
+++ b/dvorik/admin/templates/superadmin/dashboard.html
@@ -553,6 +553,9 @@
               <label>Target
                 <input type="text" name="target" value="{{ entry['target'] or '' }}" placeholder="_blank">
               </label>
+              <label>Required role
+                <input type="text" name="required_role" value="{{ entry['required_role'] or '' }}" placeholder="superadmin">
+              </label>
               <label class="crud-form__checkbox">
                 <input type="checkbox" name="visible" value="1" {% if entry['visible'] %}checked{% endif %}>
                 Visible
@@ -607,6 +610,9 @@
           <div class="crud-form__row">
             <label>Target
               <input type="text" name="target" placeholder="_self">
+            </label>
+            <label>Required role
+              <input type="text" name="required_role" placeholder="superadmin">
             </label>
             <label class="crud-form__checkbox">
               <input type="checkbox" name="visible" value="1" checked>

--- a/dvorik/db/migrations.py
+++ b/dvorik/db/migrations.py
@@ -330,9 +330,12 @@ _SCHEMA_SCRIPTS: Iterable[str] = (
         parent_id INTEGER,
         position INTEGER NOT NULL DEFAULT 0,
         target TEXT,
+        required_role TEXT,
         visible INTEGER NOT NULL DEFAULT 1,
         FOREIGN KEY(parent_id) REFERENCES ui_menu(id) ON DELETE CASCADE
     );
+
+    CREATE INDEX IF NOT EXISTS idx_ui_menu_required_role ON ui_menu(required_role);
 
     CREATE TABLE IF NOT EXISTS scheduled_job(
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -385,9 +388,40 @@ def init_db(connection: sqlite3.Connection | None = None) -> None:
         with conn:
             for script in _SCHEMA_SCRIPTS:
                 _run_script(conn, script)
+            _ensure_ui_menu_required_role(conn)
     finally:
         if owns_connection:
             conn.close()
+
+
+def _ensure_ui_menu_required_role(conn: sqlite3.Connection) -> None:
+    """Ensure the ``ui_menu.required_role`` column and index exist."""
+
+    try:
+        cursor = conn.execute("PRAGMA table_info(ui_menu)")
+    except sqlite3.Error as exc:  # pragma: no cover - defensive guard
+        logger.warning("Unable to introspect ui_menu schema: %s", exc)
+        return
+
+    column_names = set()
+    for row in cursor.fetchall():
+        try:
+            name = row["name"]  # type: ignore[index]
+        except (TypeError, KeyError):  # pragma: no cover - fallback for tuples
+            name = row[1] if isinstance(row, (tuple, list)) and len(row) > 1 else None
+        if name:
+            column_names.add(str(name))
+
+    if "required_role" not in column_names:
+        try:
+            conn.execute("ALTER TABLE ui_menu ADD COLUMN required_role TEXT")
+        except sqlite3.Error as exc:  # pragma: no cover - logged for observability
+            logger.warning("Failed to add ui_menu.required_role column: %s", exc)
+
+    try:
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_ui_menu_required_role ON ui_menu(required_role)")
+    except sqlite3.Error as exc:  # pragma: no cover - logged for observability
+        logger.warning("Failed to ensure index for ui_menu.required_role: %s", exc)
 
 
 __all__ = ["init_db"]

--- a/dvorik/plugins/example/__init__.py
+++ b/dvorik/plugins/example/__init__.py
@@ -156,14 +156,15 @@ def _ensure_menu_entry() -> None:
         with conn:
             conn.execute(
                 """
-                INSERT INTO ui_menu(slug, title, url, icon, parent_id, position, target, visible)
-                VALUES (?, ?, ?, ?, NULL, ?, NULL, 1)
+                INSERT INTO ui_menu(slug, title, url, icon, parent_id, position, target, visible, required_role)
+                VALUES (?, ?, ?, ?, NULL, ?, NULL, 1, NULL)
                 ON CONFLICT(slug) DO UPDATE SET
                     title = excluded.title,
                     url = excluded.url,
                     icon = excluded.icon,
                     position = excluded.position,
-                    visible = excluded.visible
+                    visible = excluded.visible,
+                    required_role = excluded.required_role
                 """,
                 (
                     _MENU_ENTRY.slug,

--- a/tests/test_admin_menus.py
+++ b/tests/test_admin_menus.py
@@ -1,0 +1,121 @@
+import sqlite3
+from pathlib import Path
+from typing import Iterable
+
+import pytest
+
+from dvorik.admin.blueprints import menus
+from dvorik.db.migrations import init_db
+
+
+@pytest.fixture
+def menu_database(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    db_path = tmp_path / "menu.sqlite3"
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    init_db(connection=conn)
+    conn.close()
+
+    def _db() -> sqlite3.Connection:
+        connection = sqlite3.connect(db_path)
+        connection.row_factory = sqlite3.Row
+        return connection
+
+    monkeypatch.setattr(menus, "db", _db)
+    return db_path
+
+
+def _seed_menu(db_path: Path, entries: Iterable[dict[str, object | None]]) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        with conn:
+            conn.execute("DELETE FROM ui_menu")
+            for index, entry in enumerate(entries, start=1):
+                slug = str(entry.get("slug"))
+                title = str(entry.get("title") or slug.title())
+                url = str(entry.get("url") or f"/{slug}")
+                position = int(entry.get("position") or index)
+                visible = 1 if entry.get("visible", True) else 0
+                required_role = entry.get("required_role")
+                if isinstance(required_role, str):
+                    required_role = required_role.strip() or None
+                conn.execute(
+                    """
+                    INSERT INTO ui_menu(
+                        slug, title, url, icon, parent_id, position, target, visible, required_role
+                    )
+                    VALUES (?, ?, ?, ?, NULL, ?, NULL, ?, ?)
+                    """,
+                    (
+                        slug,
+                        title,
+                        url,
+                        None,
+                        position,
+                        visible,
+                        required_role,
+                    ),
+                )
+    finally:
+        conn.close()
+
+
+def _extract_slugs(entries: Iterable[menus.MenuEntry]) -> set[str]:
+    return {entry.slug for entry in entries}
+
+
+def test_menu_entries_filtered_for_superadmin(menu_database: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _seed_menu(
+        menu_database,
+        [
+            {"slug": "common", "required_role": None},
+            {"slug": "only-super", "required_role": "superadmin"},
+            {"slug": "seller", "required_role": "seller"},
+        ],
+    )
+
+    monkeypatch.setattr(menus, "_resolve_user_role", lambda: "superadmin")
+
+    entries, is_dynamic = menus._load_menu_entries()
+
+    assert is_dynamic is True
+    slugs = _extract_slugs(entries)
+    assert slugs == {"common", "only-super"}
+
+
+def test_menu_entries_hidden_from_other_roles(menu_database: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _seed_menu(
+        menu_database,
+        [
+            {"slug": "common", "required_role": None},
+            {"slug": "only-super", "required_role": "superadmin"},
+            {"slug": "seller", "required_role": "seller"},
+        ],
+    )
+
+    monkeypatch.setattr(menus, "_resolve_user_role", lambda: "seller")
+
+    entries, is_dynamic = menus._load_menu_entries()
+
+    assert is_dynamic is True
+    slugs = _extract_slugs(entries)
+    assert slugs == {"common", "seller"}
+
+
+def test_menu_entries_hidden_when_no_role(menu_database: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _seed_menu(
+        menu_database,
+        [
+            {"slug": "common", "required_role": None},
+            {"slug": "only-super", "required_role": "superadmin"},
+        ],
+    )
+
+    monkeypatch.setattr(menus, "_resolve_user_role", lambda: None)
+
+    entries, is_dynamic = menus._load_menu_entries()
+
+    assert is_dynamic is True
+    slugs = _extract_slugs(entries)
+    assert slugs == {"common"}


### PR DESCRIPTION
## Summary
- add a `required_role` column with an index to `ui_menu` and ensure it is created during init
- filter dynamic menu rows by the current session role and expose the field in the superadmin CRUD/UI
- update the example plugin seeding logic and add regression tests covering role-specific visibility

## Testing
- pytest tests/test_admin_menus.py

------
https://chatgpt.com/codex/tasks/task_e_68dd4a3cd6c88326a6182304b809630c