### PR TITLE
Add block runtime infrastructure with legacy widget migration

### DIFF
--- a/laravel-app/app/Console/Commands/MigrateLegacyWidgets.php
+++ b/laravel-app/app/Console/Commands/MigrateLegacyWidgets.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\BlockDefinition;
+use App\Models\BlockInstance;
+use Illuminate\Console\Command;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class MigrateLegacyWidgets extends Command
+{
+    protected $signature = 'blocks:migrate-legacy {--dry-run : Run the migration without writing data}';
+
+    protected $description = 'Migrate legacy ui_widget tables into the block runtime structure.';
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+
+        $componentMap = config('block-runtime.legacy_entrypoints', []);
+        $zoneMap = config('block-runtime.legacy_zone_map', []);
+
+        $legacyWidgets = DB::table('ui_widget')->orderBy('id')->get();
+        $legacyInstances = DB::table('ui_widget_instance')->orderBy('id')->get();
+
+        $definitionMap = [];
+        $unmappedWidgets = [];
+
+        try {
+            DB::beginTransaction();
+
+            foreach ($legacyWidgets as $widget) {
+                $entrypoint = $widget->entrypoint;
+                $mapping = $componentMap[$entrypoint] ?? null;
+
+                if ($mapping === null) {
+                    $unmappedWidgets[] = $entrypoint;
+                    $this->warn("No component mapping defined for entrypoint [{$entrypoint}].");
+                    continue;
+                }
+
+                $version = (int) ($mapping['version'] ?? 1);
+                $component = $mapping['component'];
+
+                $attributes = [
+                    'module' => $widget->module,
+                    'name' => $widget->name,
+                    'version' => $version,
+                ];
+
+                $payload = [
+                    'title' => $widget->title,
+                    'description' => $widget->description,
+                    'component' => $component,
+                    'config_schema' => $widget->config_schema,
+                    'metadata' => [
+                        'legacy_entrypoint' => $entrypoint,
+                    ],
+                ];
+
+                if ($dryRun) {
+                    $this->line(sprintf('Would migrate definition %s:%s v%s to component %s', $widget->module, $widget->name, $version, $component));
+                    $definition = new BlockDefinition($attributes + $payload);
+                    $definition->id = $widget->id;
+                } else {
+                    $definition = BlockDefinition::query()->updateOrCreate($attributes, $payload);
+                }
+
+                $definitionMap[$widget->id] = $definition;
+            }
+
+            $skippedInstances = [];
+            $migratedInstances = 0;
+
+            foreach ($legacyInstances as $instance) {
+                $legacyWidgetId = $instance->widget_id;
+                $definition = $definitionMap[$legacyWidgetId] ?? null;
+
+                if ($definition === null) {
+                    $skippedInstances[] = $instance->id;
+                    $this->warn("Skipping instance {$instance->id}; no migrated definition for widget {$legacyWidgetId}.");
+                    continue;
+                }
+
+                $zone = $zoneMap[$instance->zone] ?? null;
+
+                if ($zone === null) {
+                    $skippedInstances[] = $instance->id;
+                    $this->warn("Skipping instance {$instance->id}; no zone mapping for {$instance->zone}.");
+                    continue;
+                }
+
+                $config = $instance->config_json;
+
+                if (is_string($config)) {
+                    $decoded = json_decode($config, true);
+                    $config = json_last_error() === JSON_ERROR_NONE ? $decoded : null;
+                }
+
+                $payload = [
+                    'block_definition_id' => $definition->id,
+                    'zone' => $zone,
+                    'position' => $instance->position,
+                    'config' => $config,
+                    'enabled' => (bool) $instance->enabled,
+                ];
+
+                if ($dryRun) {
+                    $this->line(sprintf('Would migrate instance %d -> definition %d (%s) zone %s', $instance->id, $definition->id, $definition->title ?? $definition->name ?? 'n/a', $zone));
+                } else {
+                    BlockInstance::query()->updateOrCreate(
+                        [
+                            'zone' => $zone,
+                            'position' => $instance->position,
+                        ],
+                        Arr::except($payload, ['zone', 'position'])
+                    );
+                }
+
+                $migratedInstances++;
+            }
+
+            if ($dryRun) {
+                DB::rollBack();
+            } else {
+                DB::commit();
+            }
+
+            if ($unmappedWidgets !== []) {
+                Log::warning('Unmapped widget entrypoints encountered during migration.', [
+                    'entrypoints' => array_values(array_unique($unmappedWidgets)),
+                ]);
+            }
+
+            if ($dryRun) {
+                $this->info('Dry-run completed. No data was modified.');
+            } else {
+                $this->info(sprintf('Migrated %d widget definitions and %d instances.', count($definitionMap), $migratedInstances));
+            }
+
+            if ($skippedInstances !== []) {
+                Log::warning('Some widget instances were skipped during migration.', [
+                    'instance_ids' => $skippedInstances,
+                ]);
+            }
+        } catch (Throwable $throwable) {
+            DB::rollBack();
+            $this->error('Migration failed: '.$throwable->getMessage());
+
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/laravel-app/app/Exceptions/InvalidBlockConfigurationException.php
+++ b/laravel-app/app/Exceptions/InvalidBlockConfigurationException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+class InvalidBlockConfigurationException extends RuntimeException
+{
+    /**
+     * @param string[] $errors
+     */
+    public function __construct(private readonly array $errors)
+    {
+        parent::__construct('Block configuration failed JSON schema validation.');
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+}

--- a/laravel-app/app/Livewire/Blocks/LegacyWidgetPlaceholder.php
+++ b/laravel-app/app/Livewire/Blocks/LegacyWidgetPlaceholder.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Livewire\Blocks;
+
+use App\Models\BlockDefinition;
+use App\Models\BlockInstance;
+use Illuminate\Contracts\View\View;
+use Livewire\Component;
+
+class LegacyWidgetPlaceholder extends Component
+{
+    public BlockInstance $block;
+
+    public BlockDefinition $definition;
+
+    /** @var array<string, mixed> */
+    public array $config = [];
+
+    public string $message;
+
+    public function mount(BlockInstance $block, BlockDefinition $definition, array $config = []): void
+    {
+        $this->block = $block;
+        $this->definition = $definition;
+        $this->config = $config;
+        $this->message = __('This block requires a custom frontend implementation.');
+    }
+
+    public function render(): View
+    {
+        return view('livewire.blocks.legacy-widget-placeholder');
+    }
+}

--- a/laravel-app/app/Models/BlockDefinition.php
+++ b/laravel-app/app/Models/BlockDefinition.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Models;
+
+use App\Services\BlockRuntime;
+use App\Models\BlockInstance;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Arr;
+
+class BlockDefinition extends Model
+{
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'config_schema' => 'array',
+        'metadata' => 'array',
+        'version' => 'integer',
+    ];
+
+    /**
+     * @return HasMany<BlockInstance>
+     */
+    public function instances(): HasMany
+    {
+        return $this->hasMany(BlockInstance::class);
+    }
+
+    protected static function booted(): void
+    {
+        static::saved(function (BlockDefinition $definition): void {
+            $runtime = app(BlockRuntime::class);
+            $runtime->forgetDefinitionCache();
+
+            $zones = $definition->instances()->pluck('zone')->all();
+
+            foreach ($zones as $zone) {
+                $runtime->forgetZoneCache($zone);
+            }
+        });
+
+        static::deleting(function (BlockDefinition $definition): void {
+            $runtime = app(BlockRuntime::class);
+
+            $zones = BlockInstance::query()
+                ->where('block_definition_id', $definition->id)
+                ->pluck('zone')
+                ->all();
+
+            foreach ($zones as $zone) {
+                $runtime->forgetZoneCache($zone);
+            }
+
+            $runtime->forgetDefinitionCache();
+        });
+
+        static::deleted(function (): void {
+            app(BlockRuntime::class)->forgetDefinitionCache();
+        });
+    }
+
+    public function getHandleAttribute(): string
+    {
+        return Arr::join([$this->module, $this->name, $this->version], ':');
+    }
+}

--- a/laravel-app/app/Models/BlockInstance.php
+++ b/laravel-app/app/Models/BlockInstance.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use App\Services\BlockRuntime;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class BlockInstance extends Model
+{
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'config' => 'array',
+        'enabled' => 'boolean',
+    ];
+
+    /**
+     * @return BelongsTo<BlockDefinition, BlockInstance>
+     */
+    public function definition(): BelongsTo
+    {
+        return $this->belongsTo(BlockDefinition::class);
+    }
+
+    protected static function booted(): void
+    {
+        static::saved(function (BlockInstance $instance): void {
+            app(BlockRuntime::class)->forgetZoneCache($instance->zone);
+        });
+
+        static::deleted(function (BlockInstance $instance): void {
+            app(BlockRuntime::class)->forgetZoneCache($instance->zone);
+        });
+    }
+}

--- a/laravel-app/app/Providers/AppServiceProvider.php
+++ b/laravel-app/app/Providers/AppServiceProvider.php
@@ -2,13 +2,21 @@
 
 namespace App\Providers;
 
+use App\Services\BlockRuntime;
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Illuminate\Support\ServiceProvider;
+use Opis\JsonSchema\Validator;
 
 class AppServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
-        //
+        $this->app->singleton(BlockRuntime::class, function ($app): BlockRuntime {
+            /** @var CacheFactory $cacheFactory */
+            $cacheFactory = $app->make(CacheFactory::class);
+
+            return new BlockRuntime($cacheFactory->store(), new Validator());
+        });
     }
 
     public function boot(): void

