### PR TITLE
feat: sync laravel schema seeds and legacy import

### DIFF
--- a/docs/migration/schema-mapping.md
+++ b/docs/migration/schema-mapping.md
@@ -10,7 +10,7 @@ This document captures the one-to-one mapping between the legacy SQLite schema d
 | `supplier` | `supplier` | Same as above; nullable `contact` kept as string. |
 | `product` | `product` | `REAL` price/vat mapped to `decimal(12,2)`/`decimal(5,2)`; boolean flags stored as integers now true booleans; timestamps stored as text replaced with `timestampTz`. |
 | `location` | `location` | Primary key stays textual; timestamp upgraded to `timestampTz`. |
-| `stock` | `stock` | `REAL` quantities mapped to `decimal(15,3)`; composite primary key preserved; timestamp upgraded to `timestampTz`. |
+| `stock` | `stock` | `REAL` quantities mapped to `decimal(15,3)`; composite primary key preserved; timestamp upgraded to `timestampTz` with `useCurrent()`. |
 | `supplier_sku` | `supplier_sku` | Boolean `active` column now real boolean; numeric quantities use `decimal(15,3)`; timestamps upgraded. |
 | `display_name_exception` | `display_name_exception` | Timestamp stored as text → `timestampTz`. |
 | `import_log` | `import_log` | `REAL` counts mapped to unsigned integer; JSON/text fields preserved; timestamps upgraded. |
@@ -38,10 +38,22 @@ This document captures the one-to-one mapping between the legacy SQLite schema d
 The legacy `product_fts` virtual table built with SQLite FTS5 is replaced by a physical PostgreSQL table backed by a `tsvector` column:
 
 - Table `product_fts` stores a `product_id` primary key linked to `product` and a `search_vector` `tsvector` column.
-- A PostgreSQL trigger function (`product_fts_refresh`) materialises combined `article`, `name`, and `local_name` text into the vector using the `simple` dictionary.
-- Three triggers (`product_fts_ai`, `product_fts_au`, `product_fts_ad`) refresh or remove the search document on insert/update/delete.
-- A GIN index (`product_fts_search_vector_gin`) accelerates search queries that replace the prior `fts5` index.
+- A PostgreSQL trigger function (`product_fts_refresh`) materialises combined `article`, `name`, and `local_name` text into the vector using the `simple` dictionary before persisting the document.
+- Three triggers (`product_fts_ai`, `product_fts_au`, `product_fts_ad`) refresh or remove the search document on insert/update/delete so the materialised search data stays in sync.
+- A dedicated GIN index (`product_fts_search_vector_gin`) on the `search_vector` column replaces SQLite's FTS5 indexing strategy for performant full-text lookups.
 
-## Boolean Casting During Import
+## Seeded Lookup Data
 
-The Laravel artisan command `legacy:ingest-sqlite` casts integer-backed boolean columns (`is_new`, `archived`, `active`, `visible`, `enabled`, etc.) into actual PostgreSQL booleans during ingestion to match the new schema expectations.
+Laravel seeders mirror the convenience inserts embedded in the SQLite schema scripts:
+
+- `LocationSeeder` ensures the default `SKL-0` hub location exists with the same title as the legacy seed.
+- `SupplierSeeder` provisions the `__default__` supplier record consumed by import routines.
+- `UiMenuSeeder` reproduces the fallback dashboard navigation (`dashboard`, `supply`, `tables`, `superadmin`).
+- `UiWidgetSeeder` and `UiWidgetInstanceSeeder` register the builtin widgets (`low_stock`, `schedule_mini`, `stock_by_location`) and arrange them in the default `home.main` zone just like `_seed_home_instances()` in the Flask admin.
+
+## Import Command Behaviour
+
+The Laravel artisan command `legacy:ingest-sqlite` handles type coercion and sequence alignment while copying data from SQLite:
+
+- Integer-backed booleans (`is_new`, `archived`, `active`, `visible`, `enabled`, etc.) are cast into true PostgreSQL booleans before bulk inserts.
+- After each table is imported and validated, `pg_get_serial_sequence` + `setval` synchronise the underlying sequences so future inserts honour the original primary key high-water marks.

--- a/laravel-app/app/Console/Commands/ImportLegacySqlite.php
+++ b/laravel-app/app/Console/Commands/ImportLegacySqlite.php
@@ -45,6 +45,30 @@ class ImportLegacySqlite extends Command
         'audit_log',
     ];
 
