### PR TITLE
Align Filament guard defaults and document Laravel launch notes

### DIFF
--- a/docs/migration/laravel-setup.md
+++ b/docs/migration/laravel-setup.md
@@ -1,10 +1,11 @@
 # Laravel Setup Notes
 
-## Overview
+## Launch Notes
 
-- Added a Laravel 11 skeleton under `laravel-app/` configured for PHP 8.3.
+- The Laravel skeleton under `laravel-app/` is generated for PHP 8.3 (for example: `mise exec php@8.3 -- laravel new laravel-app`).
 - Composer requirements include Filament v3 and Livewire v3 for the upcoming admin interface.
-- Default guard configuration now exposes a dedicated `filament` guard for panel authentication.
+- Default guard configuration now exposes a dedicated `filament` guard for panel authentication and is surfaced via the `AUTH_GUARD` environment variable.
+- Initial commits are limited to the Laravel tree to keep the PHP history isolated from the existing Python sources.
 
 ## Environment Configuration
 
@@ -15,6 +16,7 @@ The `.env.example` file sets sensible defaults for local development:
 - Storage disks including S3-compatible configuration and a public URL helper.
 - Telegram bot token, webhook secret, and super-admin chat ID placeholders required by later tasks.
 - Super admin bootstrap credentials (`SUPERADMIN_*`) consumed by the seeder.
+- `AUTH_GUARD` defaults the application to Filament authentication out of the box.
 
 ## Authentication & Authorization
 
@@ -25,7 +27,7 @@ The `.env.example` file sets sensible defaults for local development:
 ## Database & Seeding
 
 - Core Laravel migrations include an `is_super_admin` boolean on `users`.
-- `Database\Seeders\SuperAdminSeeder` provisions a default super admin using the credentials above.
+- `Database\Seeders\SuperAdminSeeder` provisions a default super admin using the credentials above and guarantees the `superadmin` role exists.
 - `DatabaseSeeder` wires the seeder so `php artisan db:seed` creates the account automatically.
 
 ## Next Steps

--- a/laravel-app/.env.example
+++ b/laravel-app/.env.example
@@ -4,6 +4,7 @@ APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
 APP_TIMEZONE=UTC
+AUTH_GUARD=filament
 
 LOG_CHANNEL=stack
 LOG_STACK=single

--- a/laravel-app/config/auth.php
+++ b/laravel-app/config/auth.php
@@ -2,7 +2,7 @@
 
 return [
     'defaults' => [
-        'guard' => env('AUTH_GUARD', 'web'),
+        'guard' => env('AUTH_GUARD', 'filament'),
         'passwords' => 'users',
     ],
 

--- a/laravel-app/database/seeders/SuperAdminSeeder.php
+++ b/laravel-app/database/seeders/SuperAdminSeeder.php
@@ -5,11 +5,19 @@ namespace Database\Seeders;
 use App\Models\User;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Hash;
+use Spatie\Permission\Models\Role;
 
 class SuperAdminSeeder extends Seeder
 {
     public function run(): void
     {
+        $guard = config('permission.defaults.guard', 'filament');
+
+        Role::firstOrCreate([
+            'name' => 'superadmin',
+            'guard_name' => $guard,
+        ]);
+
         $user = User::updateOrCreate(
             ['email' => config('app.super_admin_email', 'admin@example.com')],
             [


### PR DESCRIPTION
## Summary
- expose a configurable `AUTH_GUARD` defaulting to the Filament guard in both env template and auth config
- harden the super-admin seeder by ensuring the `superadmin` role exists before assignment
- record launch notes for the Laravel skeleton, including guard configuration guidance

## Testing
- mise exec php@8.3 -- php -l laravel-app/database/seeders/SuperAdminSeeder.php

------
https://chatgpt.com/codex/tasks/task_e_68e6296494b88326872157d19bdc3c8e