--- a/laravel-app/app/Providers/FilamentServiceProvider.php
+++ b/laravel-app/app/Providers/FilamentServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Models\User;
+use App\Services\BlockRuntime;
 use Filament\Facades\Filament;
 use Filament\Navigation\NavigationBuilder;
 use Filament\Navigation\NavigationGroup;
@@ -71,6 +72,37 @@ class FilamentServiceProvider extends ServiceProvider
             return $builder
                 ->items($items)
                 ->groups($groups);
+        });
+
+        $renderHooks = config('block-runtime.render_hooks', []);
+
+        foreach ($renderHooks as $zone => $hookConfiguration) {
+            $hook = $hookConfiguration['hook'] ?? null;
+
+            if ($hook === null) {
+                continue;
+            }
+
+            Filament::registerRenderHook($hook, function () use ($zone, $hookConfiguration): string {
+                $panelId = Filament::getCurrentPanel()?->getId();
+                $expectedPanel = $hookConfiguration['panel'] ?? null;
+
+                if ($expectedPanel !== null && $panelId !== $expectedPanel) {
+                    return '';
+                }
+
+                $routeName = $hookConfiguration['route'] ?? null;
+
+                if ($routeName !== null && ! request()->routeIs($routeName)) {
+                    return '';
+                }
+
+                return (string) app(BlockRuntime::class)->renderZone($zone);
+            });
+        }
+
+        Filament::serving(function (): void {
+            app(BlockRuntime::class)->warmDefinitionCache();
         });
     }
 

