### PR TITLE
Remove stray logging marker from app imports

### DIFF
--- a/dvorik/app.py
+++ b/dvorik/app.py
@@ -10,9 +10,7 @@ from typing import TYPE_CHECKING, Awaitable, Callable, Mapping, MutableMapping, 
 
 from dvorik.core import events
 from dvorik.core.config import Config, get_config
- codex/add-logging-bootstrap-module-with-context
 from dvorik.core.logging import bootstrap_logging
-from dvorik.core.plugins import load_plugins
 from dvorik.core.plugins import PluginDescriptor, load_plugins
 from dvorik.core.registry import JobRegistry
 from dvorik.core.scheduler import register_daily


### PR DESCRIPTION
## Summary
- remove an accidental marker line from dvorik/app.py
- deduplicate plugin imports in the application bootstrap module

## Testing
- python -m compileall dvorik/app.py
- pytest tests/test_plugins_loader.py::test_load_config_reads_plugin_settings

------
https://chatgpt.com/codex/tasks/task_e_68deab9813a88326ae7a201074cdbc82