### PR TITLE
Add plugin migration hook support

### DIFF
--- a/dvorik/app.py
+++ b/dvorik/app.py
@@ -6,11 +6,11 @@ import datetime as dt
 import logging
 import sqlite3
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Awaitable, Callable, Mapping, MutableMapping
+from typing import TYPE_CHECKING, Awaitable, Callable, Mapping, MutableMapping, Sequence
 
 from dvorik.core import events
 from dvorik.core.config import Config, get_config
-from dvorik.core.plugins import load_plugins
+from dvorik.core.plugins import PluginDescriptor, load_plugins
 from dvorik.core.registry import JobRegistry
 from dvorik.core.scheduler import register_daily
 from dvorik.db import db, init_db
@@ -51,6 +51,7 @@ def create_system(*, config: Config | None = None) -> DvorikSystem:
 
     plugins = load_plugins()
     if plugins:
+        _run_plugin_migrations(plugins)
         logger.info("Loaded %d plugin(s)", len(plugins))
     else:
         logger.info("No plugins discovered")
@@ -177,6 +178,30 @@ def _register_notifications(config: Config) -> None:
     _NOTIFICATION_STATE["conn"] = conn
     _NOTIFICATION_STATE["unsubscribers"] = unsubscribers
     logger.debug("Notification subscribers registered (%d handlers)", len(unsubscribers))
+
+
+def _run_plugin_migrations(plugins: Sequence[PluginDescriptor]) -> None:
+    migratable = [plugin for plugin in plugins if callable(plugin.migrate)]
+    if not migratable:
+        logger.debug("No plugin migrations detected")
+        return
+
+    conn = db()
+    try:
+        for plugin in migratable:
+            migrate = plugin.migrate
+            if migrate is None:
+                continue
+
+            logger.info("Running migration for plugin %s", plugin.name)
+            try:
+                migrate(conn)
+                conn.commit()
+            except Exception:  # pragma: no cover - surfaced via logs
+                conn.rollback()
+                logger.exception("Plugin %s migration failed", plugin.name)
+    finally:
+        conn.close()
 
 
 __all__ = ["create_system", "DvorikSystem"]

--- a/dvorik/core/plugins.py
+++ b/dvorik/core/plugins.py
@@ -6,9 +6,10 @@ import importlib
 import inspect
 import logging
 import pkgutil
+import sqlite3
 from dataclasses import dataclass, field
 from types import ModuleType
-from typing import Dict, Iterable, List, Mapping, Sequence
+from typing import Callable, Dict, Iterable, List, Mapping, Sequence
 
 from .registry import BotRouterRegistry, JobRegistry, MenuRegistry, WidgetRegistry
 from .version import API_VERSION as CORE_API_VERSION
@@ -25,6 +26,7 @@ class PluginDescriptor:
     version: str | None = None
     api_versions: tuple[str, ...] = field(default_factory=tuple)
     description: str | None = None
+    migrate: Callable[[sqlite3.Connection], None] | None = None
 
     @property
     def module_name(self) -> str:
@@ -43,6 +45,7 @@ def register_plugin(
     api_version: str | Sequence[str] | None = None,
     description: str | None = None,
     replace: bool = True,
+    migrate: Callable[[sqlite3.Connection], None] | None = None,
 ) -> None:
     """Register plugin metadata in the in-memory catalogue."""
 
@@ -56,6 +59,7 @@ def register_plugin(
         version=version,
         api_versions=_normalise_declared_versions(api_version),
         description=description,
+        migrate=migrate,
     )
 
     if not replace and name in _PLUGINS:
@@ -151,10 +155,14 @@ def load_plugins(dir: str = "dvorik/plugins") -> Sequence[PluginDescriptor]:
         register_plugin(
             plugin_name,
             module=module,
-            version=metadata.version or (existing_descriptor.version if existing_descriptor else None),
+            version=metadata.version
+            or (existing_descriptor.version if existing_descriptor else None),
             api_version=metadata.api_versions
             or (existing_descriptor.api_versions if existing_descriptor else None),
-            description=metadata.description or (existing_descriptor.description if existing_descriptor else None),
+            description=metadata.description
+            or (existing_descriptor.description if existing_descriptor else None),
+            migrate=metadata.migrate
+            or (existing_descriptor.migrate if existing_descriptor else None),
         )
 
     logger.info("Loaded %d plugins from %s", len(loaded_modules), package_name)
