### PR TITLE
Refine JSON log timestamp formatting

### DIFF
--- a/dvorik/core/logging.py
+++ b/dvorik/core/logging.py
@@ -50,9 +50,13 @@ class JsonLogFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:  # noqa: D401 - short summary
         record.message = record.getMessage()
 
+        timestamp = datetime.fromtimestamp(
+            record.created,
+            tz=timezone.utc,
+        ).isoformat(timespec="milliseconds")
+
         payload: dict[str, Any] = {
-            "timestamp": datetime.fromtimestamp(record.created, timezone.utc)
-            .isoformat(timespec="milliseconds"),
+            "timestamp": timestamp,
             "level": record.levelname,
             "logger": record.name,
             "message": record.message,


### PR DESCRIPTION
## Summary
- refactor the JSON log formatter to build timestamps on a single logical line while keeping the existing behavior

## Testing
- python -m compileall dvorik/core/logging.py
- python - <<'PY'
from dvorik.core.logging import bootstrap_logging, JsonLogFormatter, scoped_context
import logging, json

bootstrap_logging()

logger = logging.getLogger("sample")
with scoped_context(request_id="abc123"):
    logger.info("hello world")
PY
- pytest tests/test_plugins_loader.py::test_create_system_uses_configured_plugin_paths
- pytest dvorik/core

------
https://chatgpt.com/codex/tasks/task_e_68df5d808e448326b06dd1d373b5eab7