### PR TITLE
Implement data-driven blocks and preview tooling

### DIFF
--- a/laravel-app/app/DataSources/DataSourceManager.php
+++ b/laravel-app/app/DataSources/DataSourceManager.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace App\DataSources;
+
+use App\DataSources\Exceptions\DataSourceExecutionException;
+use App\DataSources\Exceptions\DataSourceNotFoundException;
+use App\Models\QueryRegistry;
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use PDO;
+use Throwable;
+
+class DataSourceManager
+{
+    private const PAGINATION_LIMIT_MAX = 500;
+
+    public function __construct(private readonly ConnectionInterface $connection)
+    {
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    public function execute(string $key, array $parameters = [], ?int $perPage = null, ?int $page = null): DataSourceResponse
+    {
+        $query = QueryRegistry::query()->find($key);
+
+        if (! $query instanceof QueryRegistry) {
+            throw new DataSourceNotFoundException($key);
+        }
+
+        $sql = trim((string) $query->sql);
+
+        if ($sql === '') {
+            return $this->emptyResponse($perPage ?? 15, $page ?? 1);
+        }
+
+        $page = max($page ?? 1, 1);
+        $perPage = $this->sanitizePerPage($perPage);
+
+        try {
+            $total = $this->count($sql, $parameters);
+            $rows = $this->select($sql, $parameters, $perPage, $page);
+        } catch (Throwable $throwable) {
+            throw new DataSourceExecutionException(
+                sprintf('Failed to execute data source [%s]: %s', $key, $throwable->getMessage()),
+                [$throwable->getMessage()]
+            );
+        }
+
+        $paginator = new LengthAwarePaginator(
+            $rows->values(),
+            $total,
+            $perPage,
+            $page,
+            [
+                'pageName' => $this->buildPageName($key),
+            ]
+        );
+
+        return new DataSourceResponse($rows, $total, $paginator);
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    private function count(string $sql, array $parameters): int
+    {
+        $countSql = sprintf('SELECT COUNT(*) AS aggregate FROM (%s) AS source', $sql);
+        $result = $this->connection->selectOne($countSql, $parameters);
+
+        if ($result === null) {
+            return 0;
+        }
+
+        if (is_object($result)) {
+            return (int) ($result->aggregate ?? 0);
+        }
+
+        if (is_array($result)) {
+            return (int) ($result['aggregate'] ?? 0);
+        }
+
+        return (int) $result;
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     * @return Collection<int, array<string, mixed>>
+     */
+    private function select(string $sql, array $parameters, int $perPage, int $page): Collection
+    {
+        $offset = max($page - 1, 0) * $perPage;
+        $limitPlaceholder = '__limit';
+        $offsetPlaceholder = '__offset';
+
+        while (array_key_exists($limitPlaceholder, $parameters)) {
+            $limitPlaceholder = '_'.$limitPlaceholder;
+        }
+
+        while (array_key_exists($offsetPlaceholder, $parameters)) {
+            $offsetPlaceholder = '_'.$offsetPlaceholder;
+        }
+
+        $pagedSql = sprintf(
+            'SELECT * FROM (%s) AS source LIMIT :%s OFFSET :%s',
+            $sql,
+            $limitPlaceholder,
+            $offsetPlaceholder
+        );
+
+        $bindings = $parameters + [
+            $limitPlaceholder => $perPage,
+            $offsetPlaceholder => $offset,
+        ];
+
+        $this->connection->getPdo()?->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+
+        $rows = $this->connection->select($pagedSql, $bindings);
+
+        return collect($rows)
+            ->map(function (mixed $row): array {
+                if (is_object($row)) {
+                    return (array) $row;
+                }
+
+                if (is_array($row)) {
+                    return $row;
+                }
+
+                return [];
+            });
+    }
+
+    private function sanitizePerPage(?int $perPage): int
+    {
+        $perPage ??= 15;
+
+        $perPage = max($perPage, 1);
+
+        return min($perPage, self::PAGINATION_LIMIT_MAX);
+    }
+
+    private function buildPageName(string $key): string
+    {
+        return 'page_'.Str::slug($key, '_');
+    }
+
+    private function emptyResponse(int $perPage, int $page): DataSourceResponse
+    {
+        $paginator = new LengthAwarePaginator(collect(), 0, $perPage, $page);
+
+        return new DataSourceResponse(collect(), 0, $paginator);
+    }
+}

--- a/laravel-app/app/DataSources/DataSourceResponse.php
+++ b/laravel-app/app/DataSources/DataSourceResponse.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\DataSources;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
+
+class DataSourceResponse implements Arrayable
+{
+    /**
+     * @param Collection<int, array<string, mixed>> $rows
+     */
+    public function __construct(
+        public readonly Collection $rows,
+        public readonly int $total,
+        public readonly LengthAwarePaginator $paginator,
+    ) {
+    }
+
+    /**
+     * @return string[]
+     */
+    public function columns(): array
+    {
+        $first = $this->rows->first();
+
+        if (! is_array($first)) {
+            return [];
+        }
+
+        return array_keys($first);
+    }
+
+    /**
+     * @return array{rows: array<int, array<string, mixed>>, total: int, current_page: int, per_page: int}
+     */
+    public function toArray(): array
+    {
+        return [
+            'rows' => $this->rows->values()->all(),
+            'total' => $this->total,
+            'current_page' => $this->paginator->currentPage(),
+            'per_page' => $this->paginator->perPage(),
+        ];
+    }
+}

--- a/laravel-app/app/DataSources/Exceptions/DataSourceExecutionException.php
+++ b/laravel-app/app/DataSources/Exceptions/DataSourceExecutionException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\DataSources\Exceptions;
+
+use RuntimeException;
+
+class DataSourceExecutionException extends RuntimeException
+{
+    /**
+     * @param string[] $errors
+     */
+    public function __construct(string $message, private readonly array $errors = [])
+    {
+        parent::__construct($message);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+}

--- a/laravel-app/app/DataSources/Exceptions/DataSourceNotFoundException.php
+++ b/laravel-app/app/DataSources/Exceptions/DataSourceNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\DataSources\Exceptions;
+
+use RuntimeException;
+
+class DataSourceNotFoundException extends RuntimeException
+{
+    public function __construct(string $key)
+    {
+        parent::__construct(sprintf('Data source [%s] could not be located.', $key));
+    }
+}

--- a/laravel-app/app/Http/Controllers/BlockPreviewController.php
+++ b/laravel-app/app/Http/Controllers/BlockPreviewController.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Exceptions\InvalidBlockConfigurationException;
+use App\Models\BlockDefinition;
+use App\Models\BlockInstance;
+use App\Services\BlockRuntime;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+class BlockPreviewController extends Controller
+{
+    public function __invoke(Request $request, BlockRuntime $runtime): JsonResponse
+    {
+        $validated = $request->validate([
+            'definition_id' => ['required', 'integer', 'exists:block_definitions,id'],
+            'config' => ['array'],
+        ]);
+
+        $definition = BlockDefinition::query()->findOrFail($validated['definition_id']);
+        $config = $validated['config'] ?? [];
+
+        $instance = new BlockInstance([
+            'block_definition_id' => $definition->id,
+            'zone' => 'preview',
+            'position' => 0,
+            'config' => $config,
+            'enabled' => true,
+        ]);
+
+        $instance->setRelation('definition', $definition);
+
+        try {
+            $runtime->validateConfig($definition, $config);
+            $html = $runtime->renderInstance($instance) ?? '';
+        } catch (InvalidBlockConfigurationException $exception) {
+            return response()->json([
+                'ok' => false,
+                'errors' => $exception->getErrors(),
+            ], Response::HTTP_UNPROCESSABLE_ENTITY);
+        } catch (Throwable $throwable) {
+            Log::error('Block preview failed to render.', [
+                'definition_id' => $definition->id,
+                'config' => $config,
+                'exception' => $throwable,
+            ]);
+
+            return response()->json([
+                'ok' => false,
+                'errors' => [$throwable->getMessage()],
+            ], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+
+        return response()->json([
+            'ok' => true,
+            'html' => $html,
+        ]);
+    }
+}

--- a/laravel-app/app/Livewire/Blocks/FormBlock.php
+++ b/laravel-app/app/Livewire/Blocks/FormBlock.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace App\Livewire\Blocks;
+
+use App\Models\AuditLog;
+use App\Models\BlockDefinition;
+use App\Models\BlockInstance;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\ValidationException;
+use Livewire\Attributes\Locked;
+use Livewire\Component;
+
+class FormBlock extends Component
+{
+    #[Locked]
+    public BlockInstance $block;
+
+    #[Locked]
+    public BlockDefinition $definition;
+
+    /** @var array<string, mixed> */
+    #[Locked]
+    public array $config = [];
+
+    /** @var array<string, mixed> */
+    public array $formData = [];
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $fieldDefinitions = [];
+
+    public bool $submitted = false;
+
+    public ?string $successMessage = null;
+
+    public ?string $errorMessage = null;
+
+    public function mount(BlockInstance $block, BlockDefinition $definition, array $config = []): void
+    {
+        $this->block = $block;
+        $this->definition = $definition;
+        $this->config = $config;
+
+        $this->fieldDefinitions = collect(Arr::get($config, 'fields', []))
+            ->mapWithKeys(function (array $field): array {
+                $key = (string) Arr::get($field, 'name');
+
+                return [$key => $field];
+            })
+            ->all();
+
+        foreach ($this->fieldDefinitions as $name => $definition) {
+            $this->formData[$name] = Arr::get($definition, 'default');
+        }
+    }
+
+    public function render(): View
+    {
+        return view('livewire.blocks.form-block', [
+            'title' => Arr::get($this->config, 'title'),
+            'description' => Arr::get($this->config, 'description'),
+            'fields' => $this->fieldDefinitions,
+            'submitLabel' => Arr::get($this->config, 'submit_label', __('Submit')),
+            'submitted' => $this->submitted,
+            'successMessage' => $this->successMessage,
+            'errorMessage' => $this->errorMessage,
+        ]);
+    }
+
+    public function submit(): void
+    {
+        $this->authorizeAction();
+
+        $validated = $this->validate($this->buildValidationRules());
+
+        $handler = (string) Arr::get($this->config, 'handler');
+
+        if ($handler === '') {
+            throw ValidationException::withMessages([
+                'config.handler' => __('Form block is missing the handler configuration.'),
+            ]);
+        }
+
+        [$class, $method] = $this->parseHandler($handler);
+
+        try {
+            $service = app($class);
+            $result = $service->{$method}($validated['formData']);
+        } catch (ValidationException $exception) {
+            throw $exception;
+        } catch (\Throwable $throwable) {
+            report($throwable);
+            $this->submitted = true;
+            $this->successMessage = null;
+            $this->errorMessage = __('An unexpected error occurred while processing the form.');
+
+            $this->logAudit($validated['formData'], false, $throwable->getMessage());
+
+            return;
+        }
+
+        $this->submitted = true;
+        $this->errorMessage = null;
+        $this->successMessage = Arr::get($this->config, 'success_message', __('Changes have been saved.'));
+
+        $this->logAudit($validated['formData'], true);
+
+        if ((bool) Arr::get($this->config, 'reset_on_success', true)) {
+            foreach ($this->fieldDefinitions as $name => $definition) {
+                $this->formData[$name] = Arr::get($definition, 'default');
+            }
+        }
+
+        $this->dispatch('form-block:submitted', result: $result, blockId: $this->block->id);
+    }
+
+    private function authorizeAction(): void
+    {
+        $permission = Arr::get($this->config, 'permission');
+
+        if (is_string($permission) && $permission !== '') {
+            Gate::authorize($permission);
+
+            return;
+        }
+
+        $policy = Arr::get($this->config, 'policy');
+
+        if (is_array($policy)) {
+            $ability = (string) Arr::get($policy, 'ability');
+            $modelClass = Arr::get($policy, 'model');
+
+            if ($ability !== '' && is_string($modelClass) && class_exists($modelClass)) {
+                $model = null;
+
+                if (Arr::get($policy, 'with_record', false)) {
+                    $recordId = Arr::get($policy, 'record_id');
+                    $model = $recordId !== null ? $modelClass::find($recordId) : new $modelClass();
+                }
+
+                Gate::authorize($ability, $model ?? $modelClass);
+            }
+        }
+    }
+
+    /**
+     * @return array<string, string|array<int, string>>
+     */
+    private function buildValidationRules(): array
+    {
+        $rules = [];
+
+        foreach ($this->fieldDefinitions as $name => $definition) {
+            $rules['formData.'.$name] = Arr::get($definition, 'rules', []);
+        }
+
+        return $rules;
+    }
+
+    /**
+     * @return array{0: class-string, 1: string}
+     */
+    private function parseHandler(string $handler): array
+    {
+        if (str_contains($handler, '@')) {
+            [$class, $method] = explode('@', $handler, 2);
+
+            return [$class, $method];
+        }
+
+        return [$handler, '__invoke'];
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function logAudit(array $payload, bool $success, ?string $error = null): void
+    {
+        if (! Arr::get($this->config, 'audit.enabled', true)) {
+            return;
+        }
+
+        $user = auth()->user();
+
+        AuditLog::query()->create([
+            'actor_id' => $user?->getAuthIdentifier(),
+            'actor_username' => $user?->email,
+            'action' => Arr::get($this->config, 'audit.action', 'form_block.submit'),
+            'entity' => $this->definition->handle,
+            'entity_id' => (string) $this->block->id,
+            'payload_json' => [
+                'payload' => $payload,
+                'success' => $success,
+                'error' => $error,
+            ],
+        ]);
+    }
+}

--- a/laravel-app/app/Livewire/Blocks/MetricBlock.php
+++ b/laravel-app/app/Livewire/Blocks/MetricBlock.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Livewire\Blocks;
+
+use App\DataSources\DataSourceManager;
+use App\DataSources\Exceptions\DataSourceExecutionException;
+use App\DataSources\Exceptions\DataSourceNotFoundException;
+use App\Models\BlockDefinition;
+use App\Models\BlockInstance;
+use App\Models\QueryRegistry;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\ValidationException;
+use Livewire\Attributes\Locked;
+use Livewire\Component;
+
+class MetricBlock extends Component
+{
+    #[Locked]
+    public BlockInstance $block;
+
+    #[Locked]
+    public BlockDefinition $definition;
+
+    /** @var array<string, mixed> */
+    #[Locked]
+    public array $config = [];
+
+    private DataSourceManager $sources;
+
+    /**
+     * @var array<int, array<string, mixed>>|null
+     */
+    private ?array $dataset = null;
+
+    public function boot(DataSourceManager $sources): void
+    {
+        $this->sources = $sources;
+    }
+
+    public function mount(BlockInstance $block, BlockDefinition $definition, array $config = []): void
+    {
+        $this->block = $block;
+        $this->definition = $definition;
+        $this->config = $config;
+    }
+
+    public function render(): View
+    {
+        return view('livewire.blocks.metric-block', [
+            'title' => Arr::get($this->config, 'title', $this->definition->title),
+            'description' => Arr::get($this->config, 'description', $this->definition->description),
+            'dataset' => $this->dataset(),
+            'columns' => Arr::get($this->config, 'columns', []),
+            'empty' => Arr::get($this->config, 'empty_message', __('No data available.')),
+        ]);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function dataset(): array
+    {
+        if ($this->dataset !== null) {
+            return $this->dataset;
+        }
+
+        $key = (string) Arr::get($this->config, 'data_source');
+
+        if ($key === '') {
+            throw ValidationException::withMessages([
+                'config.data_source' => __('Metric block configuration is missing the data source key.'),
+            ]);
+        }
+
+        $query = QueryRegistry::query()->find($key);
+
+        if ($query instanceof QueryRegistry) {
+            Gate::authorize('view', $query);
+        }
+
+        $parameters = Arr::get($this->config, 'parameters', []);
+        $limit = (int) Arr::get($this->config, 'limit', 25);
+
+        try {
+            $response = $this->sources->execute($key, $parameters, $limit, 1);
+        } catch (DataSourceNotFoundException $exception) {
+            throw ValidationException::withMessages([
+                'config.data_source' => $exception->getMessage(),
+            ]);
+        } catch (DataSourceExecutionException $exception) {
+            Log::warning('Metric data source execution failed.', [
+                'block_id' => $this->block->id,
+                'definition_id' => $this->definition->id,
+                'errors' => $exception->getErrors(),
+            ]);
+
+            throw ValidationException::withMessages([
+                'data_source' => $exception->getErrors(),
+            ]);
+        }
+
+        return $this->dataset = $response->rows->take($limit)->map(fn ($row) => $row)->values()->all();
+    }
+}

--- a/laravel-app/app/Livewire/Blocks/TableBlock.php
+++ b/laravel-app/app/Livewire/Blocks/TableBlock.php
@@ -1,0 +1,255 @@
+<?php
+
+namespace App\Livewire\Blocks;
+
+use App\DataSources\DataSourceManager;
+use App\DataSources\Exceptions\DataSourceExecutionException;
+use App\DataSources\Exceptions\DataSourceNotFoundException;
+use App\Models\BlockDefinition;
+use App\Models\BlockInstance;
+use App\Models\QueryRegistry;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+use Livewire\Attributes\Locked;
+use Livewire\Component;
+use Livewire\WithPagination;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class TableBlock extends Component
+{
+    use WithPagination;
+
+    #[Locked]
+    public BlockInstance $block;
+
+    #[Locked]
+    public BlockDefinition $definition;
+
+    /** @var array<string, mixed> */
+    #[Locked]
+    public array $config = [];
+
+    /** @var array<string, mixed> */
+    public array $filters = [];
+
+    public string $sortField = '';
+
+    public string $sortDirection = 'asc';
+
+    public ?string $search = null;
+
+    private DataSourceManager $sources;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $defaultParameters = [];
+
+    /**
+     * @var array<string, array<string, mixed>>
+     */
+    private array $filterDefinitions = [];
+
+    private ?DataSourceResponse $cachedResponse = null;
+
+    public function boot(DataSourceManager $sources): void
+    {
+        $this->sources = $sources;
+    }
+
+    public function mount(BlockInstance $block, BlockDefinition $definition, array $config = []): void
+    {
+        $this->block = $block;
+        $this->definition = $definition;
+        $this->config = $config;
+
+        $this->defaultParameters = Arr::get($config, 'default_parameters', []);
+        $this->filterDefinitions = collect(Arr::get($config, 'filters', []))
+            ->mapWithKeys(function (array $filter): array {
+                $key = (string) ($filter['key'] ?? $filter['parameter'] ?? Str::uuid()->toString());
+
+                return [$key => $filter];
+            })
+            ->all();
+
+        foreach ($this->filterDefinitions as $key => $filter) {
+            $default = Arr::get($filter, 'default');
+            $this->filters[$key] = $this->defaultParameters[$filter['parameter'] ?? $key] ?? $default;
+        }
+
+        $sortConfig = Arr::get($config, 'sort', []);
+        $this->sortField = (string) Arr::get($sortConfig, 'key', '');
+        $this->sortDirection = Str::lower((string) Arr::get($sortConfig, 'direction', 'asc')) === 'desc'
+            ? 'desc'
+            : 'asc';
+
+        $this->search = Arr::get($config, 'search.default');
+    }
+
+    public function updatingFilters(): void
+    {
+        $this->cachedResponse = null;
+        $this->resetPage();
+    }
+
+    public function updatingSearch(): void
+    {
+        $this->cachedResponse = null;
+        $this->resetPage();
+    }
+
+    public function render(): View
+    {
+        return view('livewire.blocks.table-block', [
+            'title' => Arr::get($this->config, 'title'),
+            'description' => Arr::get($this->config, 'description'),
+            'columns' => $this->columns(),
+            'data' => $this->dataSourceResponse()->paginator,
+            'exportable' => (bool) Arr::get($this->config, 'export.enabled', false),
+            'filterDefinitions' => $this->filterDefinitions,
+            'filterState' => $this->filters,
+            'config' => $this->config,
+        ]);
+    }
+
+    public function export(): StreamedResponse
+    {
+        $exportConfig = Arr::get($this->config, 'export', []);
+
+        if (! Arr::get($exportConfig, 'enabled', false)) {
+            abort(404);
+        }
+
+        $maxRows = (int) Arr::get($exportConfig, 'max_rows', 1000);
+        $filename = (string) Arr::get($exportConfig, 'filename', 'export.csv');
+
+        $response = $this->executeDataSource($maxRows, 1);
+
+        $columns = $response->columns();
+        $rows = $response->rows->take($maxRows);
+
+        return response()->streamDownload(function () use ($columns, $rows): void {
+            $handle = fopen('php://output', 'wb');
+
+            if ($handle === false) {
+                return;
+            }
+
+            if ($columns !== []) {
+                fputcsv($handle, $columns);
+            }
+
+            foreach ($rows as $row) {
+                fputcsv($handle, Arr::only($row, $columns));
+            }
+
+            fclose($handle);
+        }, $filename);
+    }
+
+    private function columns(): array
+    {
+        $columns = Arr::get($this->config, 'columns', []);
+
+        if ($columns !== []) {
+            return array_map(function ($column) {
+                return [
+                    'key' => (string) Arr::get($column, 'key'),
+                    'label' => (string) Arr::get($column, 'label', Arr::get($column, 'key', '')),
+                ];
+            }, $columns);
+        }
+
+        return array_map(
+            fn (string $column): array => ['key' => $column, 'label' => Str::headline($column)],
+            $this->dataSourceResponse()->columns()
+        );
+    }
+
+    private function dataSourceResponse(): DataSourceResponse
+    {
+        if ($this->cachedResponse === null) {
+            $perPage = (int) Arr::get($this->config, 'per_page', 10);
+            $this->cachedResponse = $this->executeDataSource($perPage, $this->getPage());
+        }
+
+        return $this->cachedResponse;
+    }
+
+    private function executeDataSource(int $perPage, int $page): DataSourceResponse
+    {
+        $key = (string) Arr::get($this->config, 'data_source');
+
+        if ($key === '') {
+            throw ValidationException::withMessages([
+                'config.data_source' => __('Table block configuration is missing the data source key.'),
+            ]);
+        }
+
+        $query = QueryRegistry::query()->find($key);
+
+        if ($query instanceof QueryRegistry) {
+            Gate::authorize('view', $query);
+        }
+
+        $parameters = $this->resolveParameters();
+
+        try {
+            return $this->sources->execute($key, $parameters, $perPage, $page);
+        } catch (DataSourceNotFoundException $exception) {
+            throw ValidationException::withMessages([
+                'config.data_source' => $exception->getMessage(),
+            ]);
+        } catch (DataSourceExecutionException $exception) {
+            Log::warning('Failed to execute table block data source.', [
+                'block_id' => $this->block->id,
+                'definition_id' => $this->definition->id,
+                'errors' => $exception->getErrors(),
+            ]);
+
+            throw ValidationException::withMessages([
+                'data_source' => $exception->getErrors(),
+            ]);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function resolveParameters(): array
+    {
+        $parameters = $this->defaultParameters;
+
+        foreach ($this->filters as $key => $value) {
+            $definition = $this->filterDefinitions[$key] ?? null;
+
+            if ($definition === null) {
+                continue;
+            }
+
+            $parameter = (string) Arr::get($definition, 'parameter', $key);
+            $parameters[$parameter] = $value;
+        }
+
+        if ($this->search !== null && $this->search !== '') {
+            $searchKey = (string) Arr::get($this->config, 'search.parameter', 'search');
+            $parameters[$searchKey] = $this->search;
+        }
+
+        if ($this->sortField !== '') {
+            $parameters[Arr::get($this->config, 'sort.parameter', 'sort_key')] = $this->sortField;
+            $parameters[Arr::get($this->config, 'sort.direction_parameter', 'sort_direction')] = $this->sortDirection;
+        }
+
+        return $parameters;
+    }
+
+    protected function getPaginationView(): string
+    {
+        return 'pagination::tailwind';
+    }
+}

--- a/laravel-app/config/block-runtime.php
+++ b/laravel-app/config/block-runtime.php
@@ -5,15 +5,15 @@ return [
 
     'legacy_entrypoints' => [
         'dvorik.admin.widgets.builtin:LowStockWidget' => [
-            'component' => \App\Livewire\Blocks\LegacyWidgetPlaceholder::class,
+            'component' => \App\Livewire\Blocks\MetricBlock::class,
             'version' => 1,
         ],
         'dvorik.admin.widgets.builtin:ScheduleMiniWidget' => [
-            'component' => \App\Livewire\Blocks\LegacyWidgetPlaceholder::class,
+            'component' => \App\Livewire\Blocks\MetricBlock::class,
             'version' => 1,
         ],
         'dvorik.admin.widgets.builtin:StockByLocationWidget' => [
-            'component' => \App\Livewire\Blocks\LegacyWidgetPlaceholder::class,
+            'component' => \App\Livewire\Blocks\MetricBlock::class,
             'version' => 1,
         ],
     ],

--- a/laravel-app/database/seeders/BlockDefinitionSeeder.php
+++ b/laravel-app/database/seeders/BlockDefinitionSeeder.php
@@ -11,6 +11,80 @@ class BlockDefinitionSeeder extends Seeder
     {
         $legacyMap = config('block-runtime.legacy_entrypoints', []);
 
+        $schemas = [
+            'metric' => [
+                'type' => 'object',
+                'required' => ['data_source', 'columns'],
+                'properties' => [
+                    'title' => ['type' => 'string'],
+                    'description' => ['type' => 'string'],
+                    'data_source' => ['type' => 'string'],
+                    'limit' => ['type' => 'integer', 'minimum' => 1, 'maximum' => 100],
+                    'parameters' => ['type' => 'object'],
+                    'columns' => [
+                        'type' => 'array',
+                        'items' => [
+                            'type' => 'object',
+                            'required' => ['key'],
+                            'properties' => [
+                                'key' => ['type' => 'string'],
+                                'label' => ['type' => 'string'],
+                            ],
+                        ],
+                    ],
+                    'empty_message' => ['type' => 'string'],
+                ],
+            ],
+        ];
+
+        $defaultConfigs = [
+            'builtin.low_stock' => [
+                'title' => 'Low stock overview',
+                'description' => 'Highlights products that are running low on inventory.',
+                'data_source' => 'metrics.low_stock',
+                'limit' => 10,
+                'parameters' => [
+                    'threshold' => 5,
+                ],
+                'columns' => [
+                    ['key' => 'product_name', 'label' => 'Product'],
+                    ['key' => 'location_title', 'label' => 'Location'],
+                    ['key' => 'qty_pack', 'label' => 'Quantity'],
+                ],
+                'empty_message' => 'Inventory levels look healthy.',
+            ],
+            'builtin.schedule_mini' => [
+                'title' => 'Schedule snapshot',
+                'description' => 'Shows the current duty schedule summary.',
+                'data_source' => 'metrics.schedule_snapshot',
+                'limit' => 14,
+                'parameters' => [
+                    'days' => 14,
+                ],
+                'columns' => [
+                    ['key' => 'date', 'label' => 'Date'],
+                    ['key' => 'status', 'label' => 'Status'],
+                    ['key' => 'assignees', 'label' => 'Assignees'],
+                ],
+                'empty_message' => 'No upcoming assignments have been scheduled.',
+            ],
+            'builtin.stock_by_location' => [
+                'title' => 'Stock by location',
+                'description' => 'Displays stock totals grouped by location.',
+                'data_source' => 'metrics.stock_by_location',
+                'limit' => 15,
+                'parameters' => [
+                    'location_code' => null,
+                ],
+                'columns' => [
+                    ['key' => 'location_title', 'label' => 'Location'],
+                    ['key' => 'product_name', 'label' => 'Product'],
+                    ['key' => 'qty_pack', 'label' => 'Quantity'],
+                ],
+                'empty_message' => 'No stock was found for the selected locations.',
+            ],
+        ];
+
         $definitions = [
             [
                 'module' => 'builtin',
@@ -18,6 +92,7 @@ class BlockDefinitionSeeder extends Seeder
                 'title' => 'Low stock overview',
                 'description' => 'Highlights products that are running low on inventory.',
                 'entrypoint' => 'dvorik.admin.widgets.builtin:LowStockWidget',
+                'schema_key' => 'metric',
             ],
             [
                 'module' => 'builtin',
@@ -25,6 +100,7 @@ class BlockDefinitionSeeder extends Seeder
                 'title' => 'Schedule snapshot',
                 'description' => 'Shows the current duty schedule summary.',
                 'entrypoint' => 'dvorik.admin.widgets.builtin:ScheduleMiniWidget',
+                'schema_key' => 'metric',
             ],
             [
                 'module' => 'builtin',
@@ -32,6 +108,7 @@ class BlockDefinitionSeeder extends Seeder
                 'title' => 'Stock by location',
                 'description' => 'Displays stock totals grouped by location.',
                 'entrypoint' => 'dvorik.admin.widgets.builtin:StockByLocationWidget',
+                'schema_key' => 'metric',
             ],
         ];
 
@@ -41,6 +118,8 @@ class BlockDefinitionSeeder extends Seeder
             if ($mapping === null) {
                 continue;
             }
+
+            $defaultConfig = $defaultConfigs[$definition['module'].'.'.$definition['name']] ?? null;
 
             BlockDefinition::query()->updateOrCreate(
                 [
@@ -52,9 +131,11 @@ class BlockDefinitionSeeder extends Seeder
                     'title' => $definition['title'],
                     'description' => $definition['description'],
                     'component' => $mapping['component'],
-                    'metadata' => [
+                    'config_schema' => $schemas[$definition['schema_key']] ?? null,
+                    'metadata' => array_filter([
                         'legacy_entrypoint' => $definition['entrypoint'],
-                    ],
+                        'default_config' => $defaultConfig,
+                    ]),
                 ]
             );
         }

--- a/laravel-app/database/seeders/BlockInstanceSeeder.php
+++ b/laravel-app/database/seeders/BlockInstanceSeeder.php
@@ -23,6 +23,8 @@ class BlockInstanceSeeder extends Seeder
             ->get();
 
         foreach ($definitions as $position => $definition) {
+            $config = $definition->metadata['default_config'] ?? null;
+
             BlockInstance::query()->updateOrCreate(
                 [
                     'zone' => $zone,
@@ -30,7 +32,7 @@ class BlockInstanceSeeder extends Seeder
                 ],
                 [
                     'block_definition_id' => $definition->id,
-                    'config' => null,
+                    'config' => $config,
                     'enabled' => true,
                 ]
             );

--- a/laravel-app/database/seeders/DatabaseSeeder.php
+++ b/laravel-app/database/seeders/DatabaseSeeder.php
@@ -12,6 +12,7 @@ class DatabaseSeeder extends Seeder
             LocationSeeder::class,
             SupplierSeeder::class,
             UiMenuSeeder::class,
+            QueryRegistrySeeder::class,
             BlockDefinitionSeeder::class,
             BlockInstanceSeeder::class,
             RbacSeeder::class,

--- a/laravel-app/database/seeders/QueryRegistrySeeder.php
+++ b/laravel-app/database/seeders/QueryRegistrySeeder.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class QueryRegistrySeeder extends Seeder
+{
+    public function run(): void
+    {
+        $queries = [
+            'metrics.low_stock' => [
+                'sql' => <<<'SQL'
+                    SELECT
+                        p.id AS product_id,
+                        p.name AS product_name,
+                        p.unit AS product_unit,
+                        l.code AS location_code,
+                        l.title AS location_title,
+                        s.qty_pack::numeric AS qty_pack,
+                        COALESCE(s.reserved_pack, 0)::numeric AS reserved_pack
+                    FROM stock AS s
+                    JOIN product AS p ON p.id = s.product_id
+                    JOIN location AS l ON l.code = s.location_code
+                    WHERE s.qty_pack <= COALESCE(:threshold, 0)
+                    ORDER BY s.qty_pack ASC, p.name ASC
+                    SQL,
+                'description' => 'Returns products with stock below the configured threshold ordered by lowest quantity.',
+            ],
+            'metrics.schedule_snapshot' => [
+                'sql' => <<<'SQL'
+                    WITH upcoming AS (
+                        SELECT
+                            d.date,
+                            d.is_open,
+                            COALESCE(d.notes, '') AS notes,
+                            COALESCE(string_agg(sa.tg_id::text, ', ' ORDER BY sa.tg_id), '—') AS assignees
+                        FROM schedule_day AS d
+                        LEFT JOIN schedule_assignment AS sa ON sa.date = d.date
+                        WHERE d.date BETWEEN CURRENT_DATE AND (
+                            CURRENT_DATE + (GREATEST(COALESCE(:days, 7), 1) - 1) * INTERVAL '1 day'
+                        )
+                        GROUP BY d.date, d.is_open, d.notes
+                    )
+                    SELECT
+                        to_char(upcoming.date, 'YYYY-MM-DD') AS date,
+                        CASE WHEN upcoming.is_open THEN 'Open' ELSE 'Closed' END AS status,
+                        upcoming.assignees
+                    FROM upcoming
+                    ORDER BY upcoming.date ASC
+                    SQL,
+                'description' => 'Summarises upcoming schedule assignments for the configured horizon.',
+            ],
+            'metrics.stock_by_location' => [
+                'sql' => <<<'SQL'
+                    SELECT
+                        l.code AS location_code,
+                        l.title AS location_title,
+                        p.id AS product_id,
+                        p.name AS product_name,
+                        s.qty_pack::numeric AS qty_pack
+                    FROM stock AS s
+                    JOIN product AS p ON p.id = s.product_id
+                    JOIN location AS l ON l.code = s.location_code
+                    WHERE (:location_code IS NULL OR l.code = :location_code)
+                    ORDER BY l.code ASC, p.name ASC
+                    SQL,
+                'description' => 'Lists product stock quantities grouped by location, optionally filtered by location code.',
+            ],
+        ];
+
+        foreach ($queries as $key => $definition) {
+            DB::table('query_registry')->updateOrInsert(
+                ['key' => $key],
+                [
+                    'sql' => trim($definition['sql']),
+                    'description' => $definition['description'],
+                    'updated_at' => now(),
+                ]
+            );
+        }
+    }
+}

--- a/laravel-app/resources/views/livewire/blocks/form-block.blade.php
+++ b/laravel-app/resources/views/livewire/blocks/form-block.blade.php
@@ -1,0 +1,77 @@
+<div class="space-y-4" wire:key="form-block-{{ $block->id ?? 'preview' }}">
+    @if($title)
+        <div>
+            <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">{{ $title }}</h3>
+            @if($description)
+                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ $description }}</p>
+            @endif
+        </div>
+    @endif
+
+    <form wire:submit.prevent="submit" class="space-y-4">
+        <div class="grid gap-4 sm:grid-cols-2">
+            @foreach($fields as $name => $field)
+                <div class="flex flex-col gap-1">
+                    <label for="field-{{ $name }}" class="text-sm font-medium text-gray-700 dark:text-gray-200">
+                        {{ $field['label'] ?? \Illuminate\Support\Str::headline($name) }}
+                    </label>
+
+                    @php($type = $field['type'] ?? 'text')
+
+                    @switch($type)
+                        @case('textarea')
+                            <textarea
+                                id="field-{{ $name }}"
+                                wire:model.defer="formData.{{ $name }}"
+                                class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-800 dark:border-gray-700"
+                                rows="3"
+                            ></textarea>
+                            @break
+
+                        @case('select')
+                            <select
+                                id="field-{{ $name }}"
+                                wire:model.defer="formData.{{ $name }}"
+                                class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-800 dark:border-gray-700"
+                            >
+                                @foreach($field['options'] ?? [] as $optionValue => $optionLabel)
+                                    <option value="{{ $optionValue }}">{{ $optionLabel }}</option>
+                                @endforeach
+                            </select>
+                            @break
+
+                        @default
+                            <input
+                                id="field-{{ $name }}"
+                                type="{{ $type }}"
+                                wire:model.defer="formData.{{ $name }}"
+                                class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-800 dark:border-gray-700"
+                            />
+                            @break
+                    @endswitch
+
+                    @error('formData.'.$name)
+                        <p class="text-sm text-red-600">{{ $message }}</p>
+                    @enderror
+                </div>
+            @endforeach
+        </div>
+
+        <div class="flex items-center gap-3">
+            <button
+                type="submit"
+                class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            >
+                {{ $submitLabel }}
+            </button>
+
+            <div class="text-sm">
+                @if($successMessage)
+                    <span class="text-green-600">{{ $successMessage }}</span>
+                @elseif($errorMessage)
+                    <span class="text-red-600">{{ $errorMessage }}</span>
+                @endif
+            </div>
+        </div>
+    </form>
+</div>

--- a/laravel-app/resources/views/livewire/blocks/metric-block.blade.php
+++ b/laravel-app/resources/views/livewire/blocks/metric-block.blade.php
@@ -1,0 +1,27 @@
+<div class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-800 dark:bg-gray-900" wire:key="metric-block-{{ $block->id ?? 'preview' }}">
+    <div class="flex items-center justify-between">
+        <div>
+            <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">{{ $title }}</h3>
+            @if($description)
+                <p class="text-sm text-gray-500 dark:text-gray-400">{{ $description }}</p>
+            @endif
+        </div>
+    </div>
+
+    <div class="mt-4 space-y-3">
+        @forelse($dataset as $row)
+            <div class="rounded-md border border-gray-100 bg-gray-50 p-3 dark:border-gray-800 dark:bg-gray-800/60">
+                @foreach($columns as $column)
+                    @php($label = $column['label'] ?? \Illuminate\Support\Str::headline($column['key'] ?? 'value'))
+                    @php($key = $column['key'] ?? 'value')
+                    <div class="flex items-start justify-between gap-4">
+                        <dt class="text-sm font-medium text-gray-600 dark:text-gray-300">{{ $label }}</dt>
+                        <dd class="text-sm text-gray-900 dark:text-gray-100 text-right">{{ $row[$key] ?? '—' }}</dd>
+                    </div>
+                @endforeach
+            </div>
+        @empty
+            <p class="text-sm text-gray-500 dark:text-gray-400">{{ $empty }}</p>
+        @endforelse
+    </div>
+</div>

--- a/laravel-app/resources/views/livewire/blocks/table-block.blade.php
+++ b/laravel-app/resources/views/livewire/blocks/table-block.blade.php
@@ -1,0 +1,85 @@
+<div class="space-y-4" wire:key="table-block-{{ $block->id ?? 'preview' }}">
+    @if($title)
+        <div>
+            <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">{{ $title }}</h3>
+            @if($description)
+                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ $description }}</p>
+            @endif
+        </div>
+    @endif
+
+    <div class="flex flex-wrap gap-2 items-end">
+        @foreach($filterDefinitions as $key => $filter)
+            <div class="flex flex-col">
+                <label for="filter-{{ $key }}" class="text-sm font-medium text-gray-700 dark:text-gray-200">
+                    {{ $filter['label'] ?? \Illuminate\Support\Str::headline($filter['parameter'] ?? $key) }}
+                </label>
+                <input
+                    id="filter-{{ $key }}"
+                    type="text"
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-800 dark:border-gray-700"
+                    wire:model.live="filters.{{ $key }}"
+                    >
+            </div>
+        @endforeach
+
+        @if(isset($config['search']))
+            <div class="flex flex-col">
+                <label for="table-search" class="text-sm font-medium text-gray-700 dark:text-gray-200">
+                    {{ $config['search']['label'] ?? __('Search') }}
+                </label>
+                <input
+                    id="table-search"
+                    type="search"
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-800 dark:border-gray-700"
+                    wire:model.live="search"
+                >
+            </div>
+        @endif
+
+        @if($exportable)
+            <button
+                type="button"
+                wire:click="export"
+                class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            >
+                {{ __('Export CSV') }}
+            </button>
+        @endif
+    </div>
+
+    <div class="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+        <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+            <thead class="bg-gray-50 dark:bg-gray-900/30">
+                <tr>
+                    @foreach($columns as $column)
+                        <th scope="col" class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                            {{ $column['label'] }}
+                        </th>
+                    @endforeach
+                </tr>
+            </thead>
+            <tbody class="bg-white divide-y divide-gray-200 dark:bg-gray-900 dark:divide-gray-800">
+                @forelse($data as $row)
+                    <tr class="odd:bg-white even:bg-gray-50 dark:odd:bg-gray-900 dark:even:bg-gray-800">
+                        @foreach($columns as $column)
+                            <td class="px-4 py-3 text-sm text-gray-900 dark:text-gray-100">
+                    {{ $row[$column['key']] ?? '—' }}
+                            </td>
+                        @endforeach
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="{{ count($columns) }}" class="px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-400">
+                            {{ __('No records found for the current selection.') }}
+                        </td>
+                    </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+
+    <div>
+        {{ $data->links() }}
+    </div>
+</div>

--- a/laravel-app/routes/web.php
+++ b/laravel-app/routes/web.php
@@ -1,7 +1,10 @@
 <?php
 
+use App\Http\Controllers\BlockPreviewController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::middleware(['web', 'auth'])->post('/blocks/preview', BlockPreviewController::class)->name('blocks.preview');

--- a/laravel-app/tests/Feature/BlockRuntimeTest.php
+++ b/laravel-app/tests/Feature/BlockRuntimeTest.php
@@ -1,0 +1,320 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Livewire\Blocks\FormBlock;
+use App\Livewire\Blocks\MetricBlock;
+use App\Livewire\Blocks\TableBlock;
+use App\Models\BlockDefinition;
+use App\Models\BlockInstance;
+use App\Models\QueryRegistry;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\Fixtures\DummyFormHandler;
+use Tests\TestCase;
+
+class BlockRuntimeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var PermissionRegistrar $registrar */
+        $registrar = app(PermissionRegistrar::class);
+        $registrar->forgetCachedPermissions();
+    }
+
+    public function test_table_block_renders_rows_and_exports_csv(): void
+    {
+        $user = User::factory()->create();
+        $this->grantPermission($user, 'queries.manage');
+
+        $productId = DB::table('product')->insertGetId([
+            'article' => null,
+            'barcode' => null,
+            'name' => 'Widget Alpha',
+            'brand_country' => null,
+            'local_name' => null,
+            'description' => null,
+            'unit' => 'pcs',
+            'manufacturer_id' => null,
+            'price' => null,
+            'vat_rate' => null,
+            'is_new' => false,
+            'archived' => false,
+            'archived_at' => null,
+            'updated_at' => now(),
+            'last_restock_at' => null,
+            'photo_file_id' => null,
+            'photo_path' => null,
+        ]);
+
+        QueryRegistry::query()->updateOrCreate(
+            ['key' => 'test.products'],
+            [
+                'sql' => <<<'SQL'
+                    SELECT name
+                    FROM product
+                    WHERE :search IS NULL OR name LIKE '%' || :search || '%'
+                    ORDER BY name ASC
+                SQL,
+                'description' => 'Lists products with optional search.',
+            ]
+        );
+
+        $definition = BlockDefinition::query()->create([
+            'module' => 'custom',
+            'name' => 'products_table',
+            'version' => 1,
+            'title' => 'Products',
+            'component' => TableBlock::class,
+            'config_schema' => null,
+        ]);
+
+        $instance = BlockInstance::query()->create([
+            'block_definition_id' => $definition->id,
+            'zone' => 'test.zone',
+            'position' => 0,
+            'config' => [
+                'title' => 'Products',
+                'data_source' => 'test.products',
+                'columns' => [
+                    ['key' => 'name', 'label' => 'Name'],
+                ],
+                'search' => [
+                    'parameter' => 'search',
+                    'label' => 'Search products',
+                    'default' => '',
+                ],
+                'per_page' => 10,
+                'export' => [
+                    'enabled' => true,
+                    'max_rows' => 50,
+                    'filename' => 'products.csv',
+                ],
+            ],
+            'enabled' => true,
+        ]);
+
+        $instance->setRelation('definition', $definition);
+
+        Livewire::actingAs($user)
+            ->test(TableBlock::class, [
+                'block' => $instance,
+                'definition' => $definition,
+                'config' => $instance->config,
+            ])
+            ->assertSee('Products')
+            ->assertSee('Widget Alpha')
+            ->call('export')
+            ->assertFileDownloaded('products.csv');
+    }
+
+    public function test_metric_block_uses_query_registry_data_source(): void
+    {
+        $user = User::factory()->create();
+        $this->grantPermission($user, 'queries.manage');
+
+        $locationCode = 'A1';
+
+        DB::table('location')->insert([
+            'code' => $locationCode,
+            'kind' => 'WAREHOUSE',
+            'title' => 'Main Warehouse',
+            'created_at' => now(),
+        ]);
+
+        $productId = DB::table('product')->insertGetId([
+            'article' => null,
+            'barcode' => null,
+            'name' => 'Widget Beta',
+            'brand_country' => null,
+            'local_name' => null,
+            'description' => null,
+            'unit' => 'pcs',
+            'manufacturer_id' => null,
+            'price' => null,
+            'vat_rate' => null,
+            'is_new' => false,
+            'archived' => false,
+            'archived_at' => null,
+            'updated_at' => now(),
+            'last_restock_at' => null,
+            'photo_file_id' => null,
+            'photo_path' => null,
+        ]);
+
+        DB::table('stock')->insert([
+            'product_id' => $productId,
+            'location_code' => $locationCode,
+            'qty_pack' => 3,
+            'name' => null,
+            'local_name' => null,
+            'reserved_pack' => 0,
+            'updated_at' => now(),
+        ]);
+
+        $this->seed(\Database\Seeders\QueryRegistrySeeder::class);
+
+        $definition = BlockDefinition::query()->create([
+            'module' => 'custom',
+            'name' => 'metric_stock',
+            'version' => 1,
+            'title' => 'Stock by location',
+            'component' => MetricBlock::class,
+            'config_schema' => null,
+        ]);
+
+        $config = [
+            'title' => 'Stock by location',
+            'data_source' => 'metrics.stock_by_location',
+            'limit' => 10,
+            'parameters' => ['location_code' => null],
+            'columns' => [
+                ['key' => 'location_title', 'label' => 'Location'],
+                ['key' => 'product_name', 'label' => 'Product'],
+                ['key' => 'qty_pack', 'label' => 'Quantity'],
+            ],
+        ];
+
+        $instance = BlockInstance::query()->create([
+            'block_definition_id' => $definition->id,
+            'zone' => 'test.zone',
+            'position' => 0,
+            'config' => $config,
+            'enabled' => true,
+        ]);
+
+        $instance->setRelation('definition', $definition);
+
+        Livewire::actingAs($user)
+            ->test(MetricBlock::class, [
+                'block' => $instance,
+                'definition' => $definition,
+                'config' => $config,
+            ])
+            ->assertSee('Stock by location')
+            ->assertSee('Main Warehouse')
+            ->assertSee('Widget Beta');
+    }
+
+    public function test_form_block_invokes_handler_and_logs_audit(): void
+    {
+        $user = User::factory()->create();
+        $this->grantPermission($user, 'widgets.manage');
+
+        $handler = new DummyFormHandler();
+        $this->app->instance(DummyFormHandler::class, $handler);
+
+        $definition = BlockDefinition::query()->create([
+            'module' => 'custom',
+            'name' => 'form_demo',
+            'version' => 1,
+            'title' => 'Demo form',
+            'component' => FormBlock::class,
+            'config_schema' => null,
+        ]);
+
+        $config = [
+            'title' => 'Create note',
+            'permission' => 'widgets.manage',
+            'handler' => DummyFormHandler::class,
+            'success_message' => 'Saved successfully.',
+            'fields' => [
+                [
+                    'name' => 'subject',
+                    'label' => 'Subject',
+                    'type' => 'text',
+                    'rules' => ['required', 'string'],
+                ],
+            ],
+        ];
+
+        $instance = BlockInstance::query()->create([
+            'block_definition_id' => $definition->id,
+            'zone' => 'test.zone',
+            'position' => 0,
+            'config' => $config,
+            'enabled' => true,
+        ]);
+
+        $instance->setRelation('definition', $definition);
+
+        Livewire::actingAs($user)
+            ->test(FormBlock::class, [
+                'block' => $instance,
+                'definition' => $definition,
+                'config' => $config,
+            ])
+            ->set('formData.subject', 'Hello world')
+            ->call('submit')
+            ->assertSee('Saved successfully.');
+
+        $this->assertNotEmpty($handler->calls);
+
+        $this->assertDatabaseHas('audit_log', [
+            'action' => 'form_block.submit',
+            'entity' => $definition->handle,
+        ]);
+    }
+
+    public function test_block_preview_endpoint_renders_block_html(): void
+    {
+        $user = User::factory()->create();
+        $this->grantPermission($user, 'queries.manage');
+
+        QueryRegistry::query()->updateOrCreate(
+            ['key' => 'preview.test'],
+            [
+                'sql' => 'SELECT 1 AS value',
+                'description' => 'Preview dataset',
+            ]
+        );
+
+        $definition = BlockDefinition::query()->create([
+            'module' => 'custom',
+            'name' => 'preview_table',
+            'version' => 1,
+            'title' => 'Preview Table',
+            'component' => TableBlock::class,
+            'config_schema' => null,
+        ]);
+
+        $instance = BlockInstance::query()->create([
+            'block_definition_id' => $definition->id,
+            'zone' => 'test.zone',
+            'position' => 0,
+            'config' => [
+                'data_source' => 'preview.test',
+                'columns' => [['key' => 'value', 'label' => 'Value']],
+            ],
+            'enabled' => true,
+        ]);
+
+        $response = $this->actingAs($user)
+            ->postJson(route('blocks.preview'), [
+                'definition_id' => $definition->id,
+                'config' => $instance->config,
+            ]);
+
+        $response->assertOk();
+        $response->assertJson(['ok' => true]);
+        $this->assertStringContainsString('Value', $response->json('html'));
+    }
+
+    private function grantPermission(User $user, string $permission): void
+    {
+        $perm = Permission::query()->firstOrCreate([
+            'name' => $permission,
+            'guard_name' => 'filament',
+        ]);
+
+        $user->givePermissionTo($perm);
+    }
+}

--- a/laravel-app/tests/Fixtures/DummyFormHandler.php
+++ b/laravel-app/tests/Fixtures/DummyFormHandler.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Fixtures;
+
+class DummyFormHandler
+{
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    public array $calls = [];
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function __invoke(array $payload): array
+    {
+        $this->calls[] = $payload;
+
+        return [
+            'ok' => true,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add a DataSource service plus Livewire TableBlock, FormBlock, and MetricBlock components with CSV export and audit hooks
- seed SQL-backed metric data sources and update block definitions/instances to use the new metric implementation
- expose a block preview endpoint and cover the new runtime pieces with feature tests

## Testing
- composer install --no-interaction --prefer-dist *(fails: CONNECT tunnel failed with 403 while downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68e66d6f1a2c8326b30bad711ab03002