### PR TITLE
Update admin Docker CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,6 @@ RUN mkdir -p data media/photos reports
 
 EXPOSE 8000
 
-# By default run the admin UI (compose overrides for the bot)
-CMD ["python", "-m", "admin_ui"]
+# By default run the admin service entry point (compose overrides for the bot)
+CMD ["python", "-m", "dvorik.admin"]
 


### PR DESCRIPTION
## Summary
- update the Dockerfile to run the admin service via `python -m dvorik.admin`
- refresh the accompanying CMD comment to reflect the new entry point

## Testing
- `docker build -t dvorik-admin-test .` *(fails: docker is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e328e4bde08326ae14e7fe3287b0f3