### PR TITLE
Fix schedule calendar to use local timezone

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,6 +1,7 @@
 import os
 import json
 from pathlib import Path
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 # Dedicated host paths (used on prod machine)
 _HOST_ROOT = Path("/Users/nikitamysnik/Desktop/progs").expanduser()
@@ -90,6 +91,17 @@ else:
 
 # Images
 PHOTO_QUALITY = 85
+
+# Local timezone (used when formatting dates for users)
+_cfg_tz = _cfg.get("LOCAL_TZ")
+_env_tz = os.getenv("LOCAL_TZ")
+_default_tz = "Europe/Moscow"
+LOCAL_TZ_NAME = _env_tz or _cfg_tz or _default_tz
+try:
+    LOCAL_TZ = ZoneInfo(LOCAL_TZ_NAME)
+except ZoneInfoNotFoundError:
+    LOCAL_TZ = ZoneInfo("UTC")
+    LOCAL_TZ_NAME = "UTC"
 
 # Pagination/constants
 PAGE_SIZE = 10

--- a/app/handlers/schedule.py
+++ b/app/handlers/schedule.py
@@ -14,12 +14,13 @@ import app.bot as botmod
 from app.ui.keyboards import month_calendar_kb, admin_day_actions_kb
 from app.ui.states import SchedStates, SchedTransfer, SchedAdmin
 from app.services import schedule as sched
+from app.utils_dt import local_today
 
 router = Router()
 
 
 def _month_start(d: Optional[dt.date] = None) -> dt.date:
-    d = d or dt.date.today()
+    d = d or local_today()
     return dt.date(d.year, d.month, 1)
 
 
@@ -66,7 +67,7 @@ async def cb_month_nav(cb: CallbackQuery):
 async def cb_table(cb: CallbackQuery):
     if not botmod.is_allowed(cb.from_user.id, cb.from_user.username):
         await cb.answer(); return
-    today = dt.date.today()
+    today = local_today()
     m1 = _month_start(today)
     # next month start
     m2 = dt.date(m1.year + (1 if m1.month == 12 else 0), 1 if m1.month == 12 else m1.month + 1, 1)
@@ -348,7 +349,7 @@ async def cb_admin_calendar(cb: CallbackQuery):
 async def cb_admin_table_html(cb: CallbackQuery):
     if not botmod.is_admin(cb.from_user.id, cb.from_user.username):
         await cb.answer("Нет доступа", show_alert=True); return
-    today = dt.date.today()
+    today = local_today()
     m1 = _month_start(today)
     m2 = dt.date(m1.year + (1 if m1.month == 12 else 0), 1 if m1.month == 12 else m1.month + 1, 1)
     from app import config as app_config

--- a/app/services/schedule.py
+++ b/app/services/schedule.py
@@ -7,6 +7,7 @@ from typing import List, Tuple, Optional, Dict
 import sqlite3
 
 from app import db as app_db
+from app.utils_dt import local_today
 
 
 @dataclass
@@ -504,7 +505,7 @@ def swap_employees_globally(emp_a: int, emp_b: int, start_date: Optional[dt.date
         conn = _conn(); own = True
     try:
         if start_date is None:
-            start_date = dt.date.today()
+            start_date = local_today()
         d = start_date.isoformat()
         # For each date with either emp assigned, swap presence.
         rows = conn.execute(

--- a/app/ui/keyboards.py
+++ b/app/ui/keyboards.py
@@ -11,6 +11,7 @@ from app.db import db, get_default_supplier_id
 from app import config as app_config
 from app.services.notify import get_notify_mode
 from app.utils_number import display_qty
+from app.utils_dt import local_today
 
 
 def grid_buttons(items: List[Tuple[str, str]], per_row: int = 2, back_cb: Optional[str] = None) -> InlineKeyboardMarkup:
@@ -185,7 +186,7 @@ def kb_main(user_id: Optional[int] = None, username: Optional[str] = None) -> In
     if admin:
         b.button(text="Наличие", callback_data="stock")
         b.adjust(1)
-        today_ym = dt.date.today().strftime("%Y-%m")
+        today_ym = local_today().strftime("%Y-%m")
         b.button(text="Расписание", callback_data=f"sched|month|{today_ym}")
         b.adjust(1)
         b.button(text="🛠️ Администрирование", callback_data="admin")
@@ -193,7 +194,7 @@ def kb_main(user_id: Optional[int] = None, username: Optional[str] = None) -> In
     else:
         b.button(text="Наличие", callback_data="stock")
         b.adjust(1)
-        today_ym = dt.date.today().strftime("%Y-%m")
+        today_ym = local_today().strftime("%Y-%m")
         b.button(text="Расписание", callback_data=f"sched|month|{today_ym}")
         b.adjust(1)
     b.row(InlineKeyboardButton(text="🔎 Поиск", switch_inline_query_current_chat=""))

--- a/app/utils_dt.py
+++ b/app/utils_dt.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import datetime as dt
+
+from app import config as app_config
+
+
+def local_now() -> dt.datetime:
+    """Return current datetime in the configured local timezone."""
+    tz = getattr(app_config, "LOCAL_TZ", None)
+    if tz is None:
+        # Fallback to system local time if timezone is missing in config
+        return dt.datetime.now().astimezone()
+    return dt.datetime.now(tz)
+
+
+def local_today() -> dt.date:
+    """Return today's date in the configured local timezone."""
+    return local_now().date()


### PR DESCRIPTION
## Summary
- add a configurable local timezone in the shared config and expose helpers for local dates
- switch schedule handlers and keyboards to use the local date so the current month is shown to users

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df551d42d48326975f2fb31a835e6c