@@ -213,6 +221,7 @@ class _PluginMetadata:
     version: str | None
     api_versions: tuple[str, ...]
     description: str | None
+    migrate: Callable[[sqlite3.Connection], None] | None
 
 
 def _introspect_plugin_module(module: ModuleType) -> _PluginMetadata:
@@ -220,6 +229,16 @@ def _introspect_plugin_module(module: ModuleType) -> _PluginMetadata:
     version = getattr(module, "PLUGIN_VERSION", None) or getattr(module, "__version__", None)
     name = getattr(module, "PLUGIN_NAME", None)
     description = getattr(module, "__doc__", None)
+    migrate: Callable[[sqlite3.Connection], None] | None = None
+
+    migrate_attr = getattr(module, "migrate", None)
+    if migrate_attr is not None:
+        if callable(migrate_attr):
+            migrate = migrate_attr
+        else:
+            logger.warning(
+                "Plugin %s defines a non-callable migrate attribute; ignoring", module.__name__
+            )
 
     info_callable = getattr(module, "plugin_info", None)
     if callable(info_callable):
@@ -239,7 +258,13 @@ def _introspect_plugin_module(module: ModuleType) -> _PluginMetadata:
                 description = info.get("description") or description
 
     description = description.strip() if isinstance(description, str) else description