--- a/laravel-app/app/Services/BlockRuntime.php
+++ b/laravel-app/app/Services/BlockRuntime.php
@@ -1,0 +1,327 @@
+<?php
+
+namespace App\Services;
+
+use App\Exceptions\InvalidBlockConfigurationException;
+use App\Models\BlockDefinition;
+use App\Models\BlockInstance;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use Opis\JsonSchema\ValidationResult;
+use Opis\JsonSchema\Validator;
+use RuntimeException;
+use Throwable;
+
+class BlockRuntime
+{
+    private const DEFINITIONS_CACHE_KEY = 'block-runtime:definitions';
+    private const ZONE_CACHE_PREFIX = 'block-runtime:zone:';
+
+    private Validator $validator;
+
+    public function __construct(
+        private readonly CacheRepository $cache,
+        ?Validator $validator = null,
+    ) {
+        $this->validator = $validator ?? new Validator();
+    }
+
+    public function warmDefinitionCache(): void
+    {
+        $this->definitions();
+    }
+
+    public function forgetDefinitionCache(): void
+    {
+        $this->cache->forget(self::DEFINITIONS_CACHE_KEY);
+    }
+
+    public function forgetZoneCache(string $zone): void
+    {
+        $this->cache->forget($this->zoneCacheKey($zone, true));
+        $this->cache->forget($this->zoneCacheKey($zone, false));
+    }
+
+    public function getDefinition(string $module, string $name, ?int $version = null): ?BlockDefinition
+    {
+        $key = $this->definitionKey($module, $name);
+        $definitions = $this->definitions();
+
+        if (! array_key_exists($key, $definitions)) {
+            return null;
+        }
+
+        $payload = $definitions[$key];
+
+        if ($version === null) {
+            $version = array_key_first($payload);
+        }
+
+        if ($version === null || ! array_key_exists($version, $payload)) {
+            return null;
+        }
+
+        return $this->rehydrateDefinition($payload[$version]);
+    }
+
+    public function getDefinitionById(int $id): ?BlockDefinition
+    {
+        foreach ($this->definitions() as $versions) {
+            foreach ($versions as $definition) {
+                if ((int) ($definition['id'] ?? 0) === $id) {
+                    return $this->rehydrateDefinition($definition);
+                }
+            }
+        }
+
+        return BlockDefinition::find($id);
+    }
+
+    /**
+     * @return Collection<int, BlockInstance>
+     */
+    public function getZoneInstances(string $zone, bool $onlyEnabled = true): Collection
+    {
+        $payload = $this->cache->remember(
+            $this->zoneCacheKey($zone, $onlyEnabled),
+            now()->addSeconds((int) config('block-runtime.zone_cache_ttl', 60)),
+            function () use ($zone, $onlyEnabled): array {
+                $query = BlockInstance::query()
+                    ->with('definition')
+                    ->where('zone', $zone)
+                    ->orderBy('position');
+
+                if ($onlyEnabled) {
+                    $query->where('enabled', true);
+                }
+
+                return $query->get()
+                    ->map(fn (BlockInstance $instance): array => [
+                        'instance' => $instance->attributesToArray(),
+                        'definition' => $instance->definition?->attributesToArray(),
+                    ])
+                    ->all();
+            }
+        );
+
+        return collect($payload)
+            ->map(function (array $payload): BlockInstance {
+                $instance = new BlockInstance();
+                $instance->forceFill($payload['instance']);
+                $instance->exists = true;
+
+                $definitionAttributes = $payload['definition'] ?? null;
+
+                if ($definitionAttributes !== null) {
+                    $instance->setRelation('definition', $this->rehydrateDefinition($definitionAttributes));
+                }
+
+                return $instance;
+            });
+    }
+
+    public function renderZone(string $zone, bool $onlyEnabled = true): string
+    {
+        return $this->getZoneInstances($zone, $onlyEnabled)
+            ->map(fn (BlockInstance $instance): ?string => $this->renderInstance($instance))
+            ->filter()
+            ->implode('');
+    }
+
+    public function renderInstance(BlockInstance $instance): ?string
+    {
+        $definition = $instance->definition;
+
+        if ($definition === null) {
+            $definition = $this->getDefinitionById($instance->block_definition_id);
+        }
+
+        if (! $definition instanceof BlockDefinition) {
+            Log::warning('Block definition missing for instance.', [
+                'instance_id' => $instance->id,
+                'block_definition_id' => $instance->block_definition_id,
+            ]);
+
+            return null;
+        }
+
+        $config = $instance->config ?? [];
+
+        try {
+            $this->validateConfig($definition, $config);
+        } catch (InvalidBlockConfigurationException $exception) {
+            Log::warning('Block configuration validation failed.', [
+                'instance_id' => $instance->id,
+                'block_definition_id' => $instance->block_definition_id,
+                'errors' => $exception->getErrors(),
+            ]);
+
+            return null;
+        }
+
+        $component = $definition->component;
+
+        if (! class_exists($component)) {
+            Log::warning('Block component class is missing.', [
+                'component' => $component,
+                'definition_id' => $definition->id,
+            ]);
+
+            return null;
+        }
+
+        try {
+            $mount = Livewire::mount($component, [
+                'block' => $instance,
+                'definition' => $definition,
+                'config' => $config,
+            ]);
+
+            return method_exists($mount, 'html') ? $mount->html() : (string) $mount;
+        } catch (Throwable $throwable) {
+            Log::error('Unable to mount block component.', [
+                'component' => $component,
+                'definition_id' => $definition->id,
+                'instance_id' => $instance->id,
+                'exception' => $throwable,
+            ]);
+
+            return null;
+        }
+    }
+
+    public function validateConfig(BlockDefinition $definition, array $config): void
+    {
+        $schema = $definition->config_schema;
+
+        if ($schema === null) {
+            return;
+        }
+
+        $schemaObject = $this->jsonify($schema);
+        $configObject = $this->jsonify($config);
+
+        try {
+            $result = $this->validator->validate($configObject, $schemaObject);
+        } catch (Throwable $throwable) {
+            throw new RuntimeException('Unable to validate block configuration: '.$throwable->getMessage(), 0, $throwable);
+        }
+
+        if ($result->isValid()) {
+            return;
+        }
+
+        throw new InvalidBlockConfigurationException($this->buildErrorMessages($result));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildErrorMessages(ValidationResult $result): array
+    {
+        $error = $result->error();
+
+        if ($error === null) {
+            return [];
+        }
+
+        $messages = [];
+        $queue = [$error];
+
+        while ($queue !== []) {
+            $current = array_shift($queue);
+            $dataPointer = $current->dataPointer() ?? '';
+            $message = $current->message() ?? 'Validation error.';
+            $messages[] = trim(sprintf('%s: %s', $dataPointer === '' ? '$' : $dataPointer, $message));
+
+            foreach ($current->subErrors() ?? [] as $subError) {
+                $queue[] = $subError;
+            }
+        }
+
+        return $messages;
+    }
+
+    private function jsonify(array|string|null $value): mixed
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_string($value)) {
+            $decoded = json_decode($value);
+
+            if (json_last_error() === JSON_ERROR_NONE) {
+                return $decoded;
+            }
+
+            throw new RuntimeException('Invalid JSON string encountered while preparing schema or config.');
+        }
+
+        $encoded = json_encode($value);
+
+        if ($encoded === false) {
+            throw new RuntimeException('Unable to encode value as JSON.');
+        }
+
+        $decoded = json_decode($encoded);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new RuntimeException('Unable to decode JSON: '.json_last_error_msg());
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @return array<string, array<int, array<string, mixed>>>
+     */
+    private function definitions(): array
+    {
+        return $this->cache->rememberForever(self::DEFINITIONS_CACHE_KEY, function (): array {
+            return BlockDefinition::query()
+                ->orderBy('module')
+                ->orderBy('name')
+                ->orderByDesc('version')
+                ->get()
+                ->map(fn (BlockDefinition $definition): array => $definition->attributesToArray())
+                ->reduce(function (array $carry, array $definition): array {
+                    $key = $this->definitionKey($definition['module'], $definition['name']);
+                    $version = (int) $definition['version'];
+
+                    if (! isset($carry[$key])) {
+                        $carry[$key] = [];
+                    }
+
+                    $carry[$key][$version] = $definition;
+
+                    return $carry;
+                }, []);
+        });
+    }
+
+    /**
+     * @param array<string, mixed> $attributes
+     */
+    private function rehydrateDefinition(array $attributes): BlockDefinition
+    {
+        $definition = new BlockDefinition();
+        $definition->forceFill($attributes);
+        $definition->exists = true;
+
+        return $definition;
+    }
+
+    private function definitionKey(string $module, string $name): string
+    {
+        return Str::of($module)->lower().':'.Str::of($name)->lower();
+    }
+
+    private function zoneCacheKey(string $zone, bool $onlyEnabled): string
+    {
+        return self::ZONE_CACHE_PREFIX.Str::lower($zone).($onlyEnabled ? ':enabled' : ':all');
+    }
+}

