### PR TITLE
Port legacy SQLite schema to Laravel migrations

### DIFF
--- a/docs/migration/schema-mapping.md
+++ b/docs/migration/schema-mapping.md
@@ -1,0 +1,47 @@
+# Schema Mapping Notes
+
+This document captures the one-to-one mapping between the legacy SQLite schema defined in `dvorik/db/migrations.py` and the new PostgreSQL structure expressed via Laravel migrations.
+
+## Core Conversions
+
+| SQLite Table | Laravel Table | Key Type Adjustments |
+| --- | --- | --- |
+| `manufacturer` | `manufacturer` | `INTEGER PRIMARY KEY AUTOINCREMENT` → `BIGSERIAL`; timestamp stored as text replaced with `timestamp with time zone` via `timestampTz` and `useCurrent()`. |
+| `supplier` | `supplier` | Same as above; nullable `contact` kept as string. |
+| `product` | `product` | `REAL` price/vat mapped to `decimal(12,2)`/`decimal(5,2)`; boolean flags stored as integers now true booleans; timestamps stored as text replaced with `timestampTz`. |
+| `location` | `location` | Primary key stays textual; timestamp upgraded to `timestampTz`. |
+| `stock` | `stock` | `REAL` quantities mapped to `decimal(15,3)`; composite primary key preserved; timestamp upgraded to `timestampTz`. |
+| `supplier_sku` | `supplier_sku` | Boolean `active` column now real boolean; numeric quantities use `decimal(15,3)`; timestamps upgraded. |
+| `display_name_exception` | `display_name_exception` | Timestamp stored as text → `timestampTz`. |
+| `import_log` | `import_log` | `REAL` counts mapped to unsigned integer; JSON/text fields preserved; timestamps upgraded. |
+| `product_merge_log` | `product_merge_log` | JSON payload stored in JSON columns; timestamps upgraded. |
+| `product_article_alias` | `product_article_alias` | Unique alias maintained; timestamps upgraded. |
+| `product_name_alias` | `product_name_alias` | Normalised name unique index preserved; timestamps upgraded. |
+| `product_merge_rule` | `product_merge_rule` | Boolean `active` flag stored as integer now boolean; JSON fields mapped to JSON; timestamps upgraded. |
+| `schedule_day` | `schedule_day` | Date primary key preserved; integer flag converted to boolean. |
+| `schedule_assignment` | `schedule_assignment` | `created_at` stored via `timestampTz`. |
+| `schedule_transfer_request` | `schedule_transfer_request` | Status check enforced via Laravel enum; timestamps upgraded. |
+| `schedule_anchor` | `schedule_anchor` | Date stored with native date column. |
+| `user_role` | `user_role` | Role check converted to Laravel enum; timestamps upgraded. |
+| `user_notify` | `user_notify` | Enum columns replace CHECK constraints; timestamps upgraded. |
+| `event_log` | `event_log` | Numeric delta stored as `decimal(15,3)`; timestamps upgraded. |
+| `registration_request` | `registration_request` | Enum for status; timestamps upgraded. |
+| `query_registry` | `query_registry` | Primary key string preserved; timestamp upgraded. |
+| `ui_widget` | `ui_widget` | JSON/text fields maintained; uniqueness on `(module, name)` kept. |
+| `ui_widget_instance` | `ui_widget_instance` | Boolean `enabled` stored as boolean; JSON config preserved. |
+| `ui_menu` | `ui_menu` | Self-referencing foreign key maintained; visibility flag stored as boolean. |
+| `scheduled_job` | `scheduled_job` | Enum for schedule type; timestamps upgraded. |
+| `audit_log` | `audit_log` | Timestamp upgraded; payload stored as JSON. |
+
+## Full-Text Search Replacement
+
+The legacy `product_fts` virtual table built with SQLite FTS5 is replaced by a physical PostgreSQL table backed by a `tsvector` column:
+
+- Table `product_fts` stores a `product_id` primary key linked to `product` and a `search_vector` `tsvector` column.
+- A PostgreSQL trigger function (`product_fts_refresh`) materialises combined `article`, `name`, and `local_name` text into the vector using the `simple` dictionary.
+- Three triggers (`product_fts_ai`, `product_fts_au`, `product_fts_ad`) refresh or remove the search document on insert/update/delete.
+- A GIN index (`product_fts_search_vector_gin`) accelerates search queries that replace the prior `fts5` index.
+
+## Boolean Casting During Import
+
+The Laravel artisan command `legacy:ingest-sqlite` casts integer-backed boolean columns (`is_new`, `archived`, `active`, `visible`, `enabled`, etc.) into actual PostgreSQL booleans during ingestion to match the new schema expectations.