-    return _PluginMetadata(name=name, version=version, api_versions=api_versions, description=description)
+    return _PluginMetadata(
+        name=name,
+        version=version,
+        api_versions=api_versions,
+        description=description,
+        migrate=migrate,
+    )
 
 
 def _normalise_declared_versions(

--- a/tests/test_plugin_migrations.py
+++ b/tests/test_plugin_migrations.py
@@ -1,0 +1,154 @@
+"""Tests covering plugin migration discovery and execution."""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+import pytest
+
+import dvorik.app as app_module
+from dvorik.core import config as core_config
+from dvorik.core import plugins as plugin_module
+from dvorik.core.plugins import PluginDescriptor
+from dvorik.core.version import API_VERSION as CORE_API_VERSION
+from dvorik.db import db
+
+
+@pytest.fixture(autouse=True)
+def _reset_plugins(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure plugin registries are isolated between tests."""
+
+    monkeypatch.setattr(plugin_module, "_PLUGINS", {})
+    monkeypatch.setattr(plugin_module, "_MODULE_TO_PLUGIN", {})
+
+
+def _create_test_config(tmp_path_factory: pytest.TempPathFactory) -> core_config.Config:
+    base_dir = tmp_path_factory.mktemp("dvorik-config")
+
+    data_dir = base_dir / "data"
+    uploads_dir = data_dir / "uploads"
+    normalized_dir = uploads_dir / "normalized"
+    media_dir = base_dir / "media"
+    photos_dir = media_dir / "photos"
+    reports_dir = base_dir / "reports"
+
+    for path in (data_dir, uploads_dir, normalized_dir, media_dir, photos_dir, reports_dir):
+        path.mkdir(parents=True, exist_ok=True)
+
+    db_path = data_dir / "test.sqlite3"
+
+    return core_config.Config(
+        bot_token="",
+        super_admin_id=None,
+        super_admin_username="@test",
+        admin_port=8000,
+        db_path=db_path,
+        data_dir=data_dir,
+        media_dir=media_dir,
+        reports_dir=reports_dir,
+        uploads_dir=uploads_dir,
+        normalized_uploads_dir=normalized_dir,
+        photos_dir=photos_dir,
+        page_size=10,
+        cards_page_size=20,
+        stock_page_size=30,
+        photo_quality=85,
+    )
+
+
+def test_load_plugins_exposes_migrate_callable(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    package_dir = tmp_path / "test_plugins"
+    package_dir.mkdir()
+    (package_dir / "__init__.py").write_text("", encoding="utf-8")
+    (package_dir / "example.py").write_text(
+        "\n".join(
+            (
+                "from dvorik.core.version import API_VERSION as CORE_API_VERSION",
+                "API_VERSION = CORE_API_VERSION",
+                "PLUGIN_NAME = 'example'",
+                "def migrate(conn):",
+                "    conn.execute('SELECT 1')",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    modules_to_cleanup = [name for name in sys.modules if name.startswith("test_plugins")]
+    for module_name in modules_to_cleanup:
+        sys.modules.pop(module_name)
+
+    try:
+        descriptors = plugin_module.load_plugins("test_plugins")
+        assert descriptors, "expected plugin discovery to yield at least one plugin"
+
+        discovered = next(
+            (item for item in descriptors if item.module.__name__ == "test_plugins.example"),
+            None,
+        )
+        assert discovered is not None, "expected the dummy plugin to be registered"
+        assert callable(discovered.migrate)
+    finally:
+        for module_name in list(sys.modules):
+            if module_name.startswith("test_plugins"):
+                sys.modules.pop(module_name)
+
+
+def test_create_system_runs_plugin_migrations(monkeypatch: pytest.MonkeyPatch, tmp_path_factory: pytest.TempPathFactory) -> None:
+    config = _create_test_config(tmp_path_factory)
+    monkeypatch.setattr(core_config, "_CONFIG", config, raising=False)
+
+    call_count = 0
+
+    def migrate(conn) -> None:
+        nonlocal call_count
+        call_count += 1
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS plugin_flags(
+                id INTEGER PRIMARY KEY CHECK(id = 1),
+                enabled INTEGER NOT NULL
+            )
+            """
+        )
+        row = conn.execute("SELECT enabled FROM plugin_flags WHERE id = 1").fetchone()
+        if row is None:
+            conn.execute("INSERT INTO plugin_flags(id, enabled) VALUES (1, 1)")
+        else:
+            current = int(row["enabled"])
+            new_value = 0 if current else 1
+            conn.execute("UPDATE plugin_flags SET enabled = ? WHERE id = 1", (new_value,))
+
+    module = ModuleType("test_plugin")
+    module.migrate = migrate  # type: ignore[attr-defined]
+
+    descriptor = PluginDescriptor(
+        name="test-plugin",
+        module=module,
+        version="0.0.1",
+        api_versions=(CORE_API_VERSION,),
+        description="",
+        migrate=migrate,
+    )
+
+    monkeypatch.setattr(app_module, "load_plugins", lambda dir="dvorik/plugins": (descriptor,))
+    monkeypatch.setattr(app_module, "_register_admin_components", lambda: None)
+    monkeypatch.setattr(app_module, "_register_bot_components", lambda: None)
+    monkeypatch.setattr(app_module, "_register_scheduler_jobs", lambda: None)
+    monkeypatch.setattr(app_module, "_register_notifications", lambda config: None)
+
+    app_module.create_system(config=config)
+    with db() as conn:
+        row = conn.execute("SELECT enabled FROM plugin_flags WHERE id = 1").fetchone()
+        assert row is not None
+        assert int(row["enabled"]) == 1
+
+    app_module.create_system(config=config)
+    with db() as conn:
+        row = conn.execute("SELECT enabled FROM plugin_flags WHERE id = 1").fetchone()
+        assert row is not None
+        assert int(row["enabled"]) == 0
+
+    assert call_count == 2


### PR DESCRIPTION
## Summary
- extend the plugin loader to surface an optional `migrate` callable on descriptors
- execute discovered plugin migrations after database initialisation with connection management and logging
- cover the migration flow with tests using a dummy plugin that toggles state in SQLite

## Testing
- pytest tests/test_plugin_migrations.py

------
https://chatgpt.com/codex/tasks/task_e_68dd4a3ed39c83269ff07f04b593e962