### PR TITLE
Handle disabled plugins in readiness check

### DIFF
--- a/dvorik/admin/server.py
+++ b/dvorik/admin/server.py
@@ -96,17 +96,24 @@ def create_app(*, config: Config | None = None) -> Flask:
 
         checks["database"] = {"status": "ok"}
 
-        plugins = tuple(get_plugins())
-        if not plugins:
-            checks["plugins"] = {"status": "missing", "count": 0}
-            logger.error("Readiness check failed: no plugins registered")
-            return {"status": "error", "checks": checks}, 503
+        config: Config = app.config["DVORIK_CONFIG"]
+        if config.plugin_disabled:
+            checks["plugins"] = {"status": "disabled"}
+            logger.info(
+                "Readiness check: plugin catalogue disabled via configuration"
+            )
+        else:
+            plugins = tuple(get_plugins())
+            if not plugins:
+                checks["plugins"] = {"status": "missing", "count": 0}
+                logger.error("Readiness check failed: no plugins registered")
+                return {"status": "error", "checks": checks}, 503
 
-        checks["plugins"] = {
-            "status": "ok",
-            "count": len(plugins),
-            "names": sorted(plugin.name for plugin in plugins),
-        }
+            checks["plugins"] = {
+                "status": "ok",
+                "count": len(plugins),
+                "names": sorted(plugin.name for plugin in plugins),
+            }
 
         return {"status": "ok", "checks": checks}, 200
 

--- a/tests/test_admin_readiness.py
+++ b/tests/test_admin_readiness.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import replace
+
+from dvorik.admin import auth as auth_module
+from dvorik.admin import server as server_module
+from dvorik.core import config as config_module
+
+
+def _failing_get_plugins():
+    raise AssertionError("get_plugins should not be called when plugins disabled")
+
+
+def test_readiness_reports_disabled_plugins(monkeypatch, tmp_path):
+    base_config = config_module.get_config(refresh=True)
+    config = replace(
+        base_config,
+        plugin_disabled=True,
+        db_path=tmp_path / "admin-readiness.sqlite3",
+    )
+
+    monkeypatch.setattr(auth_module, "init_app", lambda *_, **__: None)
+    monkeypatch.setattr(server_module, "_initialise_csrf", lambda _app: None)
+    monkeypatch.setattr(server_module, "_initialise_database", lambda: None)
+    monkeypatch.setattr(server_module, "_register_builtin_components", lambda _cfg: None)
+    monkeypatch.setattr(server_module, "_register_blueprints", lambda _app: None)
+    monkeypatch.setattr(server_module, "db", lambda: sqlite3.connect(":memory:"))
+    monkeypatch.setattr(server_module, "get_plugins", _failing_get_plugins)
+
+    app = server_module.create_app(config=config)
+
+    client = app.test_client()
+    response = client.get("/ready")
+
+    assert response.status_code == 200
+
+    payload = response.get_json()
+    assert payload == {
+        "status": "ok",
+        "checks": {
+            "database": {"status": "ok"},
+            "plugins": {"status": "disabled"},
+        },
+    }


### PR DESCRIPTION
## Summary
- mark the admin readiness check plugins section as disabled when plugins are disabled in configuration and log an informational message
- add a Flask-based unit test covering the readiness endpoint when plugins are disabled

## Testing
- pytest tests/test_admin_readiness.py

------
https://chatgpt.com/codex/tasks/task_e_68df5d939d908326b941e3b7382ce1aa