--- a/laravel-app/app/Console/Commands/ImportLegacySqlite.php
+++ b/laravel-app/app/Console/Commands/ImportLegacySqlite.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use PDO;
+use PDOException;
+use RuntimeException;
+use Throwable;
+
+class ImportLegacySqlite extends Command
+{
+    protected $signature = 'legacy:ingest-sqlite {path : Path to the legacy SQLite database}';
+
+    protected $description = 'Ingest data from the legacy SQLite database, validating row counts.';
+
+    /** @var string[] */
+    private array $tableOrder = [
+        'manufacturer',
+        'supplier',
+        'product',
+        'location',
+        'stock',
+        'supplier_sku',
+        'display_name_exception',
+        'import_log',
+        'product_merge_log',
+        'product_article_alias',
+        'product_name_alias',
+        'product_merge_rule',
+        'schedule_day',
+        'schedule_assignment',
+        'schedule_transfer_request',
+        'schedule_anchor',
+        'user_role',
+        'user_notify',
+        'event_log',
+        'registration_request',
+        'query_registry',
+        'ui_widget',
+        'ui_widget_instance',
+        'ui_menu',
+        'scheduled_job',
+        'audit_log',
+    ];
+
+    public function handle(): int
+    {
+        $path = (string) $this->argument('path');
+
+        if (! is_file($path)) {
+            $this->error("Legacy database not found at {$path}");
+            return self::FAILURE;
+        }
+
+        try {
+            $sqlite = new PDO('sqlite:'.$path, options: [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+        } catch (PDOException $exception) {
+            $this->error('Unable to open legacy SQLite database: '.$exception->getMessage());
+            return self::FAILURE;
+        }
+
+        DB::beginTransaction();
+
+        try {
+
+            foreach ($this->tableOrder as $table) {
+                $legacyCount = (int) $sqlite->query("SELECT COUNT(*) FROM \"{$table}\"")->fetchColumn();
+                $this->info("Importing {$table} ({$legacyCount} rows)...");
+
+                DB::statement(sprintf('TRUNCATE TABLE "%s" RESTART IDENTITY CASCADE', $table));
+
+                $stmt = $sqlite->query("SELECT * FROM \"{$table}\"");
+                $stmt->setFetchMode(PDO::FETCH_ASSOC);
+
+                $batch = [];
+                $batchSize = 500;
+
+                while (($row = $stmt->fetch()) !== false) {
+                    $batch[] = $this->transformRow($table, $row);
+
+                    if (count($batch) >= $batchSize) {
+                        $this->insertBatch($table, $batch);
+                        $batch = [];
+                    }
+                }
+
+                if ($batch !== []) {
+                    $this->insertBatch($table, $batch);
+                }
+
+                $currentCount = (int) DB::table($table)->count();
+
+                if ($currentCount !== $legacyCount) {
+                    throw new RuntimeException("Row count mismatch for {$table}: legacy={$legacyCount}, imported={$currentCount}");
+                }
+            }
+
+            DB::commit();
+            $this->info('Legacy SQLite import completed successfully.');
+        } catch (Throwable $throwable) {
+            DB::rollBack();
+            $this->error('Import failed: '.$throwable->getMessage());
+            return self::FAILURE;
+        } finally {
+            $sqlite = null;
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @param array<string, mixed> $rows
+     */
+    private function insertBatch(string $table, array $rows): void
+    {
+        if ($rows === []) {
+            return;
+        }
+
+        DB::table($table)->insert($rows);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @return array<string, mixed>
+     */
+    private function transformRow(string $table, array $row): array
+    {
+        return match ($table) {
+            'product' => $this->castBooleanColumns($row, ['is_new', 'archived']),
+            'supplier_sku' => $this->castBooleanColumns($row, ['active']),
+            'product_merge_rule' => $this->castBooleanColumns($row, ['active']),
+            'schedule_day' => $this->castBooleanColumns($row, ['is_open']),
+            'ui_widget_instance' => $this->castBooleanColumns($row, ['enabled']),
+            'ui_menu' => $this->castBooleanColumns($row, ['visible']),
+            'scheduled_job' => $this->castBooleanColumns($row, ['enabled']),
+            default => $row,
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @param string[] $columns
+     * @return array<string, mixed>
+     */
+    private function castBooleanColumns(array $row, array $columns): array
+    {
+        foreach ($columns as $column) {
+            if (array_key_exists($column, $row)) {
+                $value = $row[$column];
+                $row[$column] = $value === null ? null : (bool) ((int) $value);
+            }
+        }
+
+        return $row;
+    }
+}

--- a/laravel-app/database/migrations/2024_01_01_000100_create_inventory_tables.php
+++ b/laravel-app/database/migrations/2024_01_01_000100_create_inventory_tables.php
@@ -1,0 +1,123 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('manufacturer', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name')->unique();
+            $table->string('country')->nullable();
+            $table->timestampTz('created_at')->useCurrent();
+        });
+
+        Schema::create('supplier', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name')->unique();
+            $table->string('contact')->nullable();
+            $table->timestampTz('created_at')->useCurrent();
+        });
+
+        Schema::create('product', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('article')->nullable();
+            $table->string('barcode')->nullable();
+            $table->string('name');
+            $table->string('brand_country')->nullable();
+            $table->string('local_name')->nullable();
+            $table->text('description')->nullable();
+            $table->string('unit')->nullable();
+            $table->foreignId('manufacturer_id')->nullable()->constrained('manufacturer')->nullOnDelete();
+            $table->decimal('price', 12, 2)->nullable();
+            $table->decimal('vat_rate', 5, 2)->nullable();
+            $table->boolean('is_new')->default(false);
+            $table->boolean('archived')->default(false);
+            $table->timestampTz('archived_at')->nullable();
+            $table->timestampTz('created_at')->useCurrent();
+            $table->timestampTz('updated_at')->nullable();
+            $table->timestampTz('last_restock_at')->nullable();
+            $table->string('photo_file_id')->nullable();
+            $table->string('photo_path')->nullable();
+
+            $table->index('article');
+            $table->index('name');
+        });
+
+        Schema::create('location', function (Blueprint $table) {
+            $table->string('code')->primary();
+            $table->string('kind');
+            $table->string('title');
+            $table->timestampTz('created_at')->useCurrent();
+        });
+
+        Schema::create('stock', function (Blueprint $table) {
+            $table->foreignId('product_id')->constrained('product')->cascadeOnDelete();
+            $table->string('location_code');
+            $table->decimal('qty_pack', 15, 3)->default(0);
+            $table->string('name')->nullable();
+            $table->string('local_name')->nullable();
+            $table->decimal('reserved_pack', 15, 3)->default(0);
+            $table->timestampTz('updated_at')->useCurrent();
+
+            $table->primary(['product_id', 'location_code']);
+            $table->foreign('location_code')->references('code')->on('location')->cascadeOnDelete();
+            $table->index('location_code');
+        });
+
+        Schema::create('supplier_sku', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->foreignId('product_id')->constrained('product')->cascadeOnDelete();
+            $table->foreignId('supplier_id')->constrained('supplier')->cascadeOnDelete();
+            $table->string('code');
+            $table->string('barcode')->nullable();
+            $table->decimal('pack_qty', 15, 3)->nullable();
+            $table->boolean('active')->default(true);
+            $table->timestampTz('created_at')->useCurrent();
+            $table->timestampTz('updated_at')->nullable();
+
+            $table->unique(['supplier_id', 'code']);
+            $table->index('product_id');
+            $table->index(['supplier_id', 'active']);
+        });
+
+        Schema::create('display_name_exception', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('phrase')->unique();
+            $table->timestampTz('created_at')->useCurrent();
+        });
+
+        Schema::create('import_log', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('original_name');
+            $table->string('stored_path');
+            $table->enum('import_type', ['csv', 'excel']);
+            $table->string('source_hash')->unique();
+            $table->text('normalized_csv')->nullable();
+            $table->string('normalized_hash')->nullable()->unique();
+            $table->string('supplier')->nullable();
+            $table->string('invoice')->nullable();
+            $table->unsignedInteger('items_count')->default(0);
+            $table->json('items_json')->nullable();
+            $table->timestampTz('reverted_at')->nullable();
+            $table->timestampTz('created_at')->useCurrent();
+
+            $table->index('created_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('import_log');
+        Schema::dropIfExists('display_name_exception');
+        Schema::dropIfExists('supplier_sku');
+        Schema::dropIfExists('stock');
+        Schema::dropIfExists('location');
+        Schema::dropIfExists('product');
+        Schema::dropIfExists('supplier');
+        Schema::dropIfExists('manufacturer');
+    }
+};

--- a/laravel-app/database/migrations/2024_01_01_000200_create_product_merge_tables.php
+++ b/laravel-app/database/migrations/2024_01_01_000200_create_product_merge_tables.php
@@ -1,0 +1,68 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('product_merge_log', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->timestampTz('created_at')->useCurrent();
+            $table->foreignId('source_a_id')->constrained('product');
+            $table->foreignId('source_b_id')->constrained('product');
+            $table->foreignId('result_id')->constrained('product');
+            $table->json('field_modes');
+            $table->string('stock_mode');
+            $table->text('summary')->nullable();
+            $table->json('changes_json');
+            $table->timestampTz('reverted_at')->nullable();
+        });
+
+        Schema::create('product_article_alias', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->foreignId('product_id')->constrained('product');
+            $table->string('alias_article')->unique();
+            $table->foreignId('source_product_id')->nullable()->constrained('product');
+            $table->foreignId('merge_log_id')->nullable()->constrained('product_merge_log');
+            $table->timestampTz('created_at')->useCurrent();
+
+            $table->index('product_id');
+        });
+
+        Schema::create('product_name_alias', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->foreignId('product_id')->constrained('product');
+            $table->string('alias_name');
+            $table->string('normalized_name')->unique();
+            $table->foreignId('source_product_id')->nullable()->constrained('product');
+            $table->foreignId('merge_log_id')->nullable()->constrained('product_merge_log');
+            $table->timestampTz('created_at')->useCurrent();
+
+            $table->index('product_id');
+        });
+
+        Schema::create('product_merge_rule', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->foreignId('result_id')->constrained('product');
+            $table->json('field_modes');
+            $table->string('stock_mode');
+            $table->json('articles_json')->nullable();
+            $table->json('names_json')->nullable();
+            $table->foreignId('merge_log_id')->nullable()->constrained('product_merge_log');
+            $table->boolean('active')->default(true);
+            $table->timestampTz('created_at')->useCurrent();
+            $table->timestampTz('reverted_at')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('product_merge_rule');
+        Schema::dropIfExists('product_name_alias');
+        Schema::dropIfExists('product_article_alias');
+        Schema::dropIfExists('product_merge_log');
+    }
+};