+    /** @var array<string, string> */
+    private array $serialColumns = [
+        'manufacturer' => 'id',
+        'supplier' => 'id',
+        'product' => 'id',
+        'supplier_sku' => 'id',
+        'display_name_exception' => 'id',
+        'import_log' => 'id',
+        'product_merge_log' => 'id',
+        'product_article_alias' => 'id',
+        'product_name_alias' => 'id',
+        'product_merge_rule' => 'id',
+        'schedule_transfer_request' => 'id',
+        'schedule_anchor' => 'id',
+        'user_role' => 'id',
+        'event_log' => 'id',
+        'registration_request' => 'id',
+        'ui_widget' => 'id',
+        'ui_widget_instance' => 'id',
+        'ui_menu' => 'id',
+        'scheduled_job' => 'id',
+        'audit_log' => 'id',
+    ];
+
     public function handle(): int
     {
         $path = (string) $this->argument('path');
@@ -95,6 +119,8 @@ class ImportLegacySqlite extends Command
                 if ($currentCount !== $legacyCount) {
                     throw new RuntimeException("Row count mismatch for {$table}: legacy={$legacyCount}, imported={$currentCount}");
                 }
+
+                $this->resetSequence($table);
             }
 
             DB::commit();
@@ -155,5 +181,26 @@ class ImportLegacySqlite extends Command
         }
 
         return $row;
+    }
+
+    private function resetSequence(string $table): void
+    {
+        if (! array_key_exists($table, $this->serialColumns)) {
+            return;
+        }
+
+        $column = $this->serialColumns[$table];
+
+        $sequenceInfo = DB::selectOne('SELECT pg_get_serial_sequence(?, ?) AS sequence', [$table, $column]);
+
+        if ($sequenceInfo === null || empty($sequenceInfo->sequence)) {
+            return;
+        }
+
+        $max = DB::table($table)->max($column);
+        $value = $max === null ? 0 : (int) $max;
+        $isCalled = $value > 0;
+
+        DB::statement('SELECT setval(?, ?, ?)', [$sequenceInfo->sequence, $value, $isCalled]);
     }
 }

--- a/laravel-app/database/migrations/2024_01_01_000100_create_inventory_tables.php
+++ b/laravel-app/database/migrations/2024_01_01_000100_create_inventory_tables.php
@@ -43,8 +43,8 @@ return new class extends Migration
             $table->string('photo_file_id')->nullable();
             $table->string('photo_path')->nullable();
 
-            $table->index('article');
-            $table->index('name');
+            $table->index('article', 'idx_product_article');
+            $table->index('name', 'idx_product_name');
         });
 
         Schema::create('location', function (Blueprint $table) {
@@ -65,7 +65,7 @@ return new class extends Migration
 
             $table->primary(['product_id', 'location_code']);
             $table->foreign('location_code')->references('code')->on('location')->cascadeOnDelete();
-            $table->index('location_code');
+            $table->index('location_code', 'idx_stock_location');
         });
 
         Schema::create('supplier_sku', function (Blueprint $table) {
@@ -80,8 +80,8 @@ return new class extends Migration
             $table->timestampTz('updated_at')->nullable();
 
             $table->unique(['supplier_id', 'code']);
-            $table->index('product_id');
-            $table->index(['supplier_id', 'active']);
+            $table->index('product_id', 'idx_supplier_sku_product');
+            $table->index(['supplier_id', 'active'], 'idx_supplier_sku_supplier_active');
         });
 
         Schema::create('display_name_exception', function (Blueprint $table) {
@@ -105,7 +105,7 @@ return new class extends Migration
             $table->timestampTz('reverted_at')->nullable();
             $table->timestampTz('created_at')->useCurrent();
 
-            $table->index('created_at');
+            $table->index('created_at', 'idx_import_log_created');
         });
     }
 

--- a/laravel-app/database/migrations/2024_01_01_000200_create_product_merge_tables.php
+++ b/laravel-app/database/migrations/2024_01_01_000200_create_product_merge_tables.php
@@ -29,7 +29,7 @@ return new class extends Migration
             $table->foreignId('merge_log_id')->nullable()->constrained('product_merge_log');
             $table->timestampTz('created_at')->useCurrent();
 
-            $table->index('product_id');
+            $table->index('product_id', 'idx_product_article_alias_product');
         });
 
         Schema::create('product_name_alias', function (Blueprint $table) {
@@ -41,7 +41,7 @@ return new class extends Migration
             $table->foreignId('merge_log_id')->nullable()->constrained('product_merge_log');
             $table->timestampTz('created_at')->useCurrent();
 
-            $table->index('product_id');
+            $table->index('product_id', 'idx_product_name_alias_product');
         });
 
         Schema::create('product_merge_rule', function (Blueprint $table) {

--- a/laravel-app/database/migrations/2024_01_01_000400_create_user_and_event_tables.php
+++ b/laravel-app/database/migrations/2024_01_01_000400_create_user_and_event_tables.php
@@ -40,8 +40,8 @@ return new class extends Migration
             $table->json('payload_json')->nullable();
 
             $table->foreign('location_code')->references('code')->on('location')->nullOnDelete();
-            $table->index('ts');
-            $table->index('event_type');
+            $table->index('ts', 'idx_event_log_ts');
+            $table->index('event_type', 'idx_event_log_type');
         });
 
         Schema::create('registration_request', function (Blueprint $table) {
@@ -65,7 +65,7 @@ return new class extends Migration
             $table->string('entity_id')->nullable();
             $table->json('payload_json')->nullable();
 
-            $table->index('created_at');
+            $table->index('created_at', 'idx_audit_log_created');
         });
     }
 

