### PR TITLE
Add RBAC support with policies and Filament guard

### DIFF
--- a/docs/migration/rbac.md
+++ b/docs/migration/rbac.md
@@ -1,0 +1,67 @@
+# RBAC Migration Plan
+
+This project now relies on [spatie/laravel-permission](https://spatie.be/docs/laravel-permission) for managing panel roles.
+
+## Package & Database Setup
+
+- `composer.json` includes the package and the default guard is configured for the Filament panel.
+- Published configuration lives in `config/permission.php` with the guard fixed to `filament` so every permission check uses the panel session.
+- Published migrations create the canonical `roles`, `permissions`, and pivot tables. They set a default guard name of `filament` on every record.
+
+Run the migrations after pulling these changes:
+
+```bash
+php artisan migrate
+```
+
+## Role & Permission Mapping
+
+`Database\Seeders\RbacSeeder` provisions the full permission matrix based on the legacy `user_role` table:
+
+| Permission        | Purpose                                              | Granted to                 |
+| ----------------- | ---------------------------------------------------- | -------------------------- |
+| `widgets.manage`  | Manage widget catalog and dashboard placements.      | `superadmin`               |
+| `queries.manage`  | Manage SQL registry/table explorer entries.          | `superadmin`               |
+| `imports.manage`  | Run, review, and revert inventory imports.           | `superadmin`, `admin`      |
+| `audit.view`      | Review the administrative audit log.                 | `superadmin`, `admin`      |
+
+The seeder also introspects `user_role.role` values. Any unexpected legacy role name is created in the new `roles` table (with no permissions) so that manual review can take place instead of silently dropping access.
+
+`SuperAdminSeeder` assigns the `superadmin` role to the bootstrap account while keeping the hard `is_super_admin` override in place.
+
+Seed roles and permissions with:
+
+```bash
+php artisan db:seed --class=Database\\Seeders\\RbacSeeder
+php artisan db:seed --class=Database\\Seeders\\SuperAdminSeeder
+```
+
+The full `DatabaseSeeder` already calls both, so a plain `php artisan db:seed` after migrating is sufficient for fresh installs.
+
+## Policy Overview
+
+Policies now protect the Laravel replacements for the Flask administration screens:
+
+- `UiWidgetPolicy` → widget catalog & placements (requires `widgets.manage`).
+- `QueryRegistryPolicy` → SQL registry / saved table queries (requires `queries.manage`).
+- `ImportLogPolicy` → supply imports (requires `imports.manage`).
+- `AuditLogPolicy` → audit log reader (requires `audit.view`).
+
+The policies are registered in `AuthServiceProvider` and still inherit the blanket access that super admins receive through `Gate::before`.
+
+## Filament Guard & Navigation
+
+The Filament panel authenticates against the dedicated `filament` guard. A custom middleware (`EnsureFilamentUserHasAccess`) now runs on every panel request to ensure the signed-in user holds one of the panel roles (`superadmin`, `admin`, or `seller`).
+
+Navigation items and groups can call the `requiresPermission()` macro added in `FilamentServiceProvider`. The provider also filters the resolved navigation tree at runtime, so entries tagged with a permission disappear automatically for users who lack the capability.
+
+## Assigning Roles To Users
+
+1. Import the legacy SQLite data using `php artisan legacy:ingest-sqlite ...`.
+2. Confirm that `user_role` rows exist for each Telegram account. The values (`admin`, `seller`, etc.) now have corresponding rows in the new `roles` table.
+3. Link Laravel users to roles. Typical workflows:
+   - Match by email/username and call `$user->assignRole('admin')` in a tinker session.
+   - Use an upcoming Filament resource for managing accounts (recommended once the panel is available).
+4. Re-run `php artisan permission:cache-reset` (or any seed command) after bulk changes to flush cached permissions.
+
+Document each manual assignment in your migration checklist so the bot and panel stay in sync.

--- a/laravel-app/app/Http/Middleware/EnsureFilamentUserHasAccess.php
+++ b/laravel-app/app/Http/Middleware/EnsureFilamentUserHasAccess.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\User;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureFilamentUserHasAccess
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        if (! $user instanceof User) {
+            return $next($request);
+        }
+
+        if ($user->is_super_admin || $user->roles()->exists()) {
+            return $next($request);
+        }
+
+        abort(403);
+    }
+}