--- a/laravel-app/database/migrations/2024_01_01_000300_create_schedule_tables.php
+++ b/laravel-app/database/migrations/2024_01_01_000300_create_schedule_tables.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('schedule_day', function (Blueprint $table) {
+            $table->date('date')->primary();
+            $table->boolean('is_open')->default(true);
+            $table->text('notes')->nullable();
+        });
+
+        Schema::create('schedule_assignment', function (Blueprint $table) {
+            $table->date('date');
+            $table->unsignedBigInteger('tg_id');
+            $table->string('source')->default('auto');
+            $table->timestampTz('created_at')->useCurrent();
+
+            $table->primary(['date', 'tg_id']);
+            $table->foreign('date')->references('date')->on('schedule_day')->cascadeOnDelete();
+        });
+
+        Schema::create('schedule_transfer_request', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->date('date');
+            $table->unsignedBigInteger('from_tg_id');
+            $table->unsignedBigInteger('to_tg_id');
+            $table->enum('status', ['pending', 'accepted', 'declined', 'cancelled', 'expired'])->default('pending');
+            $table->timestampTz('created_at')->useCurrent();
+            $table->timestampTz('expires_at')->nullable();
+
+            $table->unique(['date', 'from_tg_id', 'to_tg_id']);
+            $table->foreign('date')->references('date')->on('schedule_day')->cascadeOnDelete();
+        });
+
+        Schema::create('schedule_anchor', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->date('start_date')->unique();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('schedule_anchor');
+        Schema::dropIfExists('schedule_transfer_request');
+        Schema::dropIfExists('schedule_assignment');
+        Schema::dropIfExists('schedule_day');
+    }
+};