--- a/laravel-app/database/migrations/2024_01_01_000500_create_query_and_ui_tables.php
+++ b/laravel-app/database/migrations/2024_01_01_000500_create_query_and_ui_tables.php
@@ -50,7 +50,7 @@ return new class extends Migration
             $table->string('required_role')->nullable();
             $table->boolean('visible')->default(true);
 
-            $table->index('required_role');
+            $table->index('required_role', 'idx_ui_menu_required_role');
         });
 
         Schema::create('scheduled_job', function (Blueprint $table) {

--- a/laravel-app/database/seeders/DatabaseSeeder.php
+++ b/laravel-app/database/seeders/DatabaseSeeder.php
@@ -12,6 +12,8 @@ class DatabaseSeeder extends Seeder
             LocationSeeder::class,
             SupplierSeeder::class,
             UiMenuSeeder::class,
+            UiWidgetSeeder::class,
+            UiWidgetInstanceSeeder::class,
             SuperAdminSeeder::class,
         ]);
     }

--- a/laravel-app/database/seeders/UiWidgetInstanceSeeder.php
+++ b/laravel-app/database/seeders/UiWidgetInstanceSeeder.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class UiWidgetInstanceSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $defaultOrder = [
+            'builtin.low_stock',
+            'builtin.schedule_mini',
+            'builtin.stock_by_location',
+        ];
+
+        if (DB::table('ui_widget_instance')->exists()) {
+            return;
+        }
+
+        foreach ($defaultOrder as $position => $key) {
+            [$module, $name] = explode('.', $key, 2);
+
+            $widgetId = DB::table('ui_widget')
+                ->where('module', $module)
+                ->where('name', $name)
+                ->value('id');
+
+            if ($widgetId === null) {
+                continue;
+            }
+
+            DB::table('ui_widget_instance')->updateOrInsert(
+                [
+                    'zone' => 'home.main',
+                    'position' => $position,
+                ],
+                [
+                    'widget_id' => $widgetId,
+                    'config_json' => null,
+                    'enabled' => true,
+                ],
+            );
+        }
+    }
+}

--- a/laravel-app/database/seeders/UiWidgetSeeder.php
+++ b/laravel-app/database/seeders/UiWidgetSeeder.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class UiWidgetSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $widgets = [
+            [
+                'module' => 'builtin',
+                'name' => 'low_stock',
+                'title' => 'Low stock overview',
+                'description' => 'Highlights products that are running low on inventory.',
+                'entrypoint' => 'dvorik.admin.widgets.builtin:LowStockWidget',
+                'config_schema' => null,
+            ],
+            [
+                'module' => 'builtin',
+                'name' => 'schedule_mini',
+                'title' => 'Schedule snapshot',
+                'description' => 'Shows the current duty schedule summary.',
+                'entrypoint' => 'dvorik.admin.widgets.builtin:ScheduleMiniWidget',
+                'config_schema' => null,
+            ],
+            [
+                'module' => 'builtin',
+                'name' => 'stock_by_location',
+                'title' => 'Stock by location',
+                'description' => 'Displays stock totals grouped by location.',
+                'entrypoint' => 'dvorik.admin.widgets.builtin:StockByLocationWidget',
+                'config_schema' => null,
+            ],
+        ];
+
+        foreach ($widgets as $widget) {
+            DB::table('ui_widget')->updateOrInsert(
+                [
+                    'module' => $widget['module'],
+                    'name' => $widget['name'],
+                ],
+                [
+                    'title' => $widget['title'],
+                    'description' => $widget['description'],
+                    'entrypoint' => $widget['entrypoint'],
+                    'config_schema' => $widget['config_schema'],
+                ],
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- align Laravel migrations with legacy index names so Postgres mirrors the SQLite layout
- document schema conversions, seeded lookup data, and GIN-based FTS replacement for the new stack
- seed builtin dashboard widgets and reset Postgres sequences during legacy SQLite ingestion

## Testing
- php -l database/seeders/UiWidgetSeeder.php
- php -l database/seeders/UiWidgetInstanceSeeder.php
- php -l app/Console/Commands/ImportLegacySqlite.php

------
https://chatgpt.com/codex/tasks/task_e_68e5db23acd083269d272b28843e3e40