--- a/laravel-app/composer.json
+++ b/laravel-app/composer.json
@@ -14,7 +14,8 @@
         "laravel/framework": "^11.0",
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^2.9",
-        "livewire/livewire": "^3.0"
+        "livewire/livewire": "^3.0",
+        "opis/json-schema": "^2.5"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/laravel-app/config/block-runtime.php
+++ b/laravel-app/config/block-runtime.php
@@ -1,0 +1,32 @@
+<?php
+
+return [
+    'zone_cache_ttl' => 60,
+
+    'legacy_entrypoints' => [
+        'dvorik.admin.widgets.builtin:LowStockWidget' => [
+            'component' => \App\Livewire\Blocks\LegacyWidgetPlaceholder::class,
+            'version' => 1,
+        ],
+        'dvorik.admin.widgets.builtin:ScheduleMiniWidget' => [
+            'component' => \App\Livewire\Blocks\LegacyWidgetPlaceholder::class,
+            'version' => 1,
+        ],
+        'dvorik.admin.widgets.builtin:StockByLocationWidget' => [
+            'component' => \App\Livewire\Blocks\LegacyWidgetPlaceholder::class,
+            'version' => 1,
+        ],
+    ],
+
+    'legacy_zone_map' => [
+        'home.main' => 'admin.dashboard.main',
+    ],
+
+    'render_hooks' => [
+        'admin.dashboard.main' => [
+            'panel' => 'admin',
+            'route' => 'filament.admin.pages.dashboard',
+            'hook' => 'panels::content.start',
+        ],
+    ],
+];