--- a/laravel-app/database/migrations/2024_01_01_000400_create_user_and_event_tables.php
+++ b/laravel-app/database/migrations/2024_01_01_000400_create_user_and_event_tables.php
@@ -1,0 +1,80 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('user_role', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('tg_id')->nullable();
+            $table->string('username')->nullable();
+            $table->string('display_name')->nullable();
+            $table->enum('role', ['admin', 'seller']);
+            $table->timestampTz('created_at')->useCurrent();
+
+            $table->unique(['username', 'role']);
+            $table->unique(['tg_id', 'role']);
+        });
+
+        Schema::create('user_notify', function (Blueprint $table) {
+            $table->unsignedBigInteger('user_id');
+            $table->enum('notif_type', ['zero', 'last', 'to_skl', 'new_type']);
+            $table->enum('mode', ['off', 'daily', 'instant'])->default('off');
+            $table->timestampTz('updated_at')->useCurrent();
+
+            $table->primary(['user_id', 'notif_type']);
+        });
+
+        Schema::create('event_log', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->timestampTz('ts')->useCurrent();
+            $table->string('event_type');
+            $table->foreignId('product_id')->nullable()->constrained('product')->nullOnDelete();
+            $table->string('location_code')->nullable();
+            $table->unsignedBigInteger('user_id')->nullable();
+            $table->decimal('delta', 15, 3)->nullable();
+            $table->json('payload_json')->nullable();
+
+            $table->foreign('location_code')->references('code')->on('location')->nullOnDelete();
+            $table->index('ts');
+            $table->index('event_type');
+        });
+
+        Schema::create('registration_request', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('tg_id');
+            $table->string('username')->nullable();
+            $table->string('first_name')->nullable();
+            $table->string('last_name')->nullable();
+            $table->string('requested_role')->default('admin');
+            $table->enum('status', ['pending', 'approved', 'declined', 'cancelled'])->default('pending');
+            $table->timestampTz('created_at')->useCurrent();
+        });
+
+        Schema::create('audit_log', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->timestampTz('created_at')->useCurrent();
+            $table->unsignedBigInteger('actor_id')->nullable();
+            $table->string('actor_username')->nullable();
+            $table->string('action');
+            $table->string('entity')->nullable();
+            $table->string('entity_id')->nullable();
+            $table->json('payload_json')->nullable();
+
+            $table->index('created_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('audit_log');
+        Schema::dropIfExists('registration_request');
+        Schema::dropIfExists('event_log');
+        Schema::dropIfExists('user_notify');
+        Schema::dropIfExists('user_role');
+    }
+};

