### PR TITLE
Fix ipad page view conflict markers

### DIFF
--- a/admin_ui/blueprints/home.py
+++ b/admin_ui/blueprints/home.py
@@ -103,9 +103,6 @@ def ipad_page():
         locs = bp_utils.load_locations(conn)
 
     return render_template("ipad.html", groups=groups, locations=locs)
-=======
-
-    return render_template("ipad.html", groups=groups)
 
 
 


### PR DESCRIPTION
## Summary
- resolve leftover merge conflict markers in the admin UI home blueprint
- ensure the iPad page renders with both group and location data

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5d949cb408326b48ba91536c85367