--- a/laravel-app/database/migrations/2024_01_01_001100_create_block_tables.php
+++ b/laravel-app/database/migrations/2024_01_01_001100_create_block_tables.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('block_definitions', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('module');
+            $table->string('name');
+            $table->unsignedInteger('version')->default(1);
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->string('component');
+            $table->json('config_schema')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestampsTz();
+
+            $table->unique(['module', 'name', 'version'], 'uidx_block_definitions_identity');
+        });
+
+        Schema::create('block_instances', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->foreignId('block_definition_id')->constrained('block_definitions')->cascadeOnDelete();
+            $table->string('zone');
+            $table->integer('position')->default(0);
+            $table->json('config')->nullable();
+            $table->boolean('enabled')->default(true);
+            $table->timestampsTz();
+
+            $table->unique(['zone', 'position'], 'uidx_block_instances_zone_position');
+            $table->index('enabled', 'idx_block_instances_enabled');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('block_instances');
+        Schema::dropIfExists('block_definitions');
+    }
+};

--- a/laravel-app/database/seeders/BlockDefinitionSeeder.php
+++ b/laravel-app/database/seeders/BlockDefinitionSeeder.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\BlockDefinition;
+use Illuminate\Database\Seeder;
+
+class BlockDefinitionSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $legacyMap = config('block-runtime.legacy_entrypoints', []);
+
+        $definitions = [
+            [
+                'module' => 'builtin',
+                'name' => 'low_stock',
+                'title' => 'Low stock overview',
+                'description' => 'Highlights products that are running low on inventory.',
+                'entrypoint' => 'dvorik.admin.widgets.builtin:LowStockWidget',
+            ],
+            [
+                'module' => 'builtin',
+                'name' => 'schedule_mini',
+                'title' => 'Schedule snapshot',
+                'description' => 'Shows the current duty schedule summary.',
+                'entrypoint' => 'dvorik.admin.widgets.builtin:ScheduleMiniWidget',
+            ],
+            [
+                'module' => 'builtin',
+                'name' => 'stock_by_location',
+                'title' => 'Stock by location',
+                'description' => 'Displays stock totals grouped by location.',
+                'entrypoint' => 'dvorik.admin.widgets.builtin:StockByLocationWidget',
+            ],
+        ];
+
+        foreach ($definitions as $definition) {
+            $mapping = $legacyMap[$definition['entrypoint']] ?? null;
+
+            if ($mapping === null) {
+                continue;
+            }
+
+            BlockDefinition::query()->updateOrCreate(
+                [
+                    'module' => $definition['module'],
+                    'name' => $definition['name'],
+                    'version' => (int) ($mapping['version'] ?? 1),
+                ],
+                [
+                    'title' => $definition['title'],
+                    'description' => $definition['description'],
+                    'component' => $mapping['component'],
+                    'metadata' => [
+                        'legacy_entrypoint' => $definition['entrypoint'],
+                    ],
+                ]
+            );
+        }
+    }
+}