--- a/laravel-app/app/Models/AuditLog.php
+++ b/laravel-app/app/Models/AuditLog.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class AuditLog extends Model
+{
+    protected $table = 'audit_log';
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'created_at' => 'datetime',
+        'payload_json' => 'array',
+    ];
+}

--- a/laravel-app/app/Models/ImportLog.php
+++ b/laravel-app/app/Models/ImportLog.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ImportLog extends Model
+{
+    protected $table = 'import_log';
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'items_json' => 'array',
+        'created_at' => 'datetime',
+        'reverted_at' => 'datetime',
+    ];
+}

--- a/laravel-app/app/Models/QueryRegistry.php
+++ b/laravel-app/app/Models/QueryRegistry.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class QueryRegistry extends Model
+{
+    protected $table = 'query_registry';
+
+    protected $primaryKey = 'key';
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+}

--- a/laravel-app/app/Models/UiWidget.php
+++ b/laravel-app/app/Models/UiWidget.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class UiWidget extends Model
+{
+    protected $table = 'ui_widget';
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+}

--- a/laravel-app/app/Models/User.php
+++ b/laravel-app/app/Models/User.php
@@ -9,10 +9,13 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
+use Spatie\Permission\Traits\HasRoles;
 
 class User extends Authenticatable implements FilamentUser, FilamentHasName
 {
-    use HasApiTokens, HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, Notifiable, HasRoles;
+
+    protected string $guard_name = 'filament';
 
     protected $fillable = [
         'name',
@@ -34,7 +37,11 @@ class User extends Authenticatable implements FilamentUser, FilamentHasName
 
     public function canAccessPanel(Panel $panel): bool
     {
-        return (bool) $this->is_super_admin;
+        if ($this->is_super_admin) {
+            return true;
+        }
+
+        return $this->hasAnyRole(['superadmin', 'admin', 'seller']);
     }
 
     public function getFilamentName(): string

--- a/laravel-app/app/Policies/AuditLogPolicy.php
+++ b/laravel-app/app/Policies/AuditLogPolicy.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\AuditLog;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class AuditLogPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(User $user): bool
+    {
+        return $user->can('audit.view');
+    }
+
+    public function view(User $user, AuditLog $auditLog): bool
+    {
+        return $user->can('audit.view');
+    }
+}

--- a/laravel-app/app/Policies/ImportLogPolicy.php
+++ b/laravel-app/app/Policies/ImportLogPolicy.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\ImportLog;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class ImportLogPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(User $user): bool
+    {
+        return $user->can('imports.manage');
+    }
+
+    public function view(User $user, ImportLog $import): bool
+    {
+        return $user->can('imports.manage');
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->can('imports.manage');
+    }
+
+    public function update(User $user, ImportLog $import): bool
+    {
+        return $user->can('imports.manage');
+    }
+
+    public function delete(User $user, ImportLog $import): bool
+    {
+        return $user->can('imports.manage');
+    }
+
+    public function revert(User $user, ImportLog $import): bool
+    {
+        return $user->can('imports.manage');
+    }
+}

--- a/laravel-app/app/Policies/QueryRegistryPolicy.php
+++ b/laravel-app/app/Policies/QueryRegistryPolicy.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\QueryRegistry;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class QueryRegistryPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(User $user): bool
+    {
+        return $user->can('queries.manage');
+    }
+
+    public function view(User $user, QueryRegistry $query): bool
+    {
+        return $user->can('queries.manage');
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->can('queries.manage');
+    }
+
+    public function update(User $user, QueryRegistry $query): bool
+    {
+        return $user->can('queries.manage');
+    }
+
+    public function delete(User $user, QueryRegistry $query): bool
+    {
+        return $user->can('queries.manage');
+    }
+}

--- a/laravel-app/app/Policies/UiWidgetPolicy.php
+++ b/laravel-app/app/Policies/UiWidgetPolicy.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\UiWidget;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class UiWidgetPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(User $user): bool
+    {
+        return $user->can('widgets.manage');
+    }
+
+    public function view(User $user, UiWidget $widget): bool
+    {
+        return $user->can('widgets.manage');
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->can('widgets.manage');
+    }
+
+    public function update(User $user, UiWidget $widget): bool
+    {
+        return $user->can('widgets.manage');
+    }
+
+    public function delete(User $user, UiWidget $widget): bool
+    {
+        return $user->can('widgets.manage');
+    }
+}