--- a/laravel-app/database/migrations/2024_01_01_000500_create_query_and_ui_tables.php
+++ b/laravel-app/database/migrations/2024_01_01_000500_create_query_and_ui_tables.php
@@ -1,0 +1,78 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('query_registry', function (Blueprint $table) {
+            $table->string('key')->primary();
+            $table->text('sql');
+            $table->text('description')->nullable();
+            $table->timestampTz('updated_at')->useCurrent();
+        });
+
+        Schema::create('ui_widget', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('module');
+            $table->string('name');
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->string('entrypoint')->nullable();
+            $table->json('config_schema')->nullable();
+
+            $table->unique(['module', 'name']);
+        });
+
+        Schema::create('ui_widget_instance', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->foreignId('widget_id')->constrained('ui_widget')->cascadeOnDelete();
+            $table->string('zone');
+            $table->integer('position')->default(0);
+            $table->json('config_json')->nullable();
+            $table->boolean('enabled')->default(true);
+
+            $table->unique(['zone', 'position']);
+        });
+
+        Schema::create('ui_menu', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('slug')->unique();
+            $table->string('title');
+            $table->string('url')->nullable();
+            $table->string('icon')->nullable();
+            $table->foreignId('parent_id')->nullable()->constrained('ui_menu')->cascadeOnDelete();
+            $table->integer('position')->default(0);
+            $table->string('target')->nullable();
+            $table->string('required_role')->nullable();
+            $table->boolean('visible')->default(true);
+
+            $table->index('required_role');
+        });
+
+        Schema::create('scheduled_job', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name')->unique();
+            $table->enum('schedule_type', ['daily', 'cron']);
+            $table->string('schedule_expression')->nullable();
+            $table->timestampTz('next_run_at')->nullable();
+            $table->timestampTz('last_run_at')->nullable();
+            $table->string('task_module');
+            $table->string('task_name');
+            $table->json('config_json')->nullable();
+            $table->boolean('enabled')->default(true);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('scheduled_job');
+        Schema::dropIfExists('ui_menu');
+        Schema::dropIfExists('ui_widget_instance');
+        Schema::dropIfExists('ui_widget');
+        Schema::dropIfExists('query_registry');
+    }
+};