--- a/laravel-app/database/seeders/BlockInstanceSeeder.php
+++ b/laravel-app/database/seeders/BlockInstanceSeeder.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\BlockDefinition;
+use App\Models\BlockInstance;
+use Illuminate\Database\Seeder;
+
+class BlockInstanceSeeder extends Seeder
+{
+    public function run(): void
+    {
+        if (BlockInstance::query()->exists()) {
+            return;
+        }
+
+        $zoneMap = config('block-runtime.legacy_zone_map', []);
+        $zone = $zoneMap['home.main'] ?? 'admin.dashboard.main';
+
+        $definitions = BlockDefinition::query()
+            ->where('module', 'builtin')
+            ->orderBy('name')
+            ->get();
+
+        foreach ($definitions as $position => $definition) {
+            BlockInstance::query()->updateOrCreate(
+                [
+                    'zone' => $zone,
+                    'position' => $position,
+                ],
+                [
+                    'block_definition_id' => $definition->id,
+                    'config' => null,
+                    'enabled' => true,
+                ]
+            );
+        }
+    }
+}

--- a/laravel-app/database/seeders/DatabaseSeeder.php
+++ b/laravel-app/database/seeders/DatabaseSeeder.php
@@ -12,8 +12,8 @@ class DatabaseSeeder extends Seeder
             LocationSeeder::class,
             SupplierSeeder::class,
             UiMenuSeeder::class,