--- a/laravel-app/app/Providers/AuthServiceProvider.php
+++ b/laravel-app/app/Providers/AuthServiceProvider.php
@@ -2,15 +2,30 @@
 
 namespace App\Providers;
 
+use App\Models\AuditLog;
+use App\Models\ImportLog;
+use App\Models\QueryRegistry;
+use App\Models\UiWidget;
+use App\Policies\AuditLogPolicy;
+use App\Policies\ImportLogPolicy;
+use App\Policies\QueryRegistryPolicy;
+use App\Policies\UiWidgetPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Gate;
 
 class AuthServiceProvider extends ServiceProvider
 {
-    protected $policies = [];
+    protected $policies = [
+        UiWidget::class => UiWidgetPolicy::class,
+        QueryRegistry::class => QueryRegistryPolicy::class,
+        ImportLog::class => ImportLogPolicy::class,
+        AuditLog::class => AuditLogPolicy::class,
+    ];
 
     public function boot(): void
     {
+        $this->registerPolicies();
+
         Gate::before(function ($user, $ability) {
             return $user->is_super_admin ? true : null;
         });

--- a/laravel-app/app/Providers/FilamentServiceProvider.php
+++ b/laravel-app/app/Providers/FilamentServiceProvider.php
@@ -2,6 +2,11 @@
 
 namespace App\Providers;
 
+use App\Models\User;
+use Filament\Facades\Filament;
+use Filament\Navigation\NavigationBuilder;
+use Filament\Navigation\NavigationGroup;
+use Filament\Navigation\NavigationItem;
 use Illuminate\Support\ServiceProvider;
 
 class FilamentServiceProvider extends ServiceProvider
@@ -13,6 +18,72 @@ class FilamentServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
-        // Customize Filament panels, resources, etc.
+        NavigationItem::macro('requiresPermission', function (?string $permission) {
+            if ($permission === null) {
+                return $this;
+            }
+
+            /** @var NavigationItem $this */
+            $this->visible(fn (): bool => auth()->user()?->can($permission) ?? false);
+
+            return $this;
+        });
+
+        NavigationGroup::macro('requiresPermission', function (?string $permission) {
+            if ($permission === null) {
+                return $this;
+            }
+
+            /** @var NavigationGroup $this */
+            $this->visible(fn (): bool => auth()->user()?->can($permission) ?? false);
+
+            return $this;
+        });
+
+        Filament::navigation(function (NavigationBuilder $builder): NavigationBuilder {
+            $user = auth()->user();
+
+            if (! $user instanceof User) {
+                return $builder;
+            }
+
+            $items = method_exists($builder, 'getItems')
+                ? collect($builder->getItems())
+                    ->filter(fn (NavigationItem $item): bool => $this->navigationItemVisibleForUser($item, $user))
+                    ->all()
+                : [];
+
+            $groups = method_exists($builder, 'getGroups')
+                ? collect($builder->getGroups())
+                    ->map(function (NavigationGroup $group) use ($user): NavigationGroup {
+                        $visibleItems = method_exists($group, 'getItems')
+                            ? collect($group->getItems())
+                                ->filter(fn (NavigationItem $item): bool => $this->navigationItemVisibleForUser($item, $user))
+                                ->all()
+                            : [];
+
+                        return $group->items($visibleItems);
+                    })
+                    ->filter(fn (NavigationGroup $group): bool => method_exists($group, 'getItems') ? count($group->getItems()) > 0 : true)
+                    ->all()
+                : [];
+
+            return $builder
+                ->items($items)
+                ->groups($groups);
+        });
+    }
+
+    private function navigationItemVisibleForUser(NavigationItem $item, User $user): bool
+    {
+        $meta = method_exists($item, 'getMeta') ? $item->getMeta() : [];
+
+        $requiredPermission = $meta['required_permission'] ?? null;
+
+        if ($requiredPermission === null) {
+            return true;
+        }
+
+        return $user->can($requiredPermission);
     }
 }