--- a/laravel-app/database/migrations/2024_01_01_000600_create_product_fts_support.php
+++ b/laravel-app/database/migrations/2024_01_01_000600_create_product_fts_support.php
@@ -1,0 +1,60 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('product_fts', function (Blueprint $table) {
+            $table->unsignedBigInteger('product_id')->primary();
+            $table->foreign('product_id')->references('id')->on('product')->cascadeOnDelete();
+        });
+
+        DB::statement("ALTER TABLE product_fts ADD COLUMN search_vector tsvector NOT NULL DEFAULT ''::tsvector");
+        DB::statement("CREATE INDEX product_fts_search_vector_gin ON product_fts USING GIN (search_vector)");
+
+        DB::statement(<<<'SQL'
+CREATE OR REPLACE FUNCTION product_fts_refresh() RETURNS trigger AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        DELETE FROM product_fts WHERE product_id = OLD.id;
+        RETURN OLD;
+    END IF;
+
+    INSERT INTO product_fts (product_id, search_vector)
+    VALUES (
+        NEW.id,
+        to_tsvector('simple',
+            coalesce(NEW.article, '') || ' ' ||
+            coalesce(NEW.name, '') || ' ' ||
+            coalesce(NEW.local_name, '')
+        )
+    )
+    ON CONFLICT (product_id) DO UPDATE
+    SET search_vector = EXCLUDED.search_vector;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+SQL);
+
+        DB::statement("CREATE TRIGGER product_fts_ai AFTER INSERT ON product FOR EACH ROW EXECUTE FUNCTION product_fts_refresh()");
+        DB::statement("CREATE TRIGGER product_fts_au AFTER UPDATE ON product FOR EACH ROW EXECUTE FUNCTION product_fts_refresh()");
+        DB::statement("CREATE TRIGGER product_fts_ad AFTER DELETE ON product FOR EACH ROW EXECUTE FUNCTION product_fts_refresh()");
+    }
+
+    public function down(): void
+    {
+        DB::statement("DROP TRIGGER IF EXISTS product_fts_ai ON product");
+        DB::statement("DROP TRIGGER IF EXISTS product_fts_au ON product");
+        DB::statement("DROP TRIGGER IF EXISTS product_fts_ad ON product");
+        DB::statement("DROP FUNCTION IF EXISTS product_fts_refresh()");
+        DB::statement("DROP INDEX IF EXISTS product_fts_search_vector_gin");
+
+        Schema::dropIfExists('product_fts');
+    }
+};