-            UiWidgetSeeder::class,
-            UiWidgetInstanceSeeder::class,
+            BlockDefinitionSeeder::class,
+            BlockInstanceSeeder::class,
             RbacSeeder::class,
             SuperAdminSeeder::class,
         ]);

--- a/laravel-app/resources/views/livewire/blocks/legacy-widget-placeholder.blade.php
+++ b/laravel-app/resources/views/livewire/blocks/legacy-widget-placeholder.blade.php
@@ -1,0 +1,7 @@
+<div class="p-4 border border-dashed rounded-lg text-center text-sm text-gray-500 dark:text-gray-400">
+    <p class="font-semibold text-gray-700 dark:text-gray-200">{{ $definition->title }}</p>
+    <p class="mt-2">{{ $message }}</p>
+    <p class="mt-4 text-xs text-gray-400">
+        {{ __('Legacy entrypoint: :entry', ['entry' => $definition->metadata['legacy_entrypoint'] ?? $definition->component]) }}
+    </p>
+</div>


### PR DESCRIPTION
## Summary
- add block_definitions and block_instances tables plus seeders and configuration for block runtime zones
- implement a cached BlockRuntime service with JSON Schema validation, Filament render hooks, and a Livewire placeholder component
- provide an artisan command to migrate legacy ui_widget records into the new block structure with logging for unmapped widgets

## Testing
- php -l app/Services/BlockRuntime.php
- php -l app/Console/Commands/MigrateLegacyWidgets.php
- php -l app/Livewire/Blocks/LegacyWidgetPlaceholder.php

------
https://chatgpt.com/codex/tasks/task_e_68e624294b7c83268a978124c12a8134