--- a/laravel-app/composer.json
+++ b/laravel-app/composer.json
@@ -10,6 +10,7 @@
     "require": {
         "php": "^8.3",
         "filament/filament": "^3.2",
+        "spatie/laravel-permission": "^6.7",
         "laravel/framework": "^11.0",
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^2.9",

--- a/laravel-app/config/filament.php
+++ b/laravel-app/config/filament.php
@@ -9,6 +9,10 @@ return [
             'path' => env('FILAMENT_PATH', 'admin'),
             'auth' => [
                 'guard' => env('FILAMENT_DEFAULT_GUARD', 'filament'),
+                'middleware' => [
+                    \Filament\Http\Middleware\Authenticate::class,
+                    \App\Http\Middleware\EnsureFilamentUserHasAccess::class,
+                ],
             ],
         ],
     ],

--- a/laravel-app/config/permission.php
+++ b/laravel-app/config/permission.php
@@ -1,0 +1,34 @@
+<?php
+
+return [
+    'defaults' => [
+        'guard' => 'filament',
+    ],
+
+    'models' => [
+        'permission' => Spatie\Permission\Models\Permission::class,
+        'role' => Spatie\Permission\Models\Role::class,
+    ],
+
+    'table_names' => [
+        'roles' => 'roles',
+        'permissions' => 'permissions',
+        'model_has_permissions' => 'model_has_permissions',
+        'model_has_roles' => 'model_has_roles',
+        'role_has_permissions' => 'role_has_permissions',
+    ],
+
+    'column_names' => [
+        'model_morph_key' => 'model_id',
+    ],
+
+    'display_permission_in_exception' => false,
+
+    'enable_wildcard_permission' => false,
+
+    'cache' => [
+        'expiration_time' => \DateInterval::createFromDateString('24 hours'),
+        'key' => 'spatie.permission.cache',
+        'store' => 'default',
+    ],
+];

--- a/laravel-app/database/migrations/2024_01_01_000700_create_permission_tables.php
+++ b/laravel-app/database/migrations/2024_01_01_000700_create_permission_tables.php
@@ -1,0 +1,97 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use RuntimeException;
+use Spatie\Permission\PermissionRegistrar;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $tableNames = config('permission.table_names');
+        $columnNames = config('permission.column_names');
+        $guard = config('permission.defaults.guard', 'filament');
+
+        if (empty($tableNames['roles']) || empty($tableNames['permissions']) || empty($tableNames['model_has_permissions']) || empty($tableNames['model_has_roles']) || empty($tableNames['role_has_permissions'])) {
+            throw new RuntimeException('One or more permission table names are not configured.');
+        }
+
+        Schema::create($tableNames['permissions'], function (Blueprint $table) use ($guard) {
+            $table->bigIncrements('id');
+            $table->string('name');
+            $table->string('guard_name')->default($guard);
+            $table->timestamps();
+
+            $table->unique(['name', 'guard_name']);
+        });
+
+        Schema::create($tableNames['roles'], function (Blueprint $table) use ($guard) {
+            $table->bigIncrements('id');
+            $table->string('name');
+            $table->string('guard_name')->default($guard);
+            $table->timestamps();
+
+            $table->unique(['name', 'guard_name']);
+        });
+
+        Schema::create($tableNames['model_has_permissions'], function (Blueprint $table) use ($tableNames, $columnNames) {
+            $table->unsignedBigInteger('permission_id');
+            $table->string('model_type');
+            $table->unsignedBigInteger($columnNames['model_morph_key']);
+
+            $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_permissions_model_id_model_type_index');
+            $table->foreign('permission_id')
+                ->references('id')
+                ->on($tableNames['permissions'])
+                ->cascadeOnDelete();
+
+            $table->primary(['permission_id', $columnNames['model_morph_key'], 'model_type'], 'model_has_permissions_permission_model_type_primary');
+        });
+
+        Schema::create($tableNames['model_has_roles'], function (Blueprint $table) use ($tableNames, $columnNames) {
+            $table->unsignedBigInteger('role_id');
+            $table->string('model_type');
+            $table->unsignedBigInteger($columnNames['model_morph_key']);
+
+            $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_roles_model_id_model_type_index');
+            $table->foreign('role_id')
+                ->references('id')
+                ->on($tableNames['roles'])
+                ->cascadeOnDelete();
+
+            $table->primary(['role_id', $columnNames['model_morph_key'], 'model_type'], 'model_has_roles_role_model_type_primary');
+        });
+
+        Schema::create($tableNames['role_has_permissions'], function (Blueprint $table) use ($tableNames) {
+            $table->unsignedBigInteger('permission_id');
+            $table->unsignedBigInteger('role_id');
+
+            $table->foreign('permission_id')
+                ->references('id')
+                ->on($tableNames['permissions'])
+                ->cascadeOnDelete();
+
+            $table->foreign('role_id')
+                ->references('id')
+                ->on($tableNames['roles'])
+                ->cascadeOnDelete();
+
+            $table->primary(['permission_id', 'role_id']);
+        });
+
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+    }
+
+    public function down(): void
+    {
+        $tableNames = config('permission.table_names');
+
+        Schema::dropIfExists($tableNames['role_has_permissions']);
+        Schema::dropIfExists($tableNames['model_has_roles']);
+        Schema::dropIfExists($tableNames['model_has_permissions']);
+        Schema::dropIfExists($tableNames['roles']);
+        Schema::dropIfExists($tableNames['permissions']);
+    }
+};

