### PR TITLE
Fix plugin loader registrations and plugin config usage

### DIFF
--- a/dvorik/app.py
+++ b/dvorik/app.py
@@ -10,9 +10,7 @@ from typing import TYPE_CHECKING, Awaitable, Callable, Mapping, MutableMapping, 
 
 from dvorik.core import events
 from dvorik.core.config import Config, get_config
- codex/add-logging-bootstrap-module-with-context
 from dvorik.core.logging import bootstrap_logging
-from dvorik.core.plugins import load_plugins
 from dvorik.core.plugins import PluginDescriptor, load_plugins
 from dvorik.core.registry import JobRegistry
 from dvorik.core.scheduler import register_daily
@@ -57,14 +55,10 @@ def create_system(*, config: Config | None = None) -> DvorikSystem:
     if config.plugin_disabled:
         plugins = tuple()
         logger.info("Plugin loading disabled via configuration")
-
-    plugins = load_plugins()
-    if plugins:
-        _run_plugin_migrations(plugins)
-        logger.info("Loaded %d plugin(s)", len(plugins))
     else:
         plugins = load_plugins(*config.plugin_paths)
         if plugins:
+            _run_plugin_migrations(plugins)
             logger.info("Loaded %d plugin(s)", len(plugins))
         else:
             logger.info("No plugins discovered")

--- a/dvorik/core/plugins.py
+++ b/dvorik/core/plugins.py
@@ -208,35 +208,21 @@ def load_plugins(
                 or (existing_descriptor.api_versions if existing_descriptor else None),
                 description=metadata.description
                 or (existing_descriptor.description if existing_descriptor else None),
+                migrate=metadata.migrate
+                or (existing_descriptor.migrate if existing_descriptor else None),
             )
             loaded_plugins.append(plugin_name)
 
     if loaded_plugins:
-        logger.info("Loaded plugins: %s", ", ".join(sorted(set(loaded_plugins))))
+        unique_plugins = sorted(set(loaded_plugins))
+        logger.info("Loaded plugins: %s", ", ".join(unique_plugins))
+        logger.info("Total loaded plugins: %d", len(unique_plugins))
     else:
         logger.info("No plugins loaded")
 
     if skipped_plugins:
         details = ", ".join(f"{name} ({reason})" for name, reason in skipped_plugins)
         logger.info("Skipped plugins: %s", details)
-
-
-        plugin_name = existing_name or metadata.name or module.__name__.rsplit(".", 1)[-1]
-        existing_descriptor = _PLUGINS.get(plugin_name)
-        register_plugin(
-            plugin_name,
-            module=module,
-            version=metadata.version
-            or (existing_descriptor.version if existing_descriptor else None),
-            api_version=metadata.api_versions
-            or (existing_descriptor.api_versions if existing_descriptor else None),
-            description=metadata.description
-            or (existing_descriptor.description if existing_descriptor else None),
-            migrate=metadata.migrate
-            or (existing_descriptor.migrate if existing_descriptor else None),
-        )
-
-    logger.info("Loaded %d plugins from %s", len(loaded_modules), package_name)
     return get_plugins()
 
 

--- a/tests/test_plugin_migrations.py
+++ b/tests/test_plugin_migrations.py
@@ -54,6 +54,8 @@ def _create_test_config(tmp_path_factory: pytest.TempPathFactory) -> core_config
         cards_page_size=20,
         stock_page_size=30,
         photo_quality=85,
+        plugin_paths=("dvorik/plugins",),
+        plugin_disabled=False,
     )
 
 


### PR DESCRIPTION
## Summary
- ensure plugin loader retains plugin migrations and avoids re-registering modules after discovery
- adjust application bootstrapping to honour plugin configuration flags and paths
- update plugin migration tests to provide required configuration fields

## Testing
- pytest tests/test_plugin_migrations.py
- pytest tests/test_plugins_loader.py

------
https://chatgpt.com/codex/tasks/task_e_68deab995b388326a827a13df78c1d1d