--- a/laravel-app/database/seeders/DatabaseSeeder.php
+++ b/laravel-app/database/seeders/DatabaseSeeder.php
@@ -9,6 +9,9 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         $this->call([
+            LocationSeeder::class,
+            SupplierSeeder::class,
+            UiMenuSeeder::class,
             SuperAdminSeeder::class,
         ]);
     }

--- a/laravel-app/database/seeders/LocationSeeder.php
+++ b/laravel-app/database/seeders/LocationSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Date;
+
+class LocationSeeder extends Seeder
+{
+    public function run(): void
+    {
+        DB::table('location')->updateOrInsert(
+            ['code' => 'SKL-0'],
+            [
+                'kind' => 'HUB',
+                'title' => 'Центральный склад',
+                'created_at' => Date::now(),
+            ]
+        );
+    }
+}

--- a/laravel-app/database/seeders/SupplierSeeder.php
+++ b/laravel-app/database/seeders/SupplierSeeder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Date;
+
+class SupplierSeeder extends Seeder
+{
+    public function run(): void
+    {
+        DB::table('supplier')->updateOrInsert(
+            ['name' => '__default__'],
+            [
+                'contact' => null,
+                'created_at' => Date::now(),
+            ]
+        );
+    }
+}

--- a/laravel-app/database/seeders/UiMenuSeeder.php
+++ b/laravel-app/database/seeders/UiMenuSeeder.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class UiMenuSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $entries = [
+            ['slug' => 'dashboard', 'title' => 'Dashboard', 'url' => '/', 'icon' => null, 'position' => 0],
+            ['slug' => 'supply', 'title' => 'Supply', 'url' => '/supply', 'icon' => null, 'position' => 1],
+            ['slug' => 'tables', 'title' => 'Tables', 'url' => '/tables', 'icon' => null, 'position' => 2],
+            ['slug' => 'superadmin', 'title' => 'Superadmin', 'url' => '/superadmin', 'icon' => null, 'position' => 3],
+        ];
+
+        foreach ($entries as $entry) {
+            DB::table('ui_menu')->updateOrInsert(
+                ['slug' => $entry['slug']],
+                [
+                    'title' => $entry['title'],
+                    'url' => $entry['url'],
+                    'icon' => $entry['icon'],
+                    'parent_id' => null,
+                    'position' => $entry['position'],
+                    'target' => null,
+                    'required_role' => null,
+                    'visible' => true,
+                ]
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Laravel migrations that recreate the legacy SQLite tables with PostgreSQL-friendly column types and indexes
- seed default lookup data for locations, suppliers, and navigation along with updating the database seeder list
- provide a legacy:ingest-sqlite artisan command plus schema mapping documentation covering type conversions and FTS changes

## Testing
- php -l laravel-app/app/Console/Commands/ImportLegacySqlite.php

------
https://chatgpt.com/codex/tasks/task_e_68e5d1ea84dc83269a65c085831e3da5