--- a/laravel-app/database/seeders/DatabaseSeeder.php
+++ b/laravel-app/database/seeders/DatabaseSeeder.php
@@ -14,6 +14,7 @@ class DatabaseSeeder extends Seeder
             UiMenuSeeder::class,
             UiWidgetSeeder::class,
             UiWidgetInstanceSeeder::class,
+            RbacSeeder::class,
             SuperAdminSeeder::class,
         ]);
     }

--- a/laravel-app/database/seeders/RbacSeeder.php
+++ b/laravel-app/database/seeders/RbacSeeder.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+
+class RbacSeeder extends Seeder
+{
+    public function run(): void
+    {
+        /** @var \Spatie\Permission\PermissionRegistrar $registrar */
+        $registrar = app(PermissionRegistrar::class);
+        $registrar->forgetCachedPermissions();
+
+        $guard = config('permission.defaults.guard', 'filament');
+
+        $permissions = [
+            'widgets.manage',
+            'queries.manage',
+            'imports.manage',
+            'audit.view',
+        ];
+
+        foreach ($permissions as $permission) {
+            Permission::firstOrCreate([
+                'name' => $permission,
+                'guard_name' => $guard,
+            ]);
+        }
+
+        $roles = [
+            'superadmin' => $permissions,
+            'admin' => [
+                'imports.manage',
+                'audit.view',
+            ],
+            'seller' => [],
+        ];
+
+        $legacyRoles = Schema::hasTable('user_role')
+            ? DB::table('user_role')->select('role')->distinct()->pluck('role')->all()
+            : [];
+
+        foreach ($legacyRoles as $legacyRole) {
+            if (! array_key_exists($legacyRole, $roles)) {
+                $roles[$legacyRole] = [];
+            }
+        }
+
+        foreach ($roles as $roleName => $rolePermissions) {
+            $role = Role::firstOrCreate([
+                'name' => $roleName,
+                'guard_name' => $guard,
+            ]);
+
+            $role->syncPermissions($rolePermissions);
+        }
+
+        $registrar->forgetCachedPermissions();
+    }
+}

--- a/laravel-app/database/seeders/SuperAdminSeeder.php
+++ b/laravel-app/database/seeders/SuperAdminSeeder.php
@@ -10,7 +10,7 @@ class SuperAdminSeeder extends Seeder
 {
     public function run(): void
     {
-        User::updateOrCreate(
+        $user = User::updateOrCreate(
             ['email' => config('app.super_admin_email', 'admin@example.com')],
             [
                 'name' => config('app.super_admin_name', 'Super Admin'),
@@ -19,5 +19,7 @@ class SuperAdminSeeder extends Seeder
                 'email_verified_at' => now(),
             ]
         );
+
+        $user->assignRole('superadmin');
     }
 }


### PR DESCRIPTION
## Summary
- install spatie/laravel-permission configured for the Filament guard and publish the default config and migrations
- seed roles and permissions mapped from legacy `user_role` data and assign the super admin bootstrap role
- add models and authorization policies for widget, query, import, and audit resources while tightening Filament middleware and documenting RBAC procedures

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5e70553388326afcfb